### PR TITLE
Allow configuring external compass URLs

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         - ip: {{ .Values.global.minikubeIP }}
           hostnames:
             # Used for calls to Director
-            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}"
+            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
             # Used for calls for oauth token
-            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.compass-gateway.domain }}"
+            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
       {{ end }}
       serviceAccountName: {{ include "kyma-env-broker.fullname" . }}
     {{- with .Values.deployment.securityContext }}
@@ -65,7 +65,7 @@ spec:
             - name: APP_DIRECTOR_DEFAULT_TENANT
               value: "{{ .Values.global.defaultTenant }}"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
               value: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
             - name: APP_DIRECTOR_SKIP_CERT_VERIFICATION

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         - ip: {{ .Values.global.minikubeIP }}
           hostnames:
             # Used for calls to Director
-            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
             # Used for calls for oauth token
-            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
       {{ end }}
       serviceAccountName: {{ include "kyma-env-broker.fullname" . }}
     {{- with .Values.deployment.securityContext }}
@@ -65,7 +65,7 @@ spec:
             - name: APP_DIRECTOR_DEFAULT_TENANT
               value: "{{ .Values.global.defaultTenant }}"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
               value: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
             - name: APP_DIRECTOR_SKIP_CERT_VERIFICATION

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
         - ip: {{ .Values.global.minikubeIP }}
           hostnames:
             # Used for calls to Director
-            - "{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}"
             # Used for calls for oauth token
-            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.oauth2.host }}.{{ .Values.global.compass-gateway.domain }}"
       {{ end }}
       serviceAccountName: {{ include "kyma-env-broker.fullname" . }}
     {{- with .Values.deployment.securityContext }}
@@ -64,8 +64,8 @@ spec:
               value: "{{ .Release.Namespace }}"
             - name: APP_DIRECTOR_DEFAULT_TENANT
               value: "{{ .Values.global.defaultTenant }}"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
               value: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
             - name: APP_DIRECTOR_SKIP_CERT_VERIFICATION

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -55,7 +55,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -124,7 +124,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -55,7 +55,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -124,7 +124,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -54,8 +54,8 @@ spec:
               value: "{{ .Values.e2e.azure.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "{{ .Release.Namespace }}"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -123,8 +123,8 @@ spec:
               value: "{{ .Values.e2e.azure.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -54,8 +54,8 @@ spec:
               value: "{{ .Values.e2e.gcp.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -122,8 +122,8 @@ spec:
               value: "{{ .Values.e2e.gcp.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -55,7 +55,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -123,7 +123,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -55,7 +55,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -123,7 +123,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
@@ -55,7 +55,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -126,7 +126,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
@@ -55,7 +55,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -126,7 +126,7 @@ spec:
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
@@ -54,8 +54,8 @@ spec:
               value: "{{ .Values.e2e.upgrade.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME
@@ -125,8 +125,8 @@ spec:
               value: "{{ .Values.e2e.upgrade.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
-            - name: APP_DIRECTOR_URL #TODO: Prepare for external Compass
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_DIRECTOR_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -31,10 +31,10 @@ spec:
       {{ if .Values.global.isLocalEnv }}
       hostAliases:
         - ip: {{ .Values.global.minikubeIP }}
-          hostnames: #TODO: Prepare values for external Compass
-            - "{{ .Values.global.gateway.tls.host }}.{{ .Values.global.ingress.domainName }}"
-            - "{{ .Values.global.gateway.mtls.host }}.{{ .Values.global.ingress.domainName }}"
-            - "{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}"
+          hostnames:
+            - "{{ .Values.global.compass-gateway.tls.host }}.{{ .Values.global.compass-gateway.domain }}"
+            - "{{ .Values.global.compass-gateway.mtls.host }}.{{ .Values.global.compass-gateway.domain }}"
+            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}"
             - "{{ .Values.global.oauth2.host }}.{{ .Values.global.ingress.domainName }}"
       {{ end }}
       serviceAccountName: {{ template "fullname" . }}
@@ -91,7 +91,7 @@ spec:
                   name: kcp-postgresql
                   key: postgresql-sslMode
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
             - name: APP_OAUTH_CREDENTIALS_SECRET_NAME
               value: {{ .Values.global.provisioner.secrets.integrationSystemCredentials.name | quote }}
             - name: APP_SKIP_DIRECTOR_CERT_VERIFICATION

--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -32,9 +32,9 @@ spec:
       hostAliases:
         - ip: {{ .Values.global.minikubeIP }}
           hostnames:
-            - "{{ .Values.global.compass-gateway.tls.host }}.{{ .Values.global.compass-gateway.domain }}"
-            - "{{ .Values.global.compass-gateway.mtls.host }}.{{ .Values.global.compass-gateway.domain }}"
-            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}"
+            - "{{ .Values.global.compass-gateway.tls.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass-gateway.mtls.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
             - "{{ .Values.global.oauth2.host }}.{{ .Values.global.ingress.domainName }}"
       {{ end }}
       serviceAccountName: {{ template "fullname" . }}
