### PR TITLE
Update upgradeShoot() mutation description

### DIFF
--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -100,7 +100,7 @@ The object passed to the mutation contains these configurable `GardenerConfig` v
 | **kubernetesVersion**                   | ✅                                  | upgrade only   |
 | **purpose**                             | ✅                                  |                |
 | **machineType**                         | ✅                                  |                |
-| **volumeSizeGB**                        | ✅                                  | min.35GB       |
+| **volumeSizeGB**                        | ✅                                  | min. 35GB       |
 | **diskType**                            | ✅                                  |                |
 | **autoScalerMin**                       | ✅                                  | min. 1         |
 | **autoScalerMax**                       | ✅                                  |                |

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -95,20 +95,20 @@ The mutation returns the operation ID which allows you to retrieve the operation
 
 The object passed to the mutation contains these configurable `GardenerConfig` values:
 
-| Field                                 |                                       Configurable                         | Note         |
-| ------------------------------------- | :------------------------------------------------------------------------: | ------------ |
-| **kubernetesVersion**                   |                                    ✅                                    | upgrade only |
-| **purpose**                             |                                    ✅                                    |              |
-| **machineType**                         |                                    ✅                                    |              |
-| **volumeSizeGB**                        |                                    ✅                                    | min.35GB     |
-| **diskType**                            |                                    ✅                                    |              |
-| **autoScalerMin**                       |                                    ✅                                    | min. 1       |
-| **autoScalerMax**                       |                                    ✅                                    |              |
-| **maxSurge**                            |                                    ✅                                    |              |
-| **maxUnavailable**                      |                                    ✅                                    |              |
-| **enableKubernetesVersionAutoUpdate**   |                                    ✅                                    |              |
-| **enableMachineImageVersionAutoUpdate** |                                    ✅                                    |              |
-| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅                                       | for GCP and AWS: `zones`* only <br> for Azure: `zones`* and `vnetCidr` (required) |
+| Field                                   |      Configurable                   | Note         |
+| --------------------------------------- | :---------------------------------: | ------------ |
+| **kubernetesVersion**                   | :✅:                                | upgrade only |
+| **purpose**                             | :✅:                                |              |
+| **machineType**                         | :✅:                                |              |
+| **volumeSizeGB**                        | :✅:                                | min.35GB     |
+| **diskType**                            | :✅:                                |              |
+| **autoScalerMin**                       | :✅:                                | min. 1       |
+| **autoScalerMax**                       | :✅:                                |              |
+| **maxSurge**                            | :✅:                                |              |
+| **maxUnavailable**                      | :✅:                                |              |
+| **enableKubernetesVersionAutoUpdate**   | :✅:                                |              |
+| **enableMachineImageVersionAutoUpdate** | :✅:                                |              |
+| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅  | for GCP and AWS: `zones`* only <br> for Azure: `zones`* and `vnetCidr` (required) |
 
 _*Zones can only be added to the existing ones, they cannot replace the existing zones._
 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -108,7 +108,7 @@ The object passed to the mutation contains these configurable `GardenerConfig` v
 | **maxUnavailable**                      |                                    ✅                                    |              |
 | **enableKubernetesVersionAutoUpdate**   |                                    ✅                                    |              |
 | **enableMachineImageVersionAutoUpdate** |                                    ✅                                    |              |
-| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅                                       | for GCP and AWS: `zones` only* <br> for Azure: `zones`* and `vnetCidr` (required) |
+| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅                                       | for GCP and AWS: `zones`* only <br> for Azure: `zones`* and `vnetCidr` (required) |
 
 _*Zones can only be added to the existing ones, they cannot replace the existing zones._
 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -92,14 +92,15 @@ The mutation returns the operation ID which allows you to retrieve the operation
 ***upgradeShoot*** mutation upgrades the Gardener Shoot cluster configuration, triggering Shoot reconciliation.
 
 >**NOTICE:** This operation is dangerous and could potentially damage your Runtime. Use it wisely and with reasonable configuration values. **There is no rollback functionality implemented**, so you would have to get your hands dirty to fix potential failures.
+
 The object passed to the mutation contains these configurable `GardenerConfig` values:
 
-| Field                                 |                                       Configurable                                       | Note         |
-| ------------------------------------- | :--------------------------------------------------------------------------------------: | ------------ |
+| Field                                 |                                       Configurable                         | Note         |
+| ------------------------------------- | :------------------------------------------------------------------------: | ------------ |
 | **kubernetesVersion**                   |                                    ✅                                    | upgrade only |
 | **purpose**                             |                                    ✅                                    |              |
 | **machineType**                         |                                    ✅                                    |              |
-| **volumeSizeGB**                        |                                    ✅                                    |              |
+| **volumeSizeGB**                        |                                    ✅                                    | min.35GB     |
 | **diskType**                            |                                    ✅                                    |              |
 | **autoScalerMin**                       |                                    ✅                                    | min. 1       |
 | **autoScalerMax**                       |                                    ✅                                    |              |
@@ -107,7 +108,11 @@ The object passed to the mutation contains these configurable `GardenerConfig` v
 | **maxUnavailable**                      |                                    ✅                                    |              |
 | **enableKubernetesVersionAutoUpdate**   |                                    ✅                                    |              |
 | **enableMachineImageVersionAutoUpdate** |                                    ✅                                    |              |
-| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅ | `zones` only |
+| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅                                       | for GCP and AWS: `zones` only* <br> for Azure: `zones`* and `vnetCidr` (required) |
+
+_*Zones can only be added to the existing ones, they cannot replace the existing zones._
+
+> **CAUTION:** You must adhere to the minimal values specified. Passing too small a volumeSize can damage the cluster irrevocably. 
 
 The mutation returns the operation ID which allows you to retrieve the operation status.
 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -96,7 +96,7 @@ The mutation returns the operation ID which allows you to retrieve the operation
 The object passed to the mutation contains these configurable `GardenerConfig` values:
 
 | Field                                   |      Configurable                   | Note           |
