### PR TITLE
Increase kcp-installer container memory limit to 2Gi

### DIFF
--- a/installation/resources/installer.yaml
+++ b/installation/resources/installer.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   limits:
   - max:
-      memory: 1024Mi # Maximum memory that a container can request
+      memory: 2048Mi # Maximum memory that a container can request
     default:
       # If a container does not specify memory limit, this default value will be applied.
       # If a container tries to allocate more memory, container will be OOM killed.
@@ -220,7 +220,7 @@ spec:
             memory: 32Mi
             cpu: 40m
           limits:
-            memory: 1Gi
+            memory: 2Gi
             cpu: 400m
       volumes:
       - name: helm-certs


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Increase kyma-installer container memory limit to 2Gi (#1506)
- Also increased LimitRange to 2048Mi

**Related issue(s)**