@@ -91,7 +91,7 @@ spec:
                   name: kcp-postgresql
                   key: postgresql-sslMode
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_OAUTH_CREDENTIALS_SECRET_NAME
               value: {{ .Values.global.provisioner.secrets.integrationSystemCredentials.name | quote }}
             - name: APP_SKIP_DIRECTOR_CERT_VERIFICATION

--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -32,9 +32,9 @@ spec:
       hostAliases:
         - ip: {{ .Values.global.minikubeIP }}
           hostnames:
-            - "{{ .Values.global.compass-gateway.tls.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
-            - "{{ .Values.global.compass-gateway.mtls.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
-            - "{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass.tls.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass.mtls.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
+            - "{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}"
             - "{{ .Values.global.oauth2.host }}.{{ .Values.global.ingress.domainName }}"
       {{ end }}
       serviceAccountName: {{ template "fullname" . }}
@@ -91,7 +91,7 @@ spec:
                   name: kcp-postgresql
                   key: postgresql-sslMode
             - name: APP_DIRECTOR_URL
-              value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
             - name: APP_OAUTH_CREDENTIALS_SECRET_NAME
               value: {{ .Values.global.provisioner.secrets.integrationSystemCredentials.name | quote }}
             - name: APP_SKIP_DIRECTOR_CERT_VERIFICATION

--- a/resources/kcp/charts/provisioner/templates/tests/test-provisioner.yaml
+++ b/resources/kcp/charts/provisioner/templates/tests/test-provisioner.yaml
@@ -41,7 +41,7 @@ spec:
         - name: APP_QUERY_LOGGING
           value: {{ .Values.tests.queryLogging | quote }}
         - name: APP_DIRECTOR_CLIENT_URL
-          value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
+          value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
         - name: APP_DIRECTOR_CLIENT_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: APP_DIRECTOR_CLIENT_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/provisioner/templates/tests/test-provisioner.yaml
+++ b/resources/kcp/charts/provisioner/templates/tests/test-provisioner.yaml
@@ -41,7 +41,7 @@ spec:
         - name: APP_QUERY_LOGGING
           value: {{ .Values.tests.queryLogging | quote }}
         - name: APP_DIRECTOR_CLIENT_URL
-          value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
+          value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain | default .Values.global.ingress.domainName }}/director/graphql"
         - name: APP_DIRECTOR_CLIENT_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: APP_DIRECTOR_CLIENT_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/charts/provisioner/templates/tests/test-provisioner.yaml
+++ b/resources/kcp/charts/provisioner/templates/tests/test-provisioner.yaml
@@ -41,7 +41,7 @@ spec:
         - name: APP_QUERY_LOGGING
           value: {{ .Values.tests.queryLogging | quote }}
         - name: APP_DIRECTOR_CLIENT_URL
-          value: "https://{{ .Values.global.gateway.tls.secure.oauth.host }}.{{ .Values.global.ingress.domainName }}/director/graphql"
+          value: "https://{{ .Values.global.compass-gateway.tls.secure.oauth.host }}.{{ .Values.global.compass-gateway.domain }}/director/graphql"
         - name: APP_DIRECTOR_CLIENT_NAMESPACE
           value: {{ .Release.Namespace }}
         - name: APP_DIRECTOR_CLIENT_OAUTH_CREDENTIALS_SECRET_NAME

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -65,7 +65,8 @@ global:
       integrationSystemCredentials:
         name: kcp-provisioner-credentials
 
-  gateway: #TODO: Prepare values for external Compass
+  compass-gateway:
+    domain: compass-system.svc.cluster.local
     tls:
       host: compass-gateway
       secure:

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -66,7 +66,6 @@ global:
         name: kcp-provisioner-credentials
 
   compass-gateway:
-    domain: "kyma.local"
     tls:
       host: compass-gateway
       secure:

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -65,7 +65,7 @@ global:
       integrationSystemCredentials:
         name: kcp-provisioner-credentials
 
-  compass-gateway:
+  compass:
     tls:
       host: compass-gateway
       secure:

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -66,7 +66,7 @@ global:
         name: kcp-provisioner-credentials
 
   compass-gateway:
-    domain: compass-system.svc.cluster.local
+    domain: "kyma.local"
     tls:
       host: compass-gateway
       secure:

--- a/resources/oidc-kubeconfig-service/templates/deployment.yaml
+++ b/resources/oidc-kubeconfig-service/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
               value: {{ .Values.config.oidc.kubeconfig.client | quote }}
             - name: OIDC_KUBECONFIG_CLIENT_SECRET
               value: {{ .Values.config.oidc.kubeconfig.secret | quote }}
-            - name: OIDC_ISSUER_URL #TODO: Prepare for external Compass
+            - name: OIDC_ISSUER_URL
               value: "https://dex.{{ .Values.global.ingress.domainName }}"
             - name: OIDC_CLIENT_ID
               value: {{ .Values.config.oidc.client }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Eliminate compass URLs which hard-code the use of the cluster domain name
- Introduce chart variable for external compass gateway domain name
