### PR TITLE
Add Azure lite plan

### DIFF
--- a/components/kyma-environment-broker/internal/broker/broker.go
+++ b/components/kyma-environment-broker/internal/broker/broker.go
@@ -12,8 +12,9 @@ const (
 )
 
 var planIDsMapping = map[string]string{
-	AzurePlanName: AzurePlanID,
-	GCPPlanName:   GCPPlanID,
+	AzurePlanName:     AzurePlanID,
+	AzureLitePlanName: AzureLitePlanID,
+	GCPPlanName:       GCPPlanID,
 }
 
 type KymaEnvironmentBroker struct {

--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/middleware"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
 
@@ -172,6 +173,7 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 		logger.Infof("Kyma on demand functionality is disabled. Default Kyma version will be used instead %s", parameters.KymaVersion)
 		parameters.KymaVersion = ""
 	}
+	parameters.LicenceType = b.determineLicenceType(details.PlanID)
 
 	found := b.builderFactory.IsPlanSupport(details.PlanID)
 	if !found {
@@ -225,4 +227,12 @@ func (b *ProvisionEndpoint) handleExistingOperation(operation *internal.Provisio
 	err = errors.New("provisioning operation already exist")
 	msg := fmt.Sprintf("provisioning operation with InstanceID %s already exist", operation.InstanceID)
 	return domain.ProvisionedServiceSpec{}, apiresponses.NewFailureResponse(err, http.StatusConflict, msg)
+}
+
+func (b *ProvisionEndpoint) determineLicenceType(id string) *string {
+	if id == AzureLitePlanID {
+		return ptr.String(internal.LicenceTypeLite)
+	}
+
+	return nil
 }

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -58,7 +58,7 @@ type ProvisioningProperties struct {
 	MaxUnavailable Type `json:"maxUnavailable"`
 }
 
-func GCPSchema() []byte {
+func GCPSchema(machineTypes []string) []byte {
 	f := new(bool)
 	*f = false
 	t := new(bool)
@@ -88,7 +88,7 @@ func GCPSchema() []byte {
 			},
 			MachineType: Type{
 				Type: "string",
-				Enum: ToInterfaceSlice([]string{"n1-standard-2", "n1-standard-4", "n1-standard-8", "n1-standard-16", "n1-standard-32", "n1-standard-64"}),
+				Enum: ToInterfaceSlice(machineTypes),
 			},
 			Region: Type{
 				Type: "string",
@@ -155,7 +155,7 @@ func GCPSchema() []byte {
 	return bytes
 }
 
-func AzureSchema() []byte {
+func AzureSchema(machineTypes []string) []byte {
 	f := new(bool)
 	*f = false
 	t := new(bool)
@@ -185,73 +185,7 @@ func AzureSchema() []byte {
 			},
 			MachineType: Type{
 				Type: "string",
-				Enum: ToInterfaceSlice([]string{"Standard_D8_v3"}),
-			},
-			Region: Type{
-				Type: "string",
-				Enum: ToInterfaceSlice(AzureRegions()),
-			},
-			Zones: Type{
-				Type: "array",
-				Items: []Type{{
-					Type: "string",
-					//TODO: add enum for zones
-				}},
-			},
-			AutoScalerMin: Type{
-				Type: "integer",
-			},
-			AutoScalerMax: Type{
-				Type: "integer",
-			},
-			MaxSurge: Type{
-				Type: "integer",
-			},
-			MaxUnavailable: Type{
-				Type: "integer",
-			},
-		},
-		Required: []string{"name"},
-	}
-
-	bytes, err := json.Marshal(rs)
-	if err != nil {
-		panic(err)
-	}
-	return bytes
-}
-
-func AzureLiteSchema() []byte {
-	f := new(bool)
-	*f = false
-	t := new(bool)
-	*t = true
-	rs := RootSchema{
-		Schema: "http://json-schema.org/draft-04/schema#",
-		Type: Type{
-			Type: "object",
-		},
-		Properties: ProvisioningProperties{
-			Components: Type{
-				Type: "array",
-				Items: []Type{{
-					Type: "string",
-					Enum: ToInterfaceSlice([]string{"Kiali", "Tracing"}),
-				}},
-				AdditionalItems: f,
-				UniqueItems:     t,
-			},
-			Name: Type{
-				Type: "string",
-			},
-			DiskType: Type{Type: "string"},
-			VolumeSizeGb: Type{
-				Type:    "integer",
-				Minimum: 50,
-			},
-			MachineType: Type{
-				Type: "string",
-				Enum: ToInterfaceSlice([]string{"Standard_D4_v3"}),
+				Enum: ToInterfaceSlice(machineTypes),
 			},
 			Region: Type{
 				Type: "string",
@@ -317,7 +251,7 @@ var Plans = map[string]struct {
 				},
 			},
 		},
-		provisioningRawSchema: GCPSchema(),
+		provisioningRawSchema: GCPSchema([]string{"n1-standard-2", "n1-standard-4", "n1-standard-8", "n1-standard-16", "n1-standard-32", "n1-standard-64"}),
 	},
 	AzurePlanID: {
 		PlanDefinition: domain.ServicePlan{
@@ -335,7 +269,7 @@ var Plans = map[string]struct {
 				},
 			},
 		},
-		provisioningRawSchema: AzureSchema(),
+		provisioningRawSchema: AzureSchema([]string{"Standard_D8_v3"}),
 	},
 	AzureLitePlanID: {
 		PlanDefinition: domain.ServicePlan{
@@ -353,6 +287,6 @@ var Plans = map[string]struct {
 				},
 			},
 		},
-		provisioningRawSchema: AzureLiteSchema(),
+		provisioningRawSchema: AzureSchema([]string{"Standard_D4_v3"}),
 	},
 }

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -9,13 +9,15 @@ import (
 
 func TestSchemaGenerator(t *testing.T) {
 	tests := []struct {
-		name      string
-		generator func() []byte
-		want      string
+		name         string
+		generator    func([]string) []byte
+		machineTypes []string
+		want         string
 	}{
 		{
-			name:      "Azureschema is correct",
-			generator: AzureSchema,
+			name:         "Azure schema is correct",
+			generator:    AzureSchema,
+			machineTypes: []string{"Standard_D8_v3"},
 			want: `{
 			"$schema": "http://json-schema.org/draft-04/schema#",
 			"type": "object",
@@ -75,8 +77,71 @@ func TestSchemaGenerator(t *testing.T) {
 		]
 		}`},
 		{
-			name:      "GCPschema is correct",
-			generator: GCPSchema,
+			name:         "AzureLite schema is correct",
+			generator:    AzureSchema,
+			machineTypes: []string{"Standard_D4_v3"},
+			want: `{
+			"$schema": "http://json-schema.org/draft-04/schema#",
+			"type": "object",
+			"properties": {
+			"components": {
+			"type": "array",
+			"items": [
+		{
+			"type": "string",
+			"enum": ["Kiali", "Tracing"]
+		}
+		],
+			"additionalItems": false,
+			"uniqueItems": true
+		},
+			"name": {
+			"type": "string"
+		},
+			"diskType": {
+			"type": "string"
+		},
+			"volumeSizeGb": {
+			"type": "integer",
+			"minimum": 50
+		},
+			"machineType": {
+			"type": "string",
+			"enum": ["Standard_D4_v3"]
+		},
+			"region": {
+			"type": "string",
+			"enum": [ "centralus", "eastus", "westus2", "northeurope", "uksouth", "japaneast", "southeastasia", "westeurope" ]
+		},
+			"zones": {
+			"type": "array",
+			"items": [
+			{
+			  "type": "string"
+			}
+			]
+		},
+			"autoScalerMin": {
+			"type": "integer"
+		},
+			"autoScalerMax": {
+			"type": "integer"
+		},
+			"maxSurge": {
+			"type": "integer"
+		},
+			"maxUnavailable": {
+			"type": "integer"
+		}
+		},
+			"required": [
+			"name"
+		]
+		}`},
+		{
+			name:         "GCP schema is correct",
+			generator:    GCPSchema,
+			machineTypes: []string{"n1-standard-2", "n1-standard-4", "n1-standard-8", "n1-standard-16", "n1-standard-32", "n1-standard-64"},
 			want: `{
 			"$schema": "http://json-schema.org/draft-04/schema#",
 			"type": "object",
@@ -174,7 +239,7 @@ func TestSchemaGenerator(t *testing.T) {
 				t.Fail()
 			}
 
-			got := tt.generator()
+			got := tt.generator(tt.machineTypes)
 			var prettyGot bytes.Buffer
 			err = json.Indent(&prettyGot, got, "", "  ")
 			if err != nil {

--- a/components/kyma-environment-broker/internal/broker/plans_validator.go
+++ b/components/kyma-environment-broker/internal/broker/plans_validator.go
@@ -17,7 +17,7 @@ type JSONSchemaValidator interface {
 type PlansSchemaValidator map[string]JSONSchemaValidator
 
 func NewPlansSchemaValidator() (PlansSchemaValidator, error) {
-	planIDs := []string{GCPPlanID, AzurePlanID}
+	planIDs := []string{GCPPlanID, AzurePlanID, AzureLitePlanID}
 	validators := PlansSchemaValidator{}
 
 	for _, id := range planIDs {

--- a/components/kyma-environment-broker/internal/dto.go
+++ b/components/kyma-environment-broker/internal/dto.go
@@ -4,6 +4,10 @@ import (
 	"reflect"
 )
 
+const (
+	LicenceTypeLite = "TestDevelopmentAndDemo"
+)
+
 type ProvisioningParameters struct {
 	PlanID     string                    `json:"plan_id"`
 	ServiceID  string                    `json:"service_id"`
@@ -23,6 +27,9 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 	if p.ServiceID != input.ServiceID {
 		return false
 	}
+	if p.PlatformRegion != input.PlatformRegion {
+		return false
+	}
 
 	if !reflect.DeepEqual(p.ErsContext, input.ErsContext) {
 		return false
@@ -35,12 +42,16 @@ func (p ProvisioningParameters) IsEqual(input ProvisioningParameters) bool {
 }
 
 type ProvisioningParametersDTO struct {
-	Name                        string   `json:"name"`
-	TargetSecret                *string  `json:"targetSecret"`
-	VolumeSizeGb                *int     `json:"volumeSizeGb"`
-	MachineType                 *string  `json:"machineType"`
-	Region                      *string  `json:"region"`
-	Purpose                     *string  `json:"purpose"`
+	Name         string  `json:"name"`
+	TargetSecret *string `json:"targetSecret"`
+	VolumeSizeGb *int    `json:"volumeSizeGb"`
+	MachineType  *string `json:"machineType"`
+	Region       *string `json:"region"`
+	Purpose      *string `json:"purpose"`
+	// LicenceType - based on this parameter, some options can be enabled/disabled when preparing the input
+	// for the provisioner e.g. use default overrides for SKR instead overrides from resource
+	// with "provisioning-runtime-override" label when LicenceType is "TestDevelopmentAndDemo"
+	LicenceType                 *string  `json:"licence_type"`
 	Zones                       []string `json:"zones"`
 	AutoScalerMin               *int     `json:"autoScalerMin"`
 	AutoScalerMax               *int     `json:"autoScalerMax"`

--- a/components/kyma-environment-broker/internal/hyperscaler/azure/env.go
+++ b/components/kyma-environment-broker/internal/hyperscaler/azure/env.go
@@ -49,7 +49,7 @@ func mapRegion(credentials hyperscaler.Credentials, parameters internal.Provisio
 	}
 	region := *(parameters.Parameters.Region)
 	switch parameters.PlanID {
-	case broker.AzurePlanID:
+	case broker.AzurePlanID, broker.AzureLitePlanID:
 		if !isInList(broker.AzureRegions(), region) {
 			return "", fmt.Errorf("supplied region \"%v\" is not a valid region for Azure", region)
 		}

--- a/components/kyma-environment-broker/internal/hyperscaler/azure/env_test.go
+++ b/components/kyma-environment-broker/internal/hyperscaler/azure/env_test.go
@@ -83,6 +83,16 @@ func Test_mapRegion(t *testing.T) {
 			wantRegion: "westeurope",
 			wantErr:    false,
 		},
+		{
+			name: "valid azure lite region",
+			args: args{
+				hyperscalerType: hyperscaler.Azure,
+				planID:          broker.AzureLitePlanID,
+				region:          "japaneast",
+			},
+			wantRegion: "japaneast",
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -69,6 +69,7 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 				Region:            "europe-west4-a",
 				Provider:          "gcp",
 				Purpose:           &shootPurpose,
+				LicenceType:       nil,
 				WorkerCidr:        "10.250.0.0/19",
 				AutoScalerMin:     3,
 				AutoScalerMax:     4,

--- a/components/kyma-environment-broker/internal/process/provisioning/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/input/builder.go
@@ -59,7 +59,7 @@ func NewInputBuilderFactory(optComponentsSvc OptionalComponentService, component
 
 func (f *InputBuilderFactory) IsPlanSupport(planID string) bool {
 	switch planID {
-	case broker.GCPPlanID, broker.AzurePlanID:
+	case broker.GCPPlanID, broker.AzurePlanID, broker.AzureLitePlanID:
 		return true
 	default:
 		return false
@@ -77,6 +77,8 @@ func (f *InputBuilderFactory) ForPlan(planID, kymaVersion string) (internal.Prov
 		provider = &cloudProvider.GcpInput{}
 	case broker.AzurePlanID:
 		provider = &cloudProvider.AzureInput{}
+	case broker.AzureLitePlanID:
+		provider = &cloudProvider.AzureLiteInput{}
 	// insert cases for other providers like AWS or GCP
 	default:
 		return nil, errors.Errorf("case with plan %s is not supported", planID)

--- a/components/kyma-environment-broker/internal/process/provisioning/input/input.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/input/input.go
@@ -117,6 +117,9 @@ func (r *RuntimeInput) applyProvisioningParameters() error {
 	updateString(&r.input.ClusterConfig.GardenerConfig.MachineType, r.provisioningParameters.MachineType)
 	updateString(&r.input.ClusterConfig.GardenerConfig.TargetSecret, r.provisioningParameters.TargetSecret)
 	updateString(r.input.ClusterConfig.GardenerConfig.Purpose, r.provisioningParameters.Purpose)
+	if r.provisioningParameters.LicenceType != nil {
+		r.input.ClusterConfig.GardenerConfig.LicenceType = r.provisioningParameters.LicenceType
+	}
 
 	r.hyperscalerInputProvider.ApplyParameters(r.input.ClusterConfig, r.provisioningParameters)
 

--- a/components/kyma-environment-broker/internal/process/provisioning/input/input_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/input/input_test.go
@@ -139,6 +139,7 @@ func TestInputBuilderFactoryForAzurePlan(t *testing.T) {
 	assert.Equal(t, "azure-secret", input.ClusterConfig.GardenerConfig.TargetSecret)
 	require.NotNil(t, input.ClusterConfig.GardenerConfig.Purpose)
 	assert.Equal(t, "development", *input.ClusterConfig.GardenerConfig.Purpose)
+	assert.Nil(t, input.ClusterConfig.GardenerConfig.LicenceType)
 	assert.EqualValues(t, mappedComponentList, input.KymaConfig.Components)
 	assert.Equal(t, &gqlschema.Labels{
 		"label1": "value1",

--- a/components/kyma-environment-broker/internal/process/provisioning/resolve_creds.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/resolve_creds.go
@@ -25,7 +25,7 @@ func getHyperscalerTypeForPlanID(planID string) (hyperscaler.Type, error) {
 	switch planID {
 	case broker.GCPPlanID:
 		return hyperscaler.GCP, nil
-	case broker.AzurePlanID:
+	case broker.AzurePlanID, broker.AzureLitePlanID:
 		return hyperscaler.Azure, nil
 	default:
 		return "", errors.Errorf("Cannot determine the type of Hyperscaler to use for planID: %s", planID)

--- a/components/kyma-environment-broker/internal/process/provisioning/secret_cm_overrides_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/secret_cm_overrides_test.go
@@ -22,62 +22,109 @@ import (
 )
 
 func TestOverridesFromSecretsAndConfigStep_Run(t *testing.T) {
-	// Given
-	sch := runtime.NewScheme()
-	require.NoError(t, coreV1.AddToScheme(sch))
-	client := fake.NewFakeClientWithScheme(sch, fixResources()...)
+	t.Run("default type plan", func(t *testing.T) {
+		// Given
+		sch := runtime.NewScheme()
+		require.NoError(t, coreV1.AddToScheme(sch))
+		client := fake.NewFakeClientWithScheme(sch, fixResources()...)
 
-	memoryStorage := storage.NewMemoryStorage()
+		memoryStorage := storage.NewMemoryStorage()
 
-	inputCreatorMock := &automock.ProvisionInputCreator{}
-	defer inputCreatorMock.AssertExpectations(t)
-	inputCreatorMock.On("AppendOverrides", "core", []*gqlschema.ConfigEntryInput{
-		{
-			Key:    "test1",
-			Value:  "test1abc",
-			Secret: ptr.Bool(true),
-		},
-		{
-			Key:   "test5",
-			Value: "test5abc",
-		},
-	}).Return(nil).Once()
-	inputCreatorMock.On("AppendOverrides", "helm", []*gqlschema.ConfigEntryInput{
-		{
-			Key:    "test3",
-			Value:  "test3abc",
-			Secret: ptr.Bool(true),
-		},
-	}).Return(nil).Once()
-	inputCreatorMock.On("AppendOverrides", "servicecatalog", []*gqlschema.ConfigEntryInput{
-		{
-			Key:   "test7",
-			Value: "test7abc",
-		},
-	}).Return(nil).Once()
-	inputCreatorMock.On("AppendGlobalOverrides", []*gqlschema.ConfigEntryInput{
-		{
-			Key:    "test4",
-			Value:  "test4abc",
-			Secret: ptr.Bool(true),
-		},
-		{
-			Key:   "test8",
-			Value: "test8abc",
-		},
-	}).Return(nil).Once()
-	operation := internal.ProvisioningOperation{
-		InputCreator: inputCreatorMock,
-	}
+		inputCreatorMock := &automock.ProvisionInputCreator{}
+		defer inputCreatorMock.AssertExpectations(t)
+		inputCreatorMock.On("AppendOverrides", "core", []*gqlschema.ConfigEntryInput{
+			{
+				Key:    "test1",
+				Value:  "test1abc",
+				Secret: ptr.Bool(true),
+			},
+			{
+				Key:   "test5",
+				Value: "test5abc",
+			},
+		}).Return(nil).Once()
+		inputCreatorMock.On("AppendOverrides", "helm", []*gqlschema.ConfigEntryInput{
+			{
+				Key:    "test3",
+				Value:  "test3abc",
+				Secret: ptr.Bool(true),
+			},
+		}).Return(nil).Once()
+		inputCreatorMock.On("AppendOverrides", "servicecatalog", []*gqlschema.ConfigEntryInput{
+			{
+				Key:   "test7",
+				Value: "test7abc",
+			},
+		}).Return(nil).Once()
+		inputCreatorMock.On("AppendGlobalOverrides", []*gqlschema.ConfigEntryInput{
+			{
+				Key:    "test4",
+				Value:  "test4abc",
+				Secret: ptr.Bool(true),
+			},
+			{
+				Key:   "test8",
+				Value: "test8abc",
+			},
+		}).Return(nil).Once()
+		operation := internal.ProvisioningOperation{
+			InputCreator:           inputCreatorMock,
+			ProvisioningParameters: `{}`,
+		}
 
-	step := NewOverridesFromSecretsAndConfigStep(context.TODO(), client, memoryStorage.Operations())
+		step := NewOverridesFromSecretsAndConfigStep(context.TODO(), client, memoryStorage.Operations())
 
-	// When
-	operation, repeat, err := step.Run(operation, logrus.New())
+		// When
+		operation, repeat, err := step.Run(operation, logrus.New())
 
-	// Then
-	assert.NoError(t, err)
-	assert.Equal(t, time.Duration(0), repeat)
+		// Then
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), repeat)
+	})
+
+	t.Run("lite type plan", func(t *testing.T) {
+		// Given
+		sch := runtime.NewScheme()
+		require.NoError(t, coreV1.AddToScheme(sch))
+		client := fake.NewFakeClientWithScheme(sch, fixResources()...)
+
+		memoryStorage := storage.NewMemoryStorage()
+
+		inputCreatorMock := &automock.ProvisionInputCreator{}
+		defer inputCreatorMock.AssertExpectations(t)
+		inputCreatorMock.On("AppendOverrides", "core", []*gqlschema.ConfigEntryInput{
+			{
+				Key:   "test5",
+				Value: "test5abc",
+			},
+		}).Return(nil).Once()
+		inputCreatorMock.On("AppendOverrides", "helm", []*gqlschema.ConfigEntryInput{
+			{
+				Key:    "test3",
+				Value:  "test3abc",
+				Secret: ptr.Bool(true),
+			},
+		}).Return(nil).Once()
+		inputCreatorMock.On("AppendGlobalOverrides", []*gqlschema.ConfigEntryInput{
+			{
+				Key:   "test8",
+				Value: "test8abc",
+			},
+		}).Return(nil).Once()
+		operation := internal.ProvisioningOperation{
+			InputCreator:           inputCreatorMock,
+			ProvisioningParameters: `{"parameters": {"licence_type": "TestDevelopmentAndDemo"}}`,
+		}
+
+		step := NewOverridesFromSecretsAndConfigStep(context.TODO(), client, memoryStorage.Operations())
+
+		// When
+		operation, repeat, err := step.Run(operation, logrus.New())
+
+		// Then
+		assert.NoError(t, err)
+		assert.Equal(t, time.Duration(0), repeat)
+	})
 }
 
 func fixResources() []runtime.Object {
@@ -87,7 +134,7 @@ func fixResources() []runtime.Object {
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "secret#1",
 			Namespace: namespace,
-			Labels:    map[string]string{"provisioning-runtime-override": "true", "component": "core"},
+			Labels:    map[string]string{"provisioning-runtime-override": "true", "component": "core", "default-for-lite": "true"},
 		},
 		Data: map[string][]byte{"test1": []byte("test1abc")},
 	})
@@ -111,7 +158,7 @@ func fixResources() []runtime.Object {
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "secret#4",
 			Namespace: namespace,
-			Labels:    map[string]string{"provisioning-runtime-override": "true"},
+			Labels:    map[string]string{"provisioning-runtime-override": "true", "default-for-lite": "true"},
 		},
 		Data: map[string][]byte{"test4": []byte("test4abc")},
 	})
@@ -135,7 +182,7 @@ func fixResources() []runtime.Object {
 		ObjectMeta: metaV1.ObjectMeta{
 			Name:      "configmap#3",
 			Namespace: namespace,
-			Labels:    map[string]string{"provisioning-runtime-override": "true", "component": "servicecatalog"},
+			Labels:    map[string]string{"provisioning-runtime-override": "true", "component": "servicecatalog", "default-for-lite": "true"},
 		},
 		Data: map[string]string{"test7": "test7abc"},
 	})

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -9,7 +9,10 @@ const (
 	DefaultAzureRegion = "westeurope"
 )
 
-type AzureInput struct{}
+type (
+	AzureInput     struct{}
+	AzureLiteInput struct{}
+)
 
 func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
 	return &gqlschema.ClusterConfigInput{
@@ -35,5 +38,32 @@ func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
 }
 
 func (p *AzureInput) ApplyParameters(input *gqlschema.ClusterConfigInput, params internal.ProvisioningParametersDTO) {
+	updateSlice(&input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones, params.Zones)
+}
+
+func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
+	return &gqlschema.ClusterConfigInput{
+		GardenerConfig: &gqlschema.GardenerConfigInput{
+			DiskType:       "Standard_LRS",
+			VolumeSizeGb:   50,
+			MachineType:    "Standard_D4_v3",
+			Region:         DefaultAzureRegion,
+			Provider:       "azure",
+			WorkerCidr:     "10.250.0.0/19",
+			AutoScalerMin:  3,
+			AutoScalerMax:  4,
+			MaxSurge:       4,
+			MaxUnavailable: 1,
+			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
+				AzureConfig: &gqlschema.AzureProviderConfigInput{
+					VnetCidr: "10.250.0.0/19",
+					Zones:    []string{"1", "2", "3"},
+				},
+			},
+		},
+	}
+}
+
+func (p *AzureLiteInput) ApplyParameters(input *gqlschema.ClusterConfigInput, params internal.ProvisioningParametersDTO) {
 	updateSlice(&input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones, params.Zones)
 }

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
@@ -68,6 +68,9 @@ func (g *Graphqlizer) GardenerConfigInputToGraphQL(in gqlschema.GardenerConfigIn
 		{{- if .Purpose }}
 		purpose: "{{ .Purpose }}",
 		{{- end }}
+		{{- if .LicenceType }}
+		licenceType: "{{ .LicenceType }}",
+		{{- end }}
 		diskType: "{{.DiskType}}",
 		targetSecret: "{{ .TargetSecret }}",
 		workerCidr: "{{ .WorkerCidr }}",

--- a/docs/kyma-environment-broker/03-06-runtime-overrides.md
+++ b/docs/kyma-environment-broker/03-06-runtime-overrides.md
@@ -33,12 +33,12 @@ See the examples:
       database.password: YWRtaW4xMjMK
     ```  
 
-### Disable overrides for specific plans
+## Disable overrides for specific plans
 
-Config Maps and Secrets overrides for customization Kyma Runtime works for all plans but for some kinds of special plans like for example "AzureLite"
-overrides can be disabled. To disable a specific override for a special lite plan use label `default-for-lite: "true"`.
+ConfigMaps and Secrets overrides work for all plans, however, you can disable overrides for specific lite plans, such as `AzureLite`.
+To disable a specific override for a lite plan, use the `default-for-lite: "true"` label.
 
-See the examples:
+See the example:
 
 ```yaml
 apiVersion: v1
@@ -53,4 +53,4 @@ data:
   global.disableLegacyConnectivity: "true"
 ```  
     
-Above ConfigMap activates global override for all plans except SKR provisioned with special plan marked as `lite`.
+This ConfigMap activates a global override for all plans except SKRs provisioned with a special plan marked as `lite`.

--- a/docs/kyma-environment-broker/03-06-runtime-overrides.md
+++ b/docs/kyma-environment-broker/03-06-runtime-overrides.md
@@ -32,3 +32,25 @@ See the examples:
     data:
       database.password: YWRtaW4xMjMK
     ```  
+
+### Disable overrides for specific plans
+
+Config Maps and Secrets overrides for customization Kyma Runtime works for all plans but for some kinds of special plans like for example "AzureLite"
+overrides can be disabled. To disable a specific override for a special lite plan use label `default-for-lite: "true"`.
+
+See the examples:
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    provisioning-runtime-override: "true"
+    default-for-lite: "true"
+  name: global-overrides
+  namespace: compass-system
+data:
+  global.disableLegacyConnectivity: "true"
+```  
+    
+Above ConfigMap activates global override for all plans except SKR provisioned with special plan marked as `lite`.

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -60,7 +60,7 @@ additionalRuntimeComponents: |-
 kymaVersion: "1.13.0"
 kymaVersionOnDemand: "false"
 
-enablePlans: "azure,gcp"
+enablePlans: "azure,gcp,azure_lite"
 
 gardener:
   project: "kyma-dev" # Gardener project connected to SA for HAP credentials lookup

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-39"
     kyma_environment_broker:
       dir:
-      version: "PR-34"
+      version: "PR-37"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-27"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Provides new Azure lite plan with smaller machines, less max nodes, default settings for ory, istio and monitoring charts
- Cluster with plan lite is marked in shoot annotation on Gardener
- New id for plan lite is `8cb22518-aa26-44c5-91a0-e669ec9bf443`