### PR TITLE
Allow configuring additional domain names for KCP gateway

### DIFF
--- a/resources/kcp/charts/gateway/templates/gateway.yaml
+++ b/resources/kcp/charts/gateway/templates/gateway.yaml
@@ -17,6 +17,9 @@ spec:
         credentialName: {{ .Values.global.istio.gateway.name }}-certs
       hosts:
         - "*.{{ .Values.global.ingress.domainName }}"
+{{- with .Values.gateway.additionalDomainNames }}
+{{- tpl . $ | nindent 8 }}
+{{- end }}
     - port:
         number: 80
         name: http
@@ -25,4 +28,7 @@ spec:
         httpsRedirect: true # automatic 301 redirect from http to https
       hosts:
         - "*.{{.Values.global.ingress.domainName}}"
+{{- with .Values.gateway.additionalDomainNames }}
+{{- tpl . $ | nindent 8 }}
+{{- end -}}
 {{- end -}}

--- a/resources/kcp/charts/gateway/values.yaml
+++ b/resources/kcp/charts/gateway/values.yaml
@@ -1,3 +1,4 @@
 gateway:
   enabled: false
   manageCerts: true
+  additionalDomainNames: ""


### PR DESCRIPTION
**Description**
This is needed to be able to host KCP / Kyma virtual services under two virtual host names (until KCP - Compass final split)
