### PR TITLE
Fix a few issues with e2e-upgrade test

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
@@ -57,7 +57,7 @@ spec:
             - name: APP_PROVISIONER_URL
               value: "{{ .Values.provisioner.URL }}"
             - name: APP_CONFIG_NAME
-              value: "{{ .Values.e2e.azure.configName }}"
+              value: "{{ .Values.e2e.upgrade.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -94,7 +94,7 @@ avs:
   internalTesterService: ""
   externalTesterService: ""
   # List of tags to bind to testers.
-  # Example: 
+  # Example:
   # internalTesterTags: |-
   #   - content: tag-A
   #     tag_id: 1
@@ -157,6 +157,7 @@ e2e:
   gcp:
     configName: "e2e-runtime-config-gcp"
   upgrade:
+    configName: "e2e-upgrade-runtime-config-azure"
     timeout: "100m"
     preUpgradeVersion: ""
     targetVersion: "master-156dc1a5"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -25,7 +25,7 @@ global:
         version: "PR-39"
       e2e_provisioning:
         dir:
-        version: "PR-36"
+        version: "PR-56"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/tests/e2e/provisioning/internal/provisioner/components_provider.go
+++ b/tests/e2e/provisioning/internal/provisioner/components_provider.go
@@ -181,7 +181,8 @@ func (r *ComponentsListProvider) getInstallerYamlURL(kymaVersion string) string 
 // source: https://github.com/kyma-project/test-infra/blob/master/docs/prow/prow-architecture.md#generate-development-artifacts
 func (r *ComponentsListProvider) isOnDemandRelease(version string) bool {
 	isOnDemandVersion := strings.HasPrefix(version, "PR-") ||
-		strings.HasPrefix(version, "master-")
+		strings.HasPrefix(version, "master-") ||
+		strings.EqualFold(version, "master")
 	return isOnDemandVersion
 }
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Allow configuring "master" as the upgrade version to test upgrading to the latest
- Separate the e2e-upgrade-azure SKR configmap from the e2e-azure as the two conflict when run concurrently 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