-| --------------------------------------- | :---------------------------------: | :------------: |
+| --------------------------------------- | :---------------------------------: | -------------- |
 | **kubernetesVersion**                   | ✅                                  | upgrade only   |
 | **purpose**                             | ✅                                  |                |
 | **machineType**                         | ✅                                  |                |

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -96,18 +96,18 @@ The object passed to the mutation contains these configurable `GardenerConfig` v
 
 | Field                                 |                                       Configurable                                       | Note         |
 | ------------------------------------- | :--------------------------------------------------------------------------------------: | ------------ |
-| **kubernetesVersion**                   |                                    :heavy_check_mark:                                    | upgrade only |
-| **purpose**                             |                                    :heavy_check_mark:                                    |              |
-| **machineType**                         |                                    :heavy_check_mark:                                    |              |
-| **volumeSizeGB**                        |                                    :heavy_check_mark:                                    |              |
-| **diskType**                            |                                    :heavy_check_mark:                                    |              |
-| **autoScalerMin**                       |                                    :heavy_check_mark:                                    | min. 1       |
-| **autoScalerMax**                       |                                    :heavy_check_mark:                                    |              |
-| **maxSurge**                            |                                    :heavy_check_mark:                                    |              |
-| **maxUnavailable**                      |                                    :heavy_check_mark:                                    |              |
-| **enableKubernetesVersionAutoUpdate**   |                                    :heavy_check_mark:                                    |              |
-| **enableMachineImageVersionAutoUpdate** |                                    :heavy_check_mark:                                    |              |
-| **providerSpecificConfig**              | Azure :heavy_check_mark: <br/> AWS :heavy_multiplication_x: <br/> GCP :heavy_check_mark: | `zones` only |
+| **kubernetesVersion**                   |                                    ✅                                    | upgrade only |
+| **purpose**                             |                                    ✅                                    |              |
+| **machineType**                         |                                    ✅                                    |              |
+| **volumeSizeGB**                        |                                    ✅                                    |              |
+| **diskType**                            |                                    ✅                                    |              |
+| **autoScalerMin**                       |                                    ✅                                    | min. 1       |
+| **autoScalerMax**                       |                                    ✅                                    |              |
+| **maxSurge**                            |                                    ✅                                    |              |
+| **maxUnavailable**                      |                                    ✅                                    |              |
+| **enableKubernetesVersionAutoUpdate**   |                                    ✅                                    |              |
+| **enableMachineImageVersionAutoUpdate** |                                    ✅                                    |              |
+| **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅ | `zones` only |
 
 The mutation returns the operation ID which allows you to retrieve the operation status.
 

--- a/docs/provisioner/provisioning-api.md
+++ b/docs/provisioner/provisioning-api.md
@@ -95,19 +95,19 @@ The mutation returns the operation ID which allows you to retrieve the operation
 
 The object passed to the mutation contains these configurable `GardenerConfig` values:
 
-| Field                                   |      Configurable                   | Note         |
-| --------------------------------------- | :---------------------------------: | ------------ |
-| **kubernetesVersion**                   | :✅:                                | upgrade only |
-| **purpose**                             | :✅:                                |              |
-| **machineType**                         | :✅:                                |              |
-| **volumeSizeGB**                        | :✅:                                | min.35GB     |
-| **diskType**                            | :✅:                                |              |
-| **autoScalerMin**                       | :✅:                                | min. 1       |
-| **autoScalerMax**                       | :✅:                                |              |
-| **maxSurge**                            | :✅:                                |              |
-| **maxUnavailable**                      | :✅:                                |              |
-| **enableKubernetesVersionAutoUpdate**   | :✅:                                |              |
-| **enableMachineImageVersionAutoUpdate** | :✅:                                |              |
+| Field                                   |      Configurable                   | Note           |
+| --------------------------------------- | :---------------------------------: | :------------: |
+| **kubernetesVersion**                   | ✅                                  | upgrade only   |
+| **purpose**                             | ✅                                  |                |
+| **machineType**                         | ✅                                  |                |
+| **volumeSizeGB**                        | ✅                                  | min.35GB       |
+| **diskType**                            | ✅                                  |                |
+| **autoScalerMin**                       | ✅                                  | min. 1         |
+| **autoScalerMax**                       | ✅                                  |                |
+| **maxSurge**                            | ✅                                  |                |
+| **maxUnavailable**                      | ✅                                  |                |
+| **enableKubernetesVersionAutoUpdate**   | ✅                                  |                |
+| **enableMachineImageVersionAutoUpdate** | ✅                                  |                |
 | **providerSpecificConfig**              | Azure ✅ <br/> AWS ⛔️ <br/> GCP ✅  | for GCP and AWS: `zones`* only <br> for Azure: `zones`* and `vnetCidr` (required) |
 
 _*Zones can only be added to the existing ones, they cannot replace the existing zones._


### PR DESCRIPTION
**Description**

Recently a new functionality has been added to the Runtime Provisioner that allows for upgrading Gardener shoot clusters using the Provisioning API. Moreover, certain fields now have specific restrictions and/or value requirements. These requirements need to be added to the documentation.

Changes proposed in this pull request:

- Update the `upgradeShoot` mutation description in the Provisioning API with required values and restrictions for certain parameters
- Update formatting

**Related issue**
See kyma-incubator/compass#1422

**Related PRs**
See #28, #40 