### PR TITLE
bump KYMA_VERSION to master-a673e332

### DIFF
--- a/installation/resources/KYMA_VERSION
+++ b/installation/resources/KYMA_VERSION
@@ -1,1 +1,1 @@
-master-8f216fec
+master-a673e332


### PR DESCRIPTION
Try to include the [commit a673e332 ](https://github.com/kyma-project/kyma/commit/a673e3326b3efb7b21ae60d389b33af284b79edd) which used to resolve the [serverless-webhook-svc-* OOMKilled issue](https://sap-ti.slack.com/archives/C0104BRT84X/p1600382641023200?thread_ts=1600381605.022600&cid=C0104BRT84X)