### PR TITLE
Add Frogs as CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,6 +19,18 @@
 /docs/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
 /components/schema-migrator/migrations/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
 
+# Runtime Provisioner
+/chart/compass/charts/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/components/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/docs/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/components/schema-migrator/migrations/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/tests/provisioner-tests @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+
+# Connectivity Adapter
+/chart/compass/charts/connectivity-adapter @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/components/connectivity-adapter @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+/tests/connectivity-adapter @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+
 # Director
 /chart/compass/charts/director @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik
 /chart/compass/templates/director-api-test.yaml @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,11 +26,6 @@
 /components/schema-migrator/migrations/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
 /tests/provisioner-tests @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
 
-# Connectivity Adapter
-/chart/compass/charts/connectivity-adapter @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-/components/connectivity-adapter @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-/tests/connectivity-adapter @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
-
 # Director
 /chart/compass/charts/director @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik
 /chart/compass/templates/director-api-test.yaml @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add Frogs as CODEOWNERS for ~Connectivity Adapter and~ Runtime Provisioner

Please, check if I added it to the correct file :D Currently there are `CODEOWNERS`, `OWNERS` and `OWNERS_ALIASES` files and I'm not quite sure if I did it right
