### PR TITLE
Fix AVS client authorization process

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -185,7 +185,9 @@ func main() {
 
 	edpClient := edp.NewClient(cfg.EDP, logs.WithField("service", "edpClient"))
 
-	avsDel := avs.NewDelegator(cfg.Avs, db.Operations())
+	avsClient, err := avs.NewClient(ctx, cfg.Avs)
+	fatalOnError(err)
+	avsDel := avs.NewDelegator(avsClient, cfg.Avs, db.Operations())
 	externalEvalAssistant := avs.NewExternalEvalAssistant(cfg.Avs)
 	internalEvalAssistant := avs.NewInternalEvalAssistant(cfg.Avs)
 	externalEvalCreator := provisioning.NewExternalEvalCreator(avsDel, cfg.Avs.Disabled, externalEvalAssistant)

--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -1,62 +1,184 @@
 package avs
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
 	"net/http"
-	"sync"
-	"sync/atomic"
+	"strconv"
+	"strings"
 
-	"github.com/sirupsen/logrus"
+	"github.com/pkg/errors"
 	"golang.org/x/oauth2"
 )
 
-type clientHolder struct {
-	httpClient        *http.Client
-	avsConfig         Config
-	clientInitialized uint32
-	mu                sync.Mutex
+type Client struct {
+	httpClient *http.Client
+	avsConfig  Config
 }
 
-func newClientHolder(avsConfig Config) *clientHolder {
-	return &clientHolder{
-		avsConfig: avsConfig,
+func NewClient(ctx context.Context, avsConfig Config) (*Client, error) {
+	config, initialToken, err := createInitialToken(avsConfig)
+	if err != nil {
+		return nil, errors.Wrap(err, "while creating oauth config and token")
 	}
+
+	return &Client{
+		httpClient: config.Client(ctx, initialToken),
+		avsConfig:  avsConfig,
+	}, nil
 }
 
-func (ch *clientHolder) getClient(logger logrus.FieldLogger) (*http.Client, error) {
-	if atomic.LoadUint32(&ch.clientInitialized) == 1 {
-		return ch.httpClient, nil
-	}
-
-	ch.mu.Lock()
-	defer ch.mu.Unlock()
-
-	if atomic.LoadUint32(&ch.clientInitialized) == 0 {
-		logger.Infof("creating the lazy client for avs..")
-		httpClient, err := ch.createClient()
-		if err != nil {
-			return nil, err
-		}
-		ch.httpClient = httpClient
-		atomic.StoreUint32(&ch.clientInitialized, 1)
-	}
-	return ch.httpClient, nil
-
-}
-
-func (ch *clientHolder) createClient() (*http.Client, error) {
+func createInitialToken(cfg Config) (*oauth2.Config, *oauth2.Token, error) {
 	config := &oauth2.Config{
-		ClientID: ch.avsConfig.OauthClientId,
+		ClientID: cfg.OauthClientId,
 		Endpoint: oauth2.Endpoint{
-			TokenURL:  ch.avsConfig.OauthTokenEndpoint,
+			TokenURL:  cfg.OauthTokenEndpoint,
 			AuthStyle: oauth2.AuthStyleInHeader,
 		},
 	}
-	initialToken, err := config.PasswordCredentialsToken(context.Background(),
-		ch.avsConfig.OauthUsername, ch.avsConfig.OauthPassword)
 
+	initialToken, err := config.PasswordCredentialsToken(context.TODO(), cfg.OauthUsername, cfg.OauthPassword)
 	if err != nil {
-		return nil, err
+		return nil, nil, errors.Wrap(err, "while fetching initial token")
 	}
-	return config.Client(context.Background(), initialToken), nil
+
+	return config, initialToken, nil
+}
+
+func (c *Client) resetHTTPClient() error {
+	config, initialToken, err := createInitialToken(c.avsConfig)
+	if err != nil {
+		return errors.Wrap(err, "while resetting initial token")
+	}
+	c.httpClient = config.Client(context.TODO(), initialToken)
+
+	return nil
+}
+
+func (c *Client) CreateEvaluation(evaluationRequest *BasicEvaluationCreateRequest) (*BasicEvaluationCreateResponse, error) {
+	var responseObject BasicEvaluationCreateResponse
+
+	objAsBytes, err := json.Marshal(evaluationRequest)
+	if err != nil {
+		return &responseObject, errors.Wrap(err, "while marshaling evaluation request")
+	}
+
+	request, err := http.NewRequest(http.MethodPost, c.avsConfig.ApiEndpoint, bytes.NewReader(objAsBytes))
+	if err != nil {
+		return &responseObject, errors.Wrap(err, "while creating request")
+	}
+	request.Header.Set("Content-Type", "application/json")
+
+	response, err := c.execute(request, false, true)
+	if err != nil {
+		return &responseObject, errors.Wrap(err, "while executing CreateEvaluation request")
+	}
+
+	err = json.NewDecoder(response.Body).Decode(&responseObject)
+	if err != nil {
+		return nil, errors.Wrap(err, "while decode create evaluation response")
+	}
+
+	if err := response.Body.Close(); err != nil {
+		return &responseObject, errors.Wrap(err, "while closing CreateEvaluation response")
+	}
+
+	return &responseObject, nil
+}
+
+func (c *Client) RemoveReferenceFromParentEval(evaluationId int64) error {
+	absoluteURL := fmt.Sprintf("%s/child/%d", appendId(c.avsConfig.ApiEndpoint, c.avsConfig.ParentId), evaluationId)
+	response, err := c.deleteRequest(absoluteURL)
+	if err == nil {
+		return nil
+	}
+
+	if response != nil {
+		defer response.Body.Close()
+		var responseObject avsNonSuccessResp
+		err := json.NewDecoder(response.Body).Decode(&responseObject)
+		if err != nil {
+			return errors.Wrapf(err, "while decoding avs non success response body for ID: %d", evaluationId)
+		}
+
+		if strings.Contains(strings.ToLower(responseObject.Message), "does not contain subevaluation") {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("unexpected response for evaluationId: %d while deleting reference from parent evaluation, error: %s", evaluationId, err)
+}
+
+func (c *Client) DeleteEvaluation(evaluationId int64) error {
+	absoluteURL := appendId(c.avsConfig.ApiEndpoint, evaluationId)
+	response, err := c.deleteRequest(absoluteURL)
+	if err != nil {
+		return errors.Wrap(err, "while deleting evaluation")
+	}
+
+	if err := response.Body.Close(); err != nil {
+		return errors.Wrap(err, "while closing DeleteEvaluation response body")
+	}
+
+	return nil
+}
+
+func appendId(baseUrl string, id int64) string {
+	if strings.HasSuffix(baseUrl, "/") {
+		return baseUrl + strconv.FormatInt(id, 10)
+	} else {
+		return baseUrl + "/" + strconv.FormatInt(id, 10)
+	}
+}
+
+func (c *Client) deleteRequest(absoluteURL string) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodDelete, absoluteURL, nil)
+	if err != nil {
+		return &http.Response{}, errors.Wrap(err, "while creating delete request")
+	}
+
+	response, err := c.execute(req, true, true)
+	if err != nil {
+		return &http.Response{}, errors.Wrapf(err, "while executing delete request for path: %s", absoluteURL)
+	}
+
+	return response, nil
+}
+
+func (c *Client) execute(request *http.Request, allowNotFound bool, allowResetToken bool) (*http.Response, error) {
+	response, err := c.httpClient.Do(request)
+	if err != nil {
+		return &http.Response{}, errors.Wrap(err, "while executing request by http client")
+	}
+
+	switch response.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		return response, nil
+	case http.StatusNotFound:
+		if allowNotFound {
+			return response, nil
+		}
+		return response, fmt.Errorf("response status code: %d for %s", http.StatusNotFound, request.URL.String())
+	case http.StatusUnauthorized:
+		if allowResetToken {
+			if err := c.resetHTTPClient(); err != nil {
+				return response, errors.Wrap(err, "while resetting http auth client")
+			}
+			return c.execute(request, allowNotFound, false)
+		}
+		return response, fmt.Errorf("avs server returned %d status code twice for %s (response body: %s)", http.StatusUnauthorized, request.URL.String(), responseBody(response))
+	default:
+		return response, fmt.Errorf("unsupported status code: %d for %s (response body: %s)", response.StatusCode, request.URL.String(), responseBody(response))
+	}
+}
+
+func responseBody(resp *http.Response) string {
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return ""
+	}
+	return string(bodyBytes)
 }

--- a/components/kyma-environment-broker/internal/avs/client_test.go
+++ b/components/kyma-environment-broker/internal/avs/client_test.go
@@ -1,0 +1,281 @@
+package avs
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+const (
+	evaluationID       = 997
+	parentEvaluationID = 42
+	accessToken        = "1234abcd"
+	tokenType          = "test"
+)
+
+func TestClient_CreateEvaluation(t *testing.T) {
+	t.Run("create evaluation the first time", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+		})
+		assert.NoError(t, err)
+
+		// When
+		response, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
+			Name:     "test_evaluation",
+			ParentId: parentEvaluationID,
+		})
+
+		// Then
+		assert.NoError(t, err)
+		assert.Equal(t, "test_evaluation", response.Name)
+	})
+
+	t.Run("create evaluation with token reset", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		server.tokenExpired = 1
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+		})
+		assert.NoError(t, err)
+
+		// When
+		response, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
+			Name:     "test_evaluation",
+			ParentId: parentEvaluationID,
+		})
+
+		// Then
+		assert.NoError(t, err)
+		assert.Equal(t, "test_evaluation", response.Name)
+	})
+
+	t.Run("401 error during creating evaluation", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		server.tokenExpired = 2
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+			ParentId:           parentEvaluationID,
+		})
+		assert.NoError(t, err)
+
+		// When
+		_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
+			Name: "test_evaluation",
+		})
+
+		// Then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "401")
+	})
+}
+
+func TestClient_DeleteEvaluation(t *testing.T) {
+	t.Run("delete existing evaluation", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+			ParentId:           parentEvaluationID,
+		})
+		assert.NoError(t, err)
+
+		_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
+			Name: "test_evaluation",
+		})
+		assert.NoError(t, err)
+
+		// When
+		err = client.DeleteEvaluation(evaluationID)
+
+		// Then
+		assert.NoError(t, err)
+		assert.Empty(t, server.evaluation)
+	})
+
+	t.Run("delete not existing evaluation", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+			ParentId:           parentEvaluationID,
+		})
+		assert.NoError(t, err)
+
+		_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
+			Name: "test_evaluation",
+		})
+		assert.NoError(t, err)
+
+		// When
+		err = client.DeleteEvaluation(123)
+
+		// Then
+		assert.NoError(t, err)
+		assert.Empty(t, server.evaluation[123])
+	})
+}
+
+func TestClient_RemoveReferenceFromParentEval(t *testing.T) {
+	// Given
+	server := newServer(t)
+	mockServer := fixHTTPServer(server)
+	client, err := NewClient(context.TODO(), Config{
+		OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+		ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+		ParentId:           parentEvaluationID,
+	})
+	assert.NoError(t, err)
+
+	_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
+		Name: "test_evaluation",
+	})
+	assert.NoError(t, err)
+
+	// When
+	err = client.RemoveReferenceFromParentEval(evaluationID)
+
+	// Then
+	assert.NoError(t, err)
+	assert.Empty(t, server.evaluation[evaluationID])
+}
+
+type server struct {
+	t            *testing.T
+	evaluation   map[int64]int64
+	tokenExpired int
+}
+
+func newServer(t *testing.T) *server {
+	return &server{
+		t:          t,
+		evaluation: make(map[int64]int64, 0),
+	}
+}
+
+func fixHTTPServer(srv *server) *httptest.Server {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/oauth/token", srv.token).Methods(http.MethodPost)
+	r.HandleFunc("/api/v2/evaluationmetadata", srv.createEvaluation).Methods(http.MethodPost)
+	r.HandleFunc("/api/v2/evaluationmetadata/{evalId}", srv.deleteEvaluation).Methods(http.MethodDelete)
+	r.HandleFunc("/api/v2/evaluationmetadata/{parentId}/child/{evalId}", srv.removeReferenceFromParentEval).Methods(http.MethodDelete)
+
+	return httptest.NewServer(r)
+}
+
+func (s *server) token(w http.ResponseWriter, _ *http.Request) {
+	token := oauth2.Token{
+		AccessToken:  accessToken,
+		TokenType:    tokenType,
+		RefreshToken: "",
+		Expiry:       time.Time{},
+	}
+
+	response, err := json.Marshal(token)
+	assert.NoError(s.t, err)
+	w.Header().Set("Content-Type", "application/json")
+	_, err = w.Write(response)
+	assert.NoError(s.t, err)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *server) hasAccess(token string) bool {
+	if s.tokenExpired > 0 {
+		s.tokenExpired--
+		return false
+	}
+	if token == fmt.Sprintf("%s %s", tokenType, accessToken) {
+		return true
+	}
+
+	return false
+}
+
+func (s *server) createEvaluation(w http.ResponseWriter, r *http.Request) {
+	assert.Equal(s.t, r.Header.Get("Content-Type"), "application/json")
+	if !s.hasAccess(r.Header.Get("Authorization")) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var requestObj BasicEvaluationCreateRequest
+	err := json.NewDecoder(r.Body).Decode(&requestObj)
+	assert.NoError(s.t, err)
+
+	s.evaluation[evaluationID] = parentEvaluationID
+
+	response := BasicEvaluationCreateResponse{
+		Name: requestObj.Name,
+	}
+	responseObjAsBytes, _ := json.Marshal(response)
+	_, err = w.Write(responseObjAsBytes)
+	assert.NoError(s.t, err)
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *server) deleteEvaluation(w http.ResponseWriter, r *http.Request) {
+	if !s.hasAccess(r.Header.Get("Authorization")) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	vars := mux.Vars(r)
+	id, err := strconv.ParseInt(vars["evalId"], 10, 64)
+	assert.NoError(s.t, err)
+
+	if _, ok := s.evaluation[id]; ok {
+		s.evaluation = map[int64]int64{}
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+}
+
+func (s *server) removeReferenceFromParentEval(w http.ResponseWriter, r *http.Request) {
+	if !s.hasAccess(r.Header.Get("Authorization")) {
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	vars := mux.Vars(r)
+	n, err := strconv.ParseInt(vars["parentId"], 10, 64)
+	assert.NoError(s.t, err)
+
+	id, err := strconv.ParseInt(vars["evalId"], 10, 64)
+	assert.NoError(s.t, err)
+
+	if s.evaluation[id] == n {
+		delete(s.evaluation, id)
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	w.WriteHeader(http.StatusNotFound)
+}

--- a/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
@@ -62,6 +62,7 @@ func (eea *ExternalEvalAssistant) ProvideCheckType() string {
 func (eea *ExternalEvalAssistant) IsAlreadyDeleted(lifecycleData internal.AvsLifecycleData) bool {
 	return lifecycleData.AVSExternalEvaluationDeleted
 }
+
 func (eea *ExternalEvalAssistant) GetEvaluationId(lifecycleData internal.AvsLifecycleData) int64 {
 	return lifecycleData.AVSEvaluationExternalId
 }

--- a/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
@@ -77,6 +77,7 @@ func (iec *InternalEvalAssistant) SetEvalId(lifecycleData *internal.AvsLifecycle
 func (iec *InternalEvalAssistant) IsAlreadyDeleted(lifecycleData internal.AvsLifecycleData) bool {
 	return lifecycleData.AVSInternalEvaluationDeleted
 }
+
 func (iec *InternalEvalAssistant) GetEvaluationId(lifecycleData internal.AvsLifecycleData) int64 {
 	return lifecycleData.AvsEvaluationInternalId
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	"context"
 	"encoding/json"
 	"testing"
 	"time"
@@ -60,7 +61,9 @@ func TestInitialisationStep_Run(t *testing.T) {
 	mockAvsServer := newMockAvsServer(t, idh, false)
 	defer mockAvsServer.Close()
 	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
-	avsDel := avs.NewDelegator(avsConfig, memoryStorage.Operations())
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig)
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
 	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
 	externalEvalCreator := NewExternalEvalCreator(avsDel, false, externalEvalAssistant)
 	iasType := NewIASType(nil, true)

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
@@ -1,6 +1,7 @@
 package provisioning
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -41,7 +42,9 @@ func TestInternalEvaluationStep_Run(t *testing.T) {
 	mockAvsServer := newMockAvsServer(t, idh, true)
 	defer mockAvsServer.Close()
 	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
-	avsDel := avs.NewDelegator(avsConfig, memoryStorage.Operations())
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig)
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
 	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
 	ies := NewInternalEvaluationStep(avsDel, internalEvalAssistant)
 
@@ -84,7 +87,9 @@ func TestInternalEvaluationStep_WhenOperationIsRepeatedWithIdPresent(t *testing.
 	mockAvsServer := newMockAvsServer(t, idh, true)
 	defer mockAvsServer.Close()
 	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
-	avsDel := avs.NewDelegator(avsConfig, memoryStorage.Operations())
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig)
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
 	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
 	ies := NewInternalEvaluationStep(avsDel, internalEvalAssistant)
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-66"
     kyma_environment_broker:
       dir:
-      version: "PR-37"
+      version: "PR-75"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-27"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- AVS step refactoring - moving method responsible for calls to external server from `delegator` to `avs client`
- Adding the possibility of updating the oauth2 initail token