### PR TITLE
Bump compass to master-3a1554f2

### DIFF
--- a/installation/resources/COMPASS_VERSION
+++ b/installation/resources/COMPASS_VERSION
@@ -1,1 +1,1 @@
-master
+master-3a1554f2


### PR DESCRIPTION
**Description**

Bump compass version to include https://github.com/kyma-incubator/compass/pull/1462 and also to be aligned with current master version.

