### PR TITLE
Document Runtime Provisioner's upgradeShoot mutation

### DIFF
--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -22,7 +22,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
       * Compute Admin
   - Key generated for your service account, downloaded in the JSON format
   - Gardener service account configuration (`kubeconfig.yaml`) downloaded
-  - Compass with configured Runtime Provisioner and the following [overrides](05-01-app-entry-parameters.md) set up:
+  - [Compass](https://github.com/kyma-incubator/compass) with configured Runtime Provisioner and the following [overrides](05-01-app-entry-parameters.md) set up:
       * Kubeconfig (`provisioner.gardener.kubeconfig`)
       * Gardener project name (`provisioner.gardener.project`)
   

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -66,7 +66,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
   </details>
 </div>
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL Server is listening.   
+> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.   
 
 ## Steps
 
@@ -352,6 +352,6 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
     
 </div>
 
-The operation of provisioning is asynchronous. The operation of provisioning returns the Runtime Operation Status containing the Runtime ID (`provisionRuntime.runtimeID`) and the operation ID (`provisionRuntime.id`). Use the Runtime ID to [check the Runtime Status](08-04-runtime-status.md). Use the provisioning operation ID to [check the Runtime Operation Status](08-03-runtime-operation-status.md) and verify that the provisioning was successful.
+The operation of provisioning is asynchronous. The operation of provisioning returns the Runtime operation status containing the Runtime ID (`provisionRuntime.runtimeID`) and the operation ID (`provisionRuntime.id`). Use the Runtime ID to [check the Runtime status](08-04-runtime-status.md). Use the provisioning operation ID to [check the Runtime operation status](08-03-runtime-operation-status.md) and verify that the provisioning was successful.
 
 > **NOTE:** To see how to provide the labels, see [this](../compass/03-02-labels.md) document. To see an example of label usage, go [here](../../components/director/examples/register-application/register-application.graphql). 

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -149,7 +149,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
     
       A successful call returns the operation status:
     
-      ```graphql
+      ```json
         {
           "data": {
             "provisionRuntime": {
@@ -240,7 +240,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
     
       A successful call returns the operation status:
     
-      ```graphql
+      ```json
       {
         "data": {
           "provisionRuntime": {
@@ -338,7 +338,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
     
       A successful call returns the operation status:
     
-      ```graphql
+      ```json
       {
         "data": {
           "provisionRuntime": {

--- a/docs/provisioner/08-03-runtime-operation-status.md
+++ b/docs/provisioner/08-03-runtime-operation-status.md
@@ -7,7 +7,7 @@ This tutorial shows how to check the Runtime operation status for the operations
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL Server is listening.
+> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
 Make a call to the Runtime Provisioner with a **tenant** header to verify that provisioning/deprovisioning succeeded. Pass the ID of the operation as `id`.
 

--- a/docs/provisioner/08-03-runtime-operation-status.md
+++ b/docs/provisioner/08-03-runtime-operation-status.md
@@ -24,7 +24,7 @@ query {
 
 A successful call returns a response which includes the status of the (de)provisioning operation (`state`) and the id of the (de)provisioned Runtime (`runtimeID`):
 
-```graphql
+```json
 {
   "data": {
     "runtimeOperationStatus": {

--- a/docs/provisioner/08-04-runtime-status.md
+++ b/docs/provisioner/08-04-runtime-status.md
@@ -62,7 +62,7 @@ query { runtimeStatus(id: "{RUNTIME_ID}") {
 
 An example response for a successful request looks like this:
 
-```graphql
+```json
 {
   "data": {
     "runtimeStatus": {

--- a/docs/provisioner/08-04-runtime-status.md
+++ b/docs/provisioner/08-04-runtime-status.md
@@ -7,6 +7,8 @@ This tutorial shows how to check the Runtime status.
 
 ## Steps
 
+> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
+
 Make a call to the Runtime Provisioner with a **tenant** header to check the Runtime status. Pass the Runtime ID as `id`. 
 
 ```graphql

--- a/docs/provisioner/08-05-deprovisioning.md
+++ b/docs/provisioner/08-05-deprovisioning.md
@@ -17,7 +17,7 @@ This tutorial shows how to deprovision clusters with Kyma Runtimes.
 
   A successful call returns the ID of the deprovisioning operation:
 
-  ```graphql
+  ```json
   {
     "data": {
       "deprovisionRuntime": "c7e6727f-16b5-4748-ac95-197d8f79d094"

--- a/docs/provisioner/08-05-deprovisioning.md
+++ b/docs/provisioner/08-05-deprovisioning.md
@@ -7,7 +7,7 @@ This tutorial shows how to deprovision clusters with Kyma Runtimes.
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL Server is listening.
+> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
   To deprovision a Runtime, make a call to the Runtime Provisioner with a **tenant** header using a mutation like this:  
   
@@ -25,4 +25,4 @@ This tutorial shows how to deprovision clusters with Kyma Runtimes.
   }
   ```
 
-  The operation of deprovisioning is asynchronous. Use the deprovisioning operation ID (`deprovisionRuntime`) to [check the Runtime Operation Status](08-03-runtime-operation-status.md) and verify that the deprovisioning was successful. Use the Runtime ID (`id`) to [check the Runtime Status](08-04-runtime-status.md). 
+  The operation of deprovisioning is asynchronous. Use the deprovisioning operation ID (`deprovisionRuntime`) to [check the Runtime operation status](08-03-runtime-operation-status.md) and verify that the deprovisioning was successful. Use the Runtime ID (`id`) to [check the Runtime status](08-04-runtime-status.md). 

--- a/docs/provisioner/08-06-upgrading-shoots.md
+++ b/docs/provisioner/08-06-upgrading-shoots.md
@@ -39,7 +39,9 @@ mutation {
 }
 ```
 
-A successful call returns the ID of the upgrading operation:
+All the configuration fields are optional here. If you don't include them, their values remain the same as before the upgrade.
+
+A successful call returns the ID of the upgrade operation:
 
 ```json
 {

--- a/docs/provisioner/08-06-upgrading-shoots.md
+++ b/docs/provisioner/08-06-upgrading-shoots.md
@@ -39,7 +39,7 @@ mutation {
 }
 ```
 
-All the configuration fields are optional here. If you don't include them, their values remain the same as before the upgrade.
+All the `gardenerConfig` fields are optional here. If you don't include them, their values remain the same as before the upgrade.
 
 A successful call returns the ID of the upgrade operation:
 

--- a/docs/provisioner/08-06-upgrading-shoots.md
+++ b/docs/provisioner/08-06-upgrading-shoots.md
@@ -3,13 +3,13 @@ title: Upgrade shoots
 type: Tutorials
 ---
 
-This tutorial shows how to upgrade Gardener shoots for Kyma Runtimes.
+This tutorial shows how to upgrade Gardener Shoot clusters for Kyma Runtimes.
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL Server is listening.
+> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
-To upgrade a Gardener Shoot used to host the Runtime of a given ID, make a call to the Runtime Provisioner with a **tenant** header using a mutation like this:  
+To upgrade a Gardener Shoot cluster used to host the Runtime of a given ID, make a call to the Runtime Provisioner with a **tenant** header using a mutation like this:  
 
 ```graphql
 mutation { 
@@ -49,4 +49,4 @@ A successful call returns the ID of the upgrading operation:
 }
 ```
 
-The operation of upgrading is asynchronous. Use the upgrade operation ID (`upgradeShoot`) to [check the Runtime Operation Status](08-03-runtime-operation-status.md) and verify that the upgrade was successful. Use the Runtime ID (`id`) to [check the Runtime Status](08-04-runtime-status.md). 
+The upgrade operation is asynchronous. Use the upgrade operation ID (`upgradeShoot`) to [check the Runtime operation status](08-03-runtime-operation-status.md) and verify that the upgrade was successful. Use the Runtime ID (`id`) to [check the Runtime status](08-04-runtime-status.md). 

--- a/docs/provisioner/08-06-upgrading-shoots.md
+++ b/docs/provisioner/08-06-upgrading-shoots.md
@@ -35,7 +35,12 @@ mutation {
         }
       }
     }
-  ) 
+  ) {
+        id 
+        operation 
+        state 
+        message
+    } 
 }
 ```
 

--- a/docs/provisioner/08-06-upgrading-shoots.md
+++ b/docs/provisioner/08-06-upgrading-shoots.md
@@ -1,0 +1,52 @@
+---
+title: Upgrade shoots
+type: Tutorials
+---
+
+This tutorial shows how to upgrade Gardener shoots for Kyma Runtimes.
+
+## Steps
+
+> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL Server is listening.
+
+To upgrade a Gardener Shoot used to host the Runtime of a given ID, make a call to the Runtime Provisioner with a **tenant** header using a mutation like this:  
+
+```graphql
+mutation { 
+  upgradeShoot(
+    id: "61d1841b-ccb5-44ed-a9ec-45f70cd1b0d3"
+    config: {
+      gardenerConfig: {
+        kubernetesVersion: "1.15.11"
+        volumeSizeGB: 35
+        machineType: "Standard_D2_v3"
+        diskType: "pd-standard"
+        purpose: "testing"
+        autoScalerMin: 2
+        autoScalerMax: 4
+        maxSurge: 4
+        maxUnavailable: 1
+        enableKubernetesVersionAutoUpdate: false
+        enableMachineImageVersionAutoUpdate: false
+        providerSpecificConfig: { 
+          azureConfig: {
+            zones: ["1", "2"]
+          } 
+        }
+      }
+    }
+  ) 
+}
+```
+
+A successful call returns the ID of the upgrading operation:
+
+```json
+{
+  "data": {
+    "upgradeShoot": "c7e6727f-16b5-4748-ac95-197d8f79d094"
+  }
+}
+```
+
+The operation of upgrading is asynchronous. Use the upgrade operation ID (`upgradeShoot`) to [check the Runtime Operation Status](08-03-runtime-operation-status.md) and verify that the upgrade was successful. Use the Runtime ID (`id`) to [check the Runtime Status](08-04-runtime-status.md). 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -87,6 +87,30 @@ The mutation returns OperationID allowing to retrieve the operation status.
 
 The mutation returns OperationID allowing to retrieve the operation status.
 
+### Upgrade Shoot mutation
+
+***upgradeShoot*** mutation upgrades Gardener Shoot cluster configuration, triggering shoot reconciliation.
+
+>**NOTICE:** This operation is dangerous and could potentially damage your Runtime. Use it wisely and with reasonable configuration values. **There is no rollback functionality implemented**, so you would have to get your hands dirty to fix potential failures.
+The object passed to the mutation contains these configurable `GardenerConfig` values:
+
+| Field                                 |                                       Configurable                                       | Note         |
+| ------------------------------------- | :--------------------------------------------------------------------------------------: | ------------ |
+| `kubernetesVersion`                   |                                    :heavy_check_mark:                                    | upgrade only |
+| `purpose`                             |                                    :heavy_check_mark:                                    |              |
+| `machineType`                         |                                    :heavy_check_mark:                                    |              |
+| `volumeSizeGB`                        |                                    :heavy_check_mark:                                    |              |
+| `diskType`                            |                                    :heavy_check_mark:                                    |              |
+| `autoScalerMin`                       |                                    :heavy_check_mark:                                    | min. 1       |
+| `autoScalerMax`                       |                                    :heavy_check_mark:                                    |              |
+| `maxSurge`                            |                                    :heavy_check_mark:                                    |              |
+| `maxUnavailable`                      |                                    :heavy_check_mark:                                    |              |
+| `enableKubernetesVersionAutoUpdate`   |                                    :heavy_check_mark:                                    |              |
+| `enableMachineImageVersionAutoUpdate` |                                    :heavy_check_mark:                                    |              |
+| `providerSpecificConfig`              | Azure :heavy_check_mark: <br/> AWS :heavy_multiplication_x: <br/> GCP :heavy_check_mark: | `zones` only |
+
+The mutation returns OperationID allowing to retrieve the operation status.
+
 ### Deprovision Runtime mutation
 
 ***deprovisionRuntime*** mutation deprovisions Runtimes. Pass the RuntimeID as argument. 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -1,8 +1,8 @@
-# Introduction
+# Provisioning API
 
-The goal of this document is to describe the requirements for the Provisioner component and propose an API. 
+The goal of this document is to describe the requirements for the Runtime Provisioner and propose an API. 
 
-## Requirements
+# Requirements
 
 ## Non-Functional
 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -42,7 +42,7 @@ These operations must be supported:
 These are the basic assumptions for the API design:
 
 - Cluster provisioning and Kyma installation is considered an atomic operation.
-- Provisioning, deprovisioning, upgrade, and Runtime Agent reconnecting is uniquely identified by OperationID.
+- Provisioning, deprovisioning, upgrade, and Runtime Agent reconnecting is uniquely identified by operation ID.
 - Runtime is uniquely identified by RuntimeID.
 - Before you provision the Runtime, register it in Director API. Use RuntimeID returned from Director in Provisioner API.
 - Only one asynchronous operation can be in progress on a given Runtime.  
@@ -73,7 +73,7 @@ These are the basic assumptions for the API design:
 
 Some Kubernetes cluster settings (such as size, memory, and version) are optional and default values are used.
 
-The mutation returns OperationID allowing to retrieve the operation status.
+The mutation returns operation ID which allows you to retrieve the operation status.
 
 ### Upgrade Runtime mutation
 
@@ -85,49 +85,49 @@ The mutation returns OperationID allowing to retrieve the operation status.
 - Kubernetes cluster settings
   - Version
 
-The mutation returns OperationID allowing to retrieve the operation status.
+The mutation returns operation ID which allows you to retrieve the operation status.
 
-### Upgrade Shoot mutation
+### Upgrade Shoot cluster mutation
 
-***upgradeShoot*** mutation upgrades Gardener Shoot cluster configuration, triggering shoot reconciliation.
+***upgradeShoot*** mutation upgrades the Gardener Shoot cluster configuration, triggering Shoot reconciliation.
 
 >**NOTICE:** This operation is dangerous and could potentially damage your Runtime. Use it wisely and with reasonable configuration values. **There is no rollback functionality implemented**, so you would have to get your hands dirty to fix potential failures.
 The object passed to the mutation contains these configurable `GardenerConfig` values:
 
 | Field                                 |                                       Configurable                                       | Note         |
 | ------------------------------------- | :--------------------------------------------------------------------------------------: | ------------ |
-| `kubernetesVersion`                   |                                    :heavy_check_mark:                                    | upgrade only |
-| `purpose`                             |                                    :heavy_check_mark:                                    |              |
-| `machineType`                         |                                    :heavy_check_mark:                                    |              |
-| `volumeSizeGB`                        |                                    :heavy_check_mark:                                    |              |
-| `diskType`                            |                                    :heavy_check_mark:                                    |              |
-| `autoScalerMin`                       |                                    :heavy_check_mark:                                    | min. 1       |
-| `autoScalerMax`                       |                                    :heavy_check_mark:                                    |              |
-| `maxSurge`                            |                                    :heavy_check_mark:                                    |              |
-| `maxUnavailable`                      |                                    :heavy_check_mark:                                    |              |
-| `enableKubernetesVersionAutoUpdate`   |                                    :heavy_check_mark:                                    |              |
-| `enableMachineImageVersionAutoUpdate` |                                    :heavy_check_mark:                                    |              |
-| `providerSpecificConfig`              | Azure :heavy_check_mark: <br/> AWS :heavy_multiplication_x: <br/> GCP :heavy_check_mark: | `zones` only |
+| **kubernetesVersion**                   |                                    :heavy_check_mark:                                    | upgrade only |
+| **purpose**                             |                                    :heavy_check_mark:                                    |              |
+| **machineType**                         |                                    :heavy_check_mark:                                    |              |
+| **volumeSizeGB**                        |                                    :heavy_check_mark:                                    |              |
+| **diskType**                            |                                    :heavy_check_mark:                                    |              |
+| **autoScalerMin**                       |                                    :heavy_check_mark:                                    | min. 1       |
+| **autoScalerMax**                       |                                    :heavy_check_mark:                                    |              |
+| **maxSurge**                            |                                    :heavy_check_mark:                                    |              |
+| **maxUnavailable**                      |                                    :heavy_check_mark:                                    |              |
+| **enableKubernetesVersionAutoUpdate**   |                                    :heavy_check_mark:                                    |              |
+| **enableMachineImageVersionAutoUpdate** |                                    :heavy_check_mark:                                    |              |
+| **providerSpecificConfig**              | Azure :heavy_check_mark: <br/> AWS :heavy_multiplication_x: <br/> GCP :heavy_check_mark: | `zones` only |
 
-The mutation returns OperationID allowing to retrieve the operation status.
+The mutation returns operation ID which allows you to retrieve the operation status.
 
 ### Deprovision Runtime mutation
 
 ***deprovisionRuntime*** mutation deprovisions Runtimes. Pass the RuntimeID as argument. 
 
-The mutation returns OperationID allowing to retrieve the operation status.
+The mutation returns operation ID which allows you to retrieve the operation status.
 
 ### Reconnect Runtime Agent mutation
 
 ***reconnectRuntimeAgent*** mutation reconnects the Runtime Agent. Pass the RuntimeID as argument. 
 
-The mutation returns OperationID allowing to retrieve the operation status.
+The mutation returns operation ID which allows you to retrieve the operation status.
 
 ## Retrieving operation status
 
 ### Operation status query
 
-***runtimeOperationStatus*** query gets the Runtime operation status. The query takes Operation ID as parameter and returns object containing this information:
+***runtimeOperationStatus*** query gets the Runtime operation status. The query takes the operation ID as a parameter and returns an object containing this information:
 
 - Operation type (e.g. Provisioning)
 - Operation status (e.g. InProgress)

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -42,7 +42,7 @@ These operations must be supported:
 These are the basic assumptions for the API design:
 
 - Cluster provisioning and Kyma installation is considered an atomic operation.
-- Provisioning, deprovisioning, upgrade, and Runtime Agent reconnecting is uniquely identified by operation ID.
+- Provisioning, deprovisioning, upgrade, and Runtime Agent reconnecting is uniquely identified by the operation ID.
 - Runtime is uniquely identified by RuntimeID.
 - Before you provision the Runtime, register it in Director API. Use RuntimeID returned from Director in Provisioner API.
 - Only one asynchronous operation can be in progress on a given Runtime.  
@@ -73,7 +73,7 @@ These are the basic assumptions for the API design:
 
 Some Kubernetes cluster settings (such as size, memory, and version) are optional and default values are used.
 
-The mutation returns operation ID which allows you to retrieve the operation status.
+The mutation returns the operation ID which allows you to retrieve the operation status.
 
 ### Upgrade Runtime mutation
 
@@ -85,7 +85,7 @@ The mutation returns operation ID which allows you to retrieve the operation sta
 - Kubernetes cluster settings
   - Version
 
-The mutation returns operation ID which allows you to retrieve the operation status.
+The mutation returns the operation ID which allows you to retrieve the operation status.
 
 ### Upgrade Shoot cluster mutation
 
@@ -109,19 +109,19 @@ The object passed to the mutation contains these configurable `GardenerConfig` v
 | **enableMachineImageVersionAutoUpdate** |                                    :heavy_check_mark:                                    |              |
 | **providerSpecificConfig**              | Azure :heavy_check_mark: <br/> AWS :heavy_multiplication_x: <br/> GCP :heavy_check_mark: | `zones` only |
 
-The mutation returns operation ID which allows you to retrieve the operation status.
+The mutation returns the operation ID which allows you to retrieve the operation status.
 
 ### Deprovision Runtime mutation
 
 ***deprovisionRuntime*** mutation deprovisions Runtimes. Pass the RuntimeID as argument. 
 
-The mutation returns operation ID which allows you to retrieve the operation status.
+The mutation returns the operation ID which allows you to retrieve the operation status.
 
 ### Reconnect Runtime Agent mutation
 
 ***reconnectRuntimeAgent*** mutation reconnects the Runtime Agent. Pass the RuntimeID as argument. 
 
-The mutation returns operation ID which allows you to retrieve the operation status.
+The mutation returns the operation ID which allows you to retrieve the operation status.
 
 ## Retrieving operation status
 


### PR DESCRIPTION
**Description**

A new functionality has been added to the Runtime Provisioner that allows for upgrading Gardener shoot clusters using the Provisioning API. This needs to be documented.

Changes proposed in this pull request:

- Add the `upgradeShoot` mutation description to the Provisioning API
- Add a tutorial on how to upgrade a Gardener Shoot cluster

**Related issue**
See kyma-incubator/compass#1422

**Related PR**
See https://github.com/kyma-project/control-plane/pull/28