### PR TITLE
Disable internal AVS monitoring for Trial Plan

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -311,8 +311,7 @@ func main() {
 	}{
 		{
 			weight: 1,
-			step: deprovisioning.NewSkipForTrialPlanStep(db.Operations(),
-				deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant)),
+			step:   deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant),
 		},
 		{
 			weight: 1,

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -242,8 +242,9 @@ func main() {
 			step:   provisioning.NewResolveCredentialsStep(db.Operations(), accountProvider),
 		},
 		{
-			weight:   1,
-			step:     provisioning.NewInternalEvaluationStep(avsDel, internalEvalAssistant),
+			weight: 1,
+			step: provisioning.NewSkipForTrialPlanStep(db.Operations(),
+				provisioning.NewInternalEvaluationStep(avsDel, internalEvalAssistant)),
 			disabled: cfg.Avs.Disabled,
 		},
 		{
@@ -310,7 +311,8 @@ func main() {
 	}{
 		{
 			weight: 1,
-			step:   deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant),
+			step: deprovisioning.NewSkipForTrialPlanStep(db.Operations(),
+				deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant)),
 		},
 		{
 			weight: 1,


### PR DESCRIPTION
**Description**
No monitoring and SLAs are provided for trial SKRs and they shouldn't be included in monthly SLA reports.
Skip internal AVS evaluation creation besides external AVS.