### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,13 +5,13 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `control-plane` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @PK85 @crabtree @pkosiec @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
+* @PK85 @crabtree @kfurgol @tgorgol @dbadura @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
 
 # All developers working on this repository are able to edit main values.yaml file.
-/resources/kcp/values.yaml @PK85 @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
+/resources/kcp/values.yaml @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
 
 # Registration job is used by provisioner and kyma-environment-broker
-/resources/kcp/templates/registration-job.yaml @PK85 @crabtree @pkosiec @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
+/resources/kcp/templates/registration-job.yaml @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @dbadura @kjaksik @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
 
 # Kyma Environment Broker
 /resources/kcp/charts/kyma-environment-broker @PK85 @mszostok @piotrmiskiewicz @polskikiel @ksputo @jasiu001
@@ -39,4 +39,4 @@
 /resources/oidc-kubeconfig-service @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere @colunira
 
 # All .md files
-*.md @klaudiagrz @kazydek @tomekpapiernik @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+*.md @klaudiagrz @kazydek @bszwarc @mmitoraj @majakurcius @alexandra-simeonova

--- a/OWNERS
+++ b/OWNERS
@@ -2,17 +2,16 @@
 filters:
   ".*":
     approvers:
-     - PK85 
-     - crabtree 
-     - pkosiec 
-     - kfurgol 
-     - tgorgol 
+     - PK85
+     - crabtree  
+     - kfurgol
+     - tgorgol
      - dbadura
-     - akgalwas 
-     - janmedrek 
-     - Szymongib 
-     - franpog859 
-     - Maladie 
+     - akgalwas
+     - janmedrek
+     - Szymongib
+     - franpog859
+     - Maladie
      - kjaksik
      - koala7659
   '\.md$|/docs/|^milv\.config\.yaml$':

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -2,7 +2,6 @@ aliases:
   documentation-reviewers:
     - kazydek
     - klaudiagrz
-    - tomekpapiernik
     - bszwarc
     - mmitoraj
     - majakurcius
@@ -10,7 +9,6 @@ aliases:
   documentation-approvers:
     - kazydek
     - klaudiagrz
-    - tomekpapiernik
     - bszwarc
     - mmitoraj
     - majakurcius

--- a/resources/kcp/OWNERS
+++ b/resources/kcp/OWNERS
@@ -1,14 +1,13 @@
 approvers:
   - PK85
   - crabtree
-  - pkosiec
   - kfurgol
   - tgorgol
   - kjaksik
-  - akgalwas 
-  - janmedrek 
-  - Szymongib 
-  - franpog859 
+  - akgalwas
+  - janmedrek
+  - Szymongib
+  - franpog859
   - Maladie
   - dbadura
   - rafalpotempa


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In recent months, Paweł Kosiec, Adam Szecówka, Tomek Papiernik and Michał Hudy left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. As for the persons mentioned above, the following reasons occurred:

- After consulting Paweł and Tomek, I've learned that they are no longer interested in contributing to the project.
- Adam has been inactive for more than 3 months.
- Michał has changed his GitHub login and thus the old one should be removed from all the codeowners files. His new login is already mentioned in the [emeritus file](https://github.com/kyma-project/community/blob/master/emeritus.md).

Changes proposed in this pull request:

- Remove `pkosiec` from codeowners
- Remove `aszecowka` from codeowners
- Remove `tomekpapiernik` from codeowners
- Remove `michal-hudy` from codeowners

**Related issue(s)**
[#50](https://github.tools.sap/kyma/community/issues/50)