### PR TITLE
kubeconfig-service fsnotify

### DIFF
--- a/components/kubeconfig-service/cmd/generator/main.go
+++ b/components/kubeconfig-service/cmd/generator/main.go
@@ -23,6 +23,7 @@ func main() {
 	env.InitConfig()
 	authnCfg := readAuthnConfig()
 	log.Info("Starting kubeconfig-service sever")
+	setupLogLevel()
 
 	fileWatcherCtx, fileWatcherCtxCancel := context.WithCancel(context.Background())
 
@@ -64,6 +65,16 @@ func main() {
 	case <-term:
 		log.Info("Received SIGTERM, exiting gracefully...")
 		fileWatcherCtxCancel()
+	}
+}
+
+func setupLogLevel() {
+	logLevel, err := log.ParseLevel(env.Config.LogLevel)
+	if err == nil {
+		log.SetLevel(logLevel)
+	} else {
+		log.Error(err, ". Defaulting to \"info\"")
+		log.SetLevel(log.InfoLevel)
 	}
 }
 

--- a/components/kubeconfig-service/go.mod
+++ b/components/kubeconfig-service/go.mod
@@ -4,8 +4,8 @@ go 1.13
 
 require (
 	github.com/avast/retry-go v2.6.0+incompatible
+	github.com/fsnotify/fsnotify v1.4.9
 	github.com/gorilla/mux v1.7.4
-	github.com/howeyc/fsnotify v0.9.0
 	github.com/kyma-project/control-plane/components/provisioner v0.0.0-20200702142454-d5c043eb0dbe
 	github.com/machinebox/graphql v0.2.3-0.20181106130121-3a9253180225
 	github.com/pkg/errors v0.9.1

--- a/components/kubeconfig-service/go.sum
+++ b/components/kubeconfig-service/go.sum
@@ -185,6 +185,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/frankban/quicktest v1.5.0/go.mod h1:jaStnuzAqU1AJdCO0l53JDCJrVDKcS03DbaAcR7Ks/o=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
+github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
+github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/gardener/controller-manager-library v0.0.0-20190418145731-83f4bac4b55f/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
 github.com/gardener/controller-manager-library v0.0.0-20190715130150-315e86b01963/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
 github.com/gardener/controller-manager-library v0.0.0-20190830161011-2626c078acef/go.mod h1:v6cbldxmpL2fYBEB2lSnq3LSEPwIHus9En6iIhwNE1k=
@@ -423,8 +425,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/howeyc/fsnotify v0.9.0 h1:0gtV5JmOKH4A8SsFxG2BczSeXWWPvcMT0euZt5gDAxY=
-github.com/howeyc/fsnotify v0.9.0/go.mod h1:41HzSPxBGeFRQKEEwgh49TRw/nKBsYZ2cF1OzPjSJsA=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huandu/xstrings v1.2.0/go.mod h1:DvyZB1rfVYsBIigL8HwpZgxHwXozlTgGqn63UyNX5k4=
 github.com/huandu/xstrings v1.2.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
@@ -841,6 +841,7 @@ golang.org/x/sys v0.0.0-20190804053845-51ab0e2deafa/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190826190057-c7b8b68b1456/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191119060738-e882bf8e40c2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/components/kubeconfig-service/pkg/env/env.go
+++ b/components/kubeconfig-service/pkg/env/env.go
@@ -33,6 +33,7 @@ type EnvConfig struct {
 		}
 		SupportedSigningAlgs []string `envconfig:"default=RS256"`
 	}
+	LogLevel string `envconfig:"default=info"`
 }
 
 func InitConfig() {


### PR DESCRIPTION
**Description**

The file-watching mechanism we have at the moment re-loads files when only attributes are changing (ctime, mtime, permission bits).
This causes problems in some k8s scenarios where attributes may change frequently, although the data stays the same.
Changes proposed in this pull request:

- Bump fsnotify library to the latest version (it's a new fork)
- Improve watching logic to skip only-attribute-changed scenarios
- Improved and extended tests for watch logic

**Related issue(s)**
See also: https://github.com/kyma-project/kyma/issues/8868