### PR TITLE
Fix undeterministic KEB pubsub test

### DIFF
--- a/components/kyma-environment-broker/internal/event/pubsub_test.go
+++ b/components/kyma-environment-broker/internal/event/pubsub_test.go
@@ -2,13 +2,13 @@ package event_test
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/event"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"sync"
 )
 
 func TestPubSub(t *testing.T) {

--- a/components/kyma-environment-broker/internal/event/pubsub_test.go
+++ b/components/kyma-environment-broker/internal/event/pubsub_test.go
@@ -8,22 +8,30 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/event"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"sync"
 )
 
 func TestPubSub(t *testing.T) {
 	// given
 	var gotEventAList1 []eventA
 	var gotEventAList2 []eventA
+	var mu sync.Mutex
 	handlerA1 := func(ctx context.Context, ev interface{}) error {
+		mu.Lock()
+		defer mu.Unlock()
 		gotEventAList1 = append(gotEventAList1, ev.(eventA))
 		return nil
 	}
 	handlerA2 := func(ctx context.Context, ev interface{}) error {
+		mu.Lock()
+		defer mu.Unlock()
 		gotEventAList2 = append(gotEventAList2, ev.(eventA))
 		return nil
 	}
 	var gotEventBList []eventB
 	handlerB := func(ctx context.Context, ev interface{}) error {
+		mu.Lock()
+		defer mu.Unlock()
 		gotEventBList = append(gotEventBList, ev.(eventB))
 		return nil
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- because KEB pubsub is asynchronous, the unit test must have some synchronization.
