### PR TITLE
Refactor KEB orchestration model

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/orchestration_test.go
+++ b/components/kyma-environment-broker/cmd/broker/orchestration_test.go
@@ -10,6 +10,7 @@ func TestOrchestration_OneRuntimeHappyPath(t *testing.T) {
 	// given
 	suite := NewOrchestrationSuite(t)
 	runtimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
+	otherRuntimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	orchestrationID := suite.CreateOrchestration(runtimeID)
 
 	suite.WaitForOrchestrationState(orchestrationID, internal.InProgress)
@@ -19,4 +20,7 @@ func TestOrchestration_OneRuntimeHappyPath(t *testing.T) {
 
 	// then
 	suite.WaitForOrchestrationState(orchestrationID, internal.Succeeded)
+
+	suite.AssertRuntimeUpgraded(runtimeID)
+	suite.AssertRuntimeNotUpgraded(otherRuntimeID)
 }

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
+	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"testing"
 	"time"
 
@@ -13,7 +15,6 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/event"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/orchestration"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/input"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/input/automock"
@@ -21,17 +22,14 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provisioner"
 	kebRuntime "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/runtime"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
-	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
 	"github.com/pborman/uuid"
 	"github.com/sirupsen/logrus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	coreV1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -39,7 +37,6 @@ const (
 	globalAccountLabel  = "account"
 	subAccountLabel     = "subaccount"
 	runtimeIDAnnotation = "kcp.provisioner.kyma-project.io/runtime-id"
-	platformRegion      = "cf-eu10"
 )
 
 type OrchestrationSuite struct {
@@ -209,22 +206,18 @@ func (s *OrchestrationSuite) CreateProvisionedRuntime(options RuntimeOptions) st
 }
 
 func (s *OrchestrationSuite) CreateOrchestration(runtimeID string) string {
-	params, err := json.Marshal(orchestration.Parameters{
-		Targets: internal.TargetSpec{
-			Include: []internal.RuntimeTarget{
-				{RuntimeID: runtimeID},
-			},
-		},
-	})
-	require.NoError(s.t, err)
 	now := time.Now()
 	o := internal.Orchestration{
 		OrchestrationID: uuid.New(),
 		State:           internal.Pending,
 		Description:     "started processing of Kyma upgrade",
-		Parameters: sql.NullString{
-			String: string(params),
-			Valid:  true,
+		Parameters: internal.OrchestrationParameters{
+			Targets: internal.TargetSpec{
+				Include: []internal.RuntimeTarget{
+					{RuntimeID: runtimeID},
+				},
+			},
+			DryRun: false,
 		},
 		CreatedAt: now,
 		UpdatedAt: now,
@@ -249,4 +242,12 @@ func (s *OrchestrationSuite) WaitForOrchestrationState(orchestrationID string, s
 		return orchestration.State == state, nil
 	})
 	assert.NoError(s.t, err, "timeout waiting for the orchestration expected state %s. The existing orchestration %+V", state, orchestration)
+}
+
+func (s *OrchestrationSuite) AssertRuntimeUpgraded(runtimeID string) {
+	assert.True(s.t, s.provisionerClient.IsRuntimeUpgraded(runtimeID), "The runtime %s expected to be upgraded", runtimeID)
+}
+
+func (s *OrchestrationSuite) AssertRuntimeNotUpgraded(runtimeID string) {
+	assert.False(s.t, s.provisionerClient.IsRuntimeUpgraded(runtimeID), "The runtime %s expected to be not upgraded", runtimeID)
 }

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"testing"
-	"time"
 
 	gardenerapi "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardenerFake "github.com/gardener/gardener/pkg/client/core/clientset/versioned/fake"

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -146,7 +146,7 @@ type RuntimeOperation struct {
 
 // UpgradeKymaOperation holds all information about upgrade Kyma operation
 type UpgradeKymaOperation struct {
-	RuntimeOperation `json:"-"`
+	RuntimeOperation `json:"runtime_operation"`
 	InputCreator     ProvisionerInputCreator `json:"-"`
 
 	ProvisioningParameters string `json:"provisioning_parameters"`

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -146,8 +146,8 @@ type RuntimeOperation struct {
 
 // UpgradeKymaOperation holds all information about upgrade Kyma operation
 type UpgradeKymaOperation struct {
-	RuntimeOperation                     `json:"-"`
-	InputCreator ProvisionerInputCreator `json:"-"`
+	RuntimeOperation `json:"-"`
+	InputCreator     ProvisionerInputCreator `json:"-"`
 
 	ProvisioningParameters string `json:"provisioning_parameters"`
 }
@@ -194,7 +194,6 @@ type Runtime struct {
 	// The corresponding shoot cluster's .spec.maintenance.timeWindow.End value, which is in "HHMMSS+[HHMM TZ]" format, e.g. "040000+0000"
 	MaintenanceWindowEnd time.Time `json:"maintenanceWindowEnd"`
 }
-
 
 func NewRuntimeState(runtimeID, operationID string, kymaConfig *gqlschema.KymaConfigInput, clusterConfig *gqlschema.GardenerConfigInput) RuntimeState {
 	var (

--- a/components/kyma-environment-broker/internal/orchestration/dto.go
+++ b/components/kyma-environment-broker/internal/orchestration/dto.go
@@ -6,20 +6,14 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 )
 
-type Parameters struct {
-	Targets  internal.TargetSpec   `json:"targets"`
-	Strategy internal.StrategySpec `json:"strategy,omitempty"`
-	DryRun   bool                  `json:"dry_run,omitempty"`
-}
-
 type StatusResponse struct {
-	OrchestrationID   string                      `json:"orchestration_id"`
-	State             string                      `json:"state"`
-	Description       string                      `json:"description"`
-	CreatedAt         time.Time                   `json:"created_at"`
-	UpdatedAt         time.Time                   `json:"updated_at"`
-	Parameters        Parameters                  `json:"parameters"`
-	RuntimeOperations []internal.RuntimeOperation `json:"runtime_operations"`
+	OrchestrationID   string                           `json:"orchestration_id"`
+	State             string                           `json:"state"`
+	Description       string                           `json:"description"`
+	CreatedAt         time.Time                        `json:"created_at"`
+	UpdatedAt         time.Time                        `json:"updated_at"`
+	Parameters        internal.OrchestrationParameters `json:"parameters"`
+	RuntimeOperations []internal.RuntimeOperation      `json:"runtime_operations,omitempty"`
 }
 
 type StatusResponseList struct {

--- a/components/kyma-environment-broker/internal/orchestration/handlers/converter.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/converter.go
@@ -1,8 +1,6 @@
 package handlers
 
 import (
-	"encoding/json"
-
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/orchestration"
 	"github.com/pkg/errors"
@@ -11,20 +9,6 @@ import (
 type Converter struct{}
 
 func (*Converter) OrchestrationToDTO(o *internal.Orchestration) (*orchestration.StatusResponse, error) {
-	params := orchestration.Parameters{}
-	if o.Parameters.Valid {
-		err := json.Unmarshal([]byte(o.Parameters.String), &params)
-		if err != nil {
-			return nil, errors.Wrap(err, "while un-marshalling parameters")
-		}
-	}
-	ops := make([]internal.RuntimeOperation, 0)
-	if o.RuntimeOperations.Valid {
-		err := json.Unmarshal([]byte(o.RuntimeOperations.String), &ops)
-		if err != nil {
-			return nil, errors.Wrap(err, "while un-marshalling operations")
-		}
-	}
 
 	return &orchestration.StatusResponse{
 		OrchestrationID:   o.OrchestrationID,
@@ -32,8 +16,7 @@ func (*Converter) OrchestrationToDTO(o *internal.Orchestration) (*orchestration.
 		Description:       o.Description,
 		CreatedAt:         o.CreatedAt,
 		UpdatedAt:         o.UpdatedAt,
-		Parameters:        params,
-		RuntimeOperations: ops,
+		Parameters:        o.Parameters,
 	}, nil
 }
 

--- a/components/kyma-environment-broker/internal/orchestration/handlers/converter.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/converter.go
@@ -11,12 +11,12 @@ type Converter struct{}
 func (*Converter) OrchestrationToDTO(o *internal.Orchestration) (*orchestration.StatusResponse, error) {
 
 	return &orchestration.StatusResponse{
-		OrchestrationID:   o.OrchestrationID,
-		State:             o.State,
-		Description:       o.Description,
-		CreatedAt:         o.CreatedAt,
-		UpdatedAt:         o.UpdatedAt,
-		Parameters:        o.Parameters,
+		OrchestrationID: o.OrchestrationID,
+		State:           o.State,
+		Description:     o.Description,
+		CreatedAt:       o.CreatedAt,
+		UpdatedAt:       o.UpdatedAt,
+		Parameters:      o.Parameters,
 	}, nil
 }
 

--- a/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
@@ -98,9 +98,9 @@ func (h *kymaHandler) createOrchestration(w http.ResponseWriter, r *http.Request
 		OrchestrationID: uuid.New().String(),
 		State:           internal.Pending,
 		Description:     "started processing of Kyma upgrade",
-		Parameters: params,
-		CreatedAt: now,
-		UpdatedAt: now,
+		Parameters:      params,
+		CreatedAt:       now,
+		UpdatedAt:       now,
 	}
 
 	err = h.db.Insert(o)

--- a/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"database/sql"
 	"encoding/json"
 	"net/http"
 	"time"
@@ -85,19 +84,12 @@ func (h *kymaHandler) listOrchestration(w http.ResponseWriter, r *http.Request) 
 }
 
 func (h *kymaHandler) createOrchestration(w http.ResponseWriter, r *http.Request) {
-	dto := orchestration.Parameters{}
+	params := internal.OrchestrationParameters{}
 
-	err := json.NewDecoder(r.Body).Decode(&dto)
+	err := json.NewDecoder(r.Body).Decode(&params)
 	if err != nil {
 		h.log.Errorf("while decoding request body: %v", err)
 		httputil.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrapf(err, "while decoding request body"))
-		return
-	}
-
-	params, err := json.Marshal(dto)
-	if err != nil {
-		h.log.Errorf("while encoding request params: %v", err)
-		httputil.WriteErrorResponse(w, http.StatusInternalServerError, errors.Wrapf(err, "while encoding request params"))
 		return
 	}
 
@@ -106,10 +98,7 @@ func (h *kymaHandler) createOrchestration(w http.ResponseWriter, r *http.Request
 		OrchestrationID: uuid.New().String(),
 		State:           internal.Pending,
 		Description:     "started processing of Kyma upgrade",
-		Parameters: sql.NullString{
-			String: string(params),
-			Valid:  true,
-		},
+		Parameters: params,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}

--- a/components/kyma-environment-broker/internal/orchestration/kyma/manager_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/kyma/manager_test.go
@@ -1,12 +1,9 @@
 package kyma_test
 
 import (
-	"database/sql"
-	"encoding/json"
 	"testing"
 	"time"
 
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/orchestration"
 	"github.com/pivotal-cf/brokerapi/v7/domain"
 	"github.com/stretchr/testify/assert"
 
@@ -34,7 +31,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		}).Return([]internal.Runtime{}, nil)
 
 		id := "id"
-		err := store.Orchestrations().Insert(internal.Orchestration{OrchestrationID: id})
+		err := store.Orchestrations().Insert(internal.Orchestration{OrchestrationID: id, State: internal.Pending})
 		require.NoError(t, err)
 
 		svc := kyma.NewUpgradeKymaManager(store.Orchestrations(), store.Operations(), nil, resolver, 20*time.Millisecond, logrus.New())
@@ -80,17 +77,13 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		defer resolver.AssertExpectations(t)
 		resolver.On("Resolve", internal.TargetSpec{}).Return([]internal.Runtime{}, nil).Once()
 
-		p := orchestration.Parameters{
-			DryRun: true,
-		}
-		serialized, err := json.Marshal(p)
-		require.NoError(t, err)
-
 		id := "id"
-		err = store.Orchestrations().Insert(internal.Orchestration{OrchestrationID: id, Parameters: sql.NullString{
-			String: string(serialized),
-			Valid:  true,
-		}})
+		err := store.Orchestrations().Insert(internal.Orchestration{
+			OrchestrationID: id,
+			State: internal.Pending,
+			Parameters: internal.OrchestrationParameters{
+				DryRun: true,
+			}})
 		require.NoError(t, err)
 
 		svc := kyma.NewUpgradeKymaManager(store.Orchestrations(), store.Operations(), nil, resolver, poolingInterval, logrus.New())
@@ -114,42 +107,33 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		defer resolver.AssertExpectations(t)
 
 		id := "id"
-		operations := []internal.RuntimeOperation{{
-			Runtime: internal.Runtime{
-				RuntimeID: id,
-			},
-			OperationID: id,
-		}}
-		ops, err := json.Marshal(&operations)
-		require.NoError(t, err)
 
 		upgradeOperation := internal.UpgradeKymaOperation{
-			Operation: internal.Operation{
-				ID:                     id,
-				Version:                0,
-				CreatedAt:              time.Now(),
-				UpdatedAt:              time.Now(),
-				InstanceID:             "",
-				ProvisionerOperationID: "",
-				State:                  domain.Succeeded,
-				Description:            "operation created",
+			RuntimeOperation: internal.RuntimeOperation{
+				Operation: internal.Operation{
+					ID:                     id,
+					Version:                0,
+					CreatedAt:              time.Now(),
+					UpdatedAt:              time.Now(),
+					InstanceID:             "",
+					ProvisionerOperationID: "",
+					State:                  domain.Succeeded,
+					Description:            "operation created",
+				},
+				RuntimeID:    id,
+				SubAccountID: "sub",
+				DryRun:       false,
 			},
 			ProvisioningParameters: "",
 			InputCreator:           nil,
-			SubAccountID:           "sub",
-			RuntimeID:              id,
-			DryRun:                 false,
 		}
-		err = store.Operations().InsertUpgradeKymaOperation(upgradeOperation)
+		err := store.Operations().InsertUpgradeKymaOperation(upgradeOperation)
 		require.NoError(t, err)
 
 		givenO := internal.Orchestration{
 			OrchestrationID: id,
 			State:           internal.InProgress,
-			RuntimeOperations: sql.NullString{
-				String: string(ops),
-				Valid:  true,
-			}}
+			}
 		err = store.Orchestrations().Insert(givenO)
 		require.NoError(t, err)
 

--- a/components/kyma-environment-broker/internal/orchestration/kyma/manager_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/kyma/manager_test.go
@@ -80,7 +80,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		id := "id"
 		err := store.Orchestrations().Insert(internal.Orchestration{
 			OrchestrationID: id,
-			State: internal.Pending,
+			State:           internal.Pending,
 			Parameters: internal.OrchestrationParameters{
 				DryRun: true,
 			}})
@@ -133,7 +133,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		givenO := internal.Orchestration{
 			OrchestrationID: id,
 			State:           internal.InProgress,
-			}
+		}
 		err = store.Orchestrations().Insert(givenO)
 		require.NoError(t, err)
 

--- a/components/kyma-environment-broker/internal/orchestration/strategy_instant.go
+++ b/components/kyma-environment-broker/internal/orchestration/strategy_instant.go
@@ -36,7 +36,7 @@ func (p *InstantOrchestrationStrategy) Execute(operations []internal.RuntimeOper
 	q.Run(stopCh, workers)
 
 	for _, op := range operations {
-		q.Add(op.OperationID)
+		q.Add(op.ID)
 	}
 
 	return 0, nil

--- a/components/kyma-environment-broker/internal/orchestration/strategy_instant_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/strategy_instant_test.go
@@ -15,7 +15,7 @@ func TestNewInstantOrchestrationStrategy(t *testing.T) {
 
 	ops := make([]internal.RuntimeOperation, 3)
 	for i := range ops {
-		ops[i] = internal.RuntimeOperation{OperationID: rand.String(3)}
+		ops[i] = internal.RuntimeOperation{Operation: internal.Operation{ID: rand.String(3)}}
 	}
 
 	_, err := s.Execute(ops, internal.StrategySpec{})

--- a/components/kyma-environment-broker/internal/orchestration/strategy_parallel.go
+++ b/components/kyma-environment-broker/internal/orchestration/strategy_parallel.go
@@ -44,7 +44,7 @@ func (p *ParallelOrchestrationStrategy) Execute(operations []internal.RuntimeOpe
 		if isMaintenanceWindowMode {
 			time.Sleep(time.Until(op.MaintenanceWindowEnd))
 		}
-		q.Add(op.OperationID)
+		q.Add(op.ID)
 	}
 	q.ShutDown()
 

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
@@ -104,12 +104,14 @@ func TestInitialisationStep_Run(t *testing.T) {
 
 func fixUpgradeKymaOperation(t *testing.T) internal.UpgradeKymaOperation {
 	return internal.UpgradeKymaOperation{
-		Operation: internal.Operation{
-			ID:                     fixUpgradeOperationID,
-			InstanceID:             fixInstanceID,
-			ProvisionerOperationID: fixProvisionerOperationID,
-			Description:            "",
-			UpdatedAt:              time.Now(),
+		RuntimeOperation: internal.RuntimeOperation{
+			Operation: internal.Operation{
+				ID:                     fixUpgradeOperationID,
+				InstanceID:             fixInstanceID,
+				ProvisionerOperationID: fixProvisionerOperationID,
+				Description:            "",
+				UpdatedAt:              time.Now(),
+			},
 		},
 		ProvisioningParameters: fixRawProvisioningParameters(t),
 	}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/manager.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/manager.go
@@ -9,7 +9,6 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/event"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
-	"github.com/pivotal-cf/brokerapi/v7/domain"
 	"github.com/sirupsen/logrus"
 )
 
@@ -69,6 +68,9 @@ func (m *Manager) Execute(operationID string) (time.Duration, error) {
 		return 3 * time.Second, nil
 	}
 	operation := *op
+	if operation.IsFinished() {
+		return 0, nil
+	}
 
 	var when time.Duration
 	logOperation := m.log.WithFields(logrus.Fields{"operation": operationID, "instanceID": operation.InstanceID})
@@ -85,7 +87,7 @@ func (m *Manager) Execute(operationID string) (time.Duration, error) {
 				logStep.Errorf("Process operation failed: %s", err)
 				return 0, err
 			}
-			if operation.State != domain.InProgress {
+			if operation.IsFinished() {
 				logStep.Infof("Operation %q got status %s. Process finished.", operation.ID, operation.State)
 				return 0, nil
 			}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/manager_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/manager_test.go
@@ -101,11 +101,13 @@ func TestManager_Execute(t *testing.T) {
 
 func fixOperation(ID string) internal.UpgradeKymaOperation {
 	return internal.UpgradeKymaOperation{
-		Operation: internal.Operation{
-			ID:          ID,
-			State:       domain.InProgress,
-			InstanceID:  "fea2c1a1-139d-43f6-910a-a618828a79d5",
-			Description: "",
+		RuntimeOperation: internal.RuntimeOperation{
+			Operation: internal.Operation{
+				ID:          ID,
+				State:       domain.InProgress,
+				InstanceID:  "fea2c1a1-139d-43f6-910a-a618828a79d5",
+				Description: "",
+			},
 		},
 	}
 }

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step_test.go
@@ -79,13 +79,15 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 
 func fixUpgradeKymaOperationWithInputCreator(t *testing.T) internal.UpgradeKymaOperation {
 	return internal.UpgradeKymaOperation{
-		Operation: internal.Operation{
-			ID:          fixUpgradeOperationID,
-			InstanceID:  fixInstanceID,
-			Description: "",
-			UpdatedAt:   time.Now(),
+		RuntimeOperation: internal.RuntimeOperation{
+			Operation: internal.Operation{
+				ID:          fixUpgradeOperationID,
+				InstanceID:  fixInstanceID,
+				Description: "",
+				UpdatedAt:   time.Now(),
+			},
+			RuntimeID: fixRuntimeID,
 		},
-		RuntimeID:              fixRuntimeID,
 		ProvisioningParameters: fixRawProvisioningParameters(t),
 		InputCreator:           fixInputCreator(t),
 	}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma_operation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma_operation_test.go
@@ -87,20 +87,23 @@ func TestUpgradeKymaOperationManager_RetryOperation(t *testing.T) {
 
 func fixUpgradeKymaOperation() internal.UpgradeKymaOperation {
 	return internal.UpgradeKymaOperation{
-		Operation: internal.Operation{
-			ID:                     "2c538027-d1c4-41ef-a26c-c9604483cb6d",
-			Version:                0,
-			CreatedAt:              time.Now(),
-			UpdatedAt:              time.Time{},
-			InstanceID:             "2b6645a1-87e7-491d-bce3-cc0fbe16b6c0",
-			ProvisionerOperationID: "",
-			State:                  domain.InProgress,
-			Description:            "op description",
+		RuntimeOperation: internal.RuntimeOperation{
+			Operation: internal.Operation{
+				ID:                     "2c538027-d1c4-41ef-a26c-c9604483cb6d",
+				Version:                0,
+				CreatedAt:              time.Now(),
+				UpdatedAt:              time.Time{},
+				InstanceID:             "2b6645a1-87e7-491d-bce3-cc0fbe16b6c0",
+				ProvisionerOperationID: "",
+				State:                  domain.InProgress,
+				Description:            "op description",
+			},
+			SubAccountID:           "",
+			RuntimeID:              "",
+			DryRun:                 false,
 		},
 		ProvisioningParameters: "",
 		InputCreator:           nil,
-		SubAccountID:           "",
-		RuntimeID:              "",
-		DryRun:                 false,
+
 	}
 }

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma_operation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma_operation_test.go
@@ -98,12 +98,11 @@ func fixUpgradeKymaOperation() internal.UpgradeKymaOperation {
 				State:                  domain.InProgress,
 				Description:            "op description",
 			},
-			SubAccountID:           "",
-			RuntimeID:              "",
-			DryRun:                 false,
+			SubAccountID: "",
+			RuntimeID:    "",
+			DryRun:       false,
 		},
 		ProvisioningParameters: "",
 		InputCreator:           nil,
-
 	}
 }

--- a/components/kyma-environment-broker/internal/provisioner/fake_client.go
+++ b/components/kyma-environment-broker/internal/provisioner/fake_client.go
@@ -15,6 +15,7 @@ type runtime struct {
 type FakeClient struct {
 	mu         sync.Mutex
 	runtimes   []runtime
+	upgrades   map[string]schema.UpgradeRuntimeInput
 	operations map[string]schema.OperationStatus
 }
 
@@ -22,6 +23,7 @@ func NewFakeClient() *FakeClient {
 	return &FakeClient{
 		runtimes:   []runtime{},
 		operations: make(map[string]schema.OperationStatus),
+		upgrades:   make(map[string]schema.UpgradeRuntimeInput),
 	}
 }
 
@@ -114,8 +116,14 @@ func (c *FakeClient) UpgradeRuntime(accountID, runtimeID string, config schema.U
 		Operation: schema.OperationTypeUpgrade,
 		State:     schema.OperationStateInProgress,
 	}
+	c.upgrades[runtimeID] = config
 	return schema.OperationStatus{
 		RuntimeID: &runtimeID,
 		ID:        &opId,
 	}, nil
+}
+
+func (c *FakeClient) IsRuntimeUpgraded(runtimeID string) bool {
+	_, found := c.upgrades[runtimeID]
+	return found
 }

--- a/components/kyma-environment-broker/internal/storage/dbsession/dbmodel/operation.go
+++ b/components/kyma-environment-broker/internal/storage/dbsession/dbmodel/operation.go
@@ -26,6 +26,7 @@ type OperationDTO struct {
 	TargetOperationID string
 	State             string
 	Description       string
+	OrchestrationID   string
 
 	Data string
 

--- a/components/kyma-environment-broker/internal/storage/dbsession/dbmodel/orchestration.go
+++ b/components/kyma-environment-broker/internal/storage/dbsession/dbmodel/orchestration.go
@@ -1,9 +1,10 @@
 package dbmodel
 
 import (
-	"time"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"encoding/json"
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 )
 
 type OrchestrationDTO struct {
@@ -23,15 +24,14 @@ func NewOrchestrationDTO(o internal.Orchestration) (OrchestrationDTO, error) {
 
 	dto := OrchestrationDTO{
 		OrchestrationID: o.OrchestrationID,
-		State: o.State,
-		CreatedAt: o.CreatedAt,
-		UpdatedAt: o.UpdatedAt,
-		Description: o.Description,
-		Parameters: string(params),
+		State:           o.State,
+		CreatedAt:       o.CreatedAt,
+		UpdatedAt:       o.UpdatedAt,
+		Description:     o.Description,
+		Parameters:      string(params),
 	}
 	return dto, nil
 }
-
 
 func (o *OrchestrationDTO) ToOrchestration() (internal.Orchestration, error) {
 	var params internal.OrchestrationParameters

--- a/components/kyma-environment-broker/internal/storage/dbsession/dbmodel/orchestration.go
+++ b/components/kyma-environment-broker/internal/storage/dbsession/dbmodel/orchestration.go
@@ -1,0 +1,50 @@
+package dbmodel
+
+import (
+	"time"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"encoding/json"
+)
+
+type OrchestrationDTO struct {
+	OrchestrationID string
+	State           string
+	Description     string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	Parameters      string
+}
+
+func NewOrchestrationDTO(o internal.Orchestration) (OrchestrationDTO, error) {
+	params, err := json.Marshal(o.Parameters)
+	if err != nil {
+		return OrchestrationDTO{}, err
+	}
+
+	dto := OrchestrationDTO{
+		OrchestrationID: o.OrchestrationID,
+		State: o.State,
+		CreatedAt: o.CreatedAt,
+		UpdatedAt: o.UpdatedAt,
+		Description: o.Description,
+		Parameters: string(params),
+	}
+	return dto, nil
+}
+
+
+func (o *OrchestrationDTO) ToOrchestration() (internal.Orchestration, error) {
+	var params internal.OrchestrationParameters
+	err := json.Unmarshal([]byte(o.Parameters), &params)
+	if err != nil {
+		return internal.Orchestration{}, err
+	}
+	return internal.Orchestration{
+		OrchestrationID: o.OrchestrationID,
+		State:           o.State,
+		Description:     o.Description,
+		CreatedAt:       o.CreatedAt,
+		UpdatedAt:       o.UpdatedAt,
+		Parameters:      params,
+	}, nil
+}

--- a/components/kyma-environment-broker/internal/storage/dbsession/factory.go
+++ b/components/kyma-environment-broker/internal/storage/dbsession/factory.go
@@ -30,11 +30,12 @@ type ReadSession interface {
 	GetOperationStats() ([]dbmodel.OperationStatEntry, error)
 	GetInstanceStats() ([]dbmodel.InstanceByGlobalAccountIDStatEntry, error)
 	GetNumberOfInstancesForGlobalAccountID(globalAccountID string) (int, error)
-	GetOrchestrationByID(oID string) (internal.Orchestration, dberr.Error)
-	ListOrchestrationsByState(state string) ([]internal.Orchestration, dberr.Error)
-	ListRuntimeStateByRuntimeID(runtimeID string) ([]dbmodel.RuntimeStateDTO, dberr.Error)
-	ListOrchestrations() ([]internal.Orchestration, dberr.Error)
+	GetOrchestrationByID(oID string) (dbmodel.OrchestrationDTO, dberr.Error)
+	ListOrchestrationsByState(state string) ([]dbmodel.OrchestrationDTO, error)
+	ListOrchestrations() ([]dbmodel.OrchestrationDTO, dberr.Error)
 	ListInstances(limit int, cursor string) ([]internal.Instance, *pagination.Page, int, error)
+	GetOperationStatsForOrchestration(orchestrationID string) ([]dbmodel.OperationStatEntry, error)
+	ListRuntimeStateByRuntimeID(runtimeID string) ([]dbmodel.RuntimeStateDTO, dberr.Error)
 }
 
 //go:generate mockery -name=WriteSession
@@ -44,8 +45,8 @@ type WriteSession interface {
 	DeleteInstance(instanceID string) dberr.Error
 	InsertOperation(dto dbmodel.OperationDTO) dberr.Error
 	UpdateOperation(instance dbmodel.OperationDTO) dberr.Error
-	InsertOrchestration(o internal.Orchestration) dberr.Error
-	UpdateOrchestration(o internal.Orchestration) dberr.Error
+	InsertOrchestration(o dbmodel.OrchestrationDTO) dberr.Error
+	UpdateOrchestration(o dbmodel.OrchestrationDTO) dberr.Error
 	InsertRuntimeState(state dbmodel.RuntimeStateDTO) dberr.Error
 	InsertLMSTenant(dto dbmodel.LMSTenantDTO) dberr.Error
 }

--- a/components/kyma-environment-broker/internal/storage/dbsession/write.go
+++ b/components/kyma-environment-broker/internal/storage/dbsession/write.go
@@ -33,7 +33,7 @@ func (ws writeSession) InsertInstance(instance internal.Instance) dberr.Error {
 		Pair("service_plan_name", instance.ServicePlanName).
 		Pair("dashboard_url", instance.DashboardURL).
 		Pair("provisioning_parameters", instance.ProvisioningParameters).
-	// in postgres database it will be equal to "0001-01-01 00:00:00+00"
+		// in postgres database it will be equal to "0001-01-01 00:00:00+00"
 		Pair("deleted_at", time.Time{}).
 		Exec()
 

--- a/components/kyma-environment-broker/internal/storage/dbsession/write.go
+++ b/components/kyma-environment-broker/internal/storage/dbsession/write.go
@@ -33,7 +33,7 @@ func (ws writeSession) InsertInstance(instance internal.Instance) dberr.Error {
 		Pair("service_plan_name", instance.ServicePlanName).
 		Pair("dashboard_url", instance.DashboardURL).
 		Pair("provisioning_parameters", instance.ProvisioningParameters).
-		// in postgres database it will be equal to "0001-01-01 00:00:00+00"
+	// in postgres database it will be equal to "0001-01-01 00:00:00+00"
 		Pair("deleted_at", time.Time{}).
 		Exec()
 
@@ -91,6 +91,7 @@ func (ws writeSession) InsertOperation(op dbmodel.OperationDTO) dberr.Error {
 		Pair("target_operation_id", op.TargetOperationID).
 		Pair("type", op.Type).
 		Pair("data", op.Data).
+		Pair("orchestration_id", op.OrchestrationID).
 		Exec()
 
 	if err != nil {
@@ -105,7 +106,7 @@ func (ws writeSession) InsertOperation(op dbmodel.OperationDTO) dberr.Error {
 	return nil
 }
 
-func (ws writeSession) InsertOrchestration(o internal.Orchestration) dberr.Error {
+func (ws writeSession) InsertOrchestration(o dbmodel.OrchestrationDTO) dberr.Error {
 	_, err := ws.insertInto(postsql.OrchestrationTableName).
 		Pair("orchestration_id", o.OrchestrationID).
 		Pair("created_at", o.CreatedAt).
@@ -113,7 +114,6 @@ func (ws writeSession) InsertOrchestration(o internal.Orchestration) dberr.Error
 		Pair("description", o.Description).
 		Pair("state", o.State).
 		Pair("parameters", o.Parameters).
-		Pair("runtime_operations", o.RuntimeOperations).
 		Exec()
 
 	if err != nil {
@@ -128,7 +128,7 @@ func (ws writeSession) InsertOrchestration(o internal.Orchestration) dberr.Error
 	return nil
 }
 
-func (ws writeSession) UpdateOrchestration(o internal.Orchestration) dberr.Error {
+func (ws writeSession) UpdateOrchestration(o dbmodel.OrchestrationDTO) dberr.Error {
 	res, err := ws.update(postsql.OrchestrationTableName).
 		Where(dbr.Eq("orchestration_id", o.OrchestrationID)).
 		Set("created_at", o.CreatedAt).
@@ -136,7 +136,6 @@ func (ws writeSession) UpdateOrchestration(o internal.Orchestration) dberr.Error
 		Set("description", o.Description).
 		Set("state", o.State).
 		Set("parameters", o.Parameters).
-		Set("runtime_operations", o.RuntimeOperations).
 		Exec()
 
 	if err != nil {
@@ -214,6 +213,7 @@ func (ws writeSession) UpdateOperation(op dbmodel.OperationDTO) dberr.Error {
 		Set("target_operation_id", op.TargetOperationID).
 		Set("type", op.Type).
 		Set("data", op.Data).
+		Set("orchestration_id", op.OrchestrationID).
 		Exec()
 
 	if err != nil {

--- a/components/kyma-environment-broker/internal/storage/driver/memory/operation.go
+++ b/components/kyma-environment-broker/internal/storage/driver/memory/operation.go
@@ -267,3 +267,18 @@ func (s *operations) GetOperationStats() (internal.OperationStats, error) {
 	}
 	return result, nil
 }
+
+func (s *operations) GetOperationStatsForOrchestration(orchestrationID string) (map[domain.LastOperationState]int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	result := map[domain.LastOperationState]int{
+		domain.InProgress: 0,
+		domain.Succeeded:  0,
+		domain.Failed:     0,
+	}
+	for _, op := range s.upgradeKymaOperations {
+		result[op.State] = result[op.State] + 1
+	}
+	return result, nil
+}

--- a/components/kyma-environment-broker/internal/storage/ext.go
+++ b/components/kyma-environment-broker/internal/storage/ext.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dbsession/dbmodel"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/predicate"
+	"github.com/pivotal-cf/brokerapi/v7/domain"
 )
 
 type Instances interface {
@@ -29,6 +30,7 @@ type Operations interface {
 	GetOperationsInProgressByType(operationType dbmodel.OperationType) ([]internal.Operation, error)
 	GetOperationStats() (internal.OperationStats, error)
 	GetOperationsForIDs(operationIDList []string) ([]internal.Operation, error)
+	GetOperationStatsForOrchestration(orchestrationID string) (map[domain.LastOperationState]int, error)
 }
 
 type Provisioning interface {

--- a/components/kyma-environment-broker/internal/storage/storage_test.go
+++ b/components/kyma-environment-broker/internal/storage/storage_test.go
@@ -477,8 +477,16 @@ func TestSchemaInitializer(t *testing.T) {
 						Description:            "description",
 						Version:                1,
 					},
-					OrchestrationID: "orchestration-id",
+					DryRun:                 false,
+					ShootName:              "shoot-stage",
+					MaintenanceWindowBegin: time.Now().Truncate(time.Millisecond).Add(time.Hour),
+					MaintenanceWindowEnd:   time.Now().Truncate(time.Millisecond).Add(time.Minute).Add(time.Hour),
+					RuntimeID:              "runtime-id",
+					GlobalAccountID:        "global-account-if",
+					SubAccountID:           "subaccount-id",
+					OrchestrationID:        "orchestration-id",
 				},
+				ProvisioningParameters: "{}",
 			}
 
 			err = InitTestDBTables(t, cfg.ConnectionURL())

--- a/components/kyma-environment-broker/internal/storage/storage_test.go
+++ b/components/kyma-environment-broker/internal/storage/storage_test.go
@@ -495,7 +495,6 @@ func TestSchemaInitializer(t *testing.T) {
 			err = svc.InsertUpgradeKymaOperation(givenOperation2)
 			require.NoError(t, err)
 
-
 			ops, err := svc.GetUpgradeKymaOperationByInstanceID("inst-id")
 			require.NoError(t, err)
 
@@ -623,12 +622,12 @@ func TestSchemaInitializer(t *testing.T) {
 
 		const fixID = "test"
 		givenOrchestration := internal.Orchestration{
-			OrchestrationID:   fixID,
-			State:             "test",
-			Description:       "test",
-			CreatedAt:         now,
-			UpdatedAt:         now,
-			Parameters:        internal.OrchestrationParameters{
+			OrchestrationID: fixID,
+			State:           "test",
+			Description:     "test",
+			CreatedAt:       now,
+			UpdatedAt:       now,
+			Parameters: internal.OrchestrationParameters{
 				DryRun: true,
 			},
 		}

--- a/components/kyma-environment-broker/internal/storage/storage_test.go
+++ b/components/kyma-environment-broker/internal/storage/storage_test.go
@@ -769,9 +769,13 @@ func assertDeprovisioningOperation(t *testing.T, expected, got internal.Deprovis
 func assertUpgradeKymaOperation(t *testing.T, expected, got internal.UpgradeKymaOperation) {
 	// do not check zones and monothonic clock, see: https://golang.org/pkg/time/#Time
 	assert.True(t, expected.CreatedAt.Equal(got.CreatedAt), fmt.Sprintf("Expected %s got %s", expected.CreatedAt, got.CreatedAt))
+	assert.True(t, expected.MaintenanceWindowBegin.Equal(got.MaintenanceWindowBegin))
+	assert.True(t, expected.MaintenanceWindowEnd.Equal(got.MaintenanceWindowEnd))
 
 	expected.CreatedAt = got.CreatedAt
 	expected.UpdatedAt = got.UpdatedAt
+	expected.MaintenanceWindowBegin = got.MaintenanceWindowBegin
+	expected.MaintenanceWindowEnd = got.MaintenanceWindowEnd
 	assert.Equal(t, expected, got)
 }
 

--- a/components/kyma-environment-broker/internal/storage/tests_utils.go
+++ b/components/kyma-environment-broker/internal/storage/tests_utils.go
@@ -223,6 +223,7 @@ func FixTables() map[string]string {
 			description text NOT NULL,
 			type varchar(32) NOT NULL,
 			data json NOT NULL,
+			orchestration_id varchar(64),
 			created_at TIMESTAMPTZ NOT NULL,
 			updated_at TIMESTAMPTZ NOT NULL
 			)`, postsql.OperationTableName),

--- a/components/schema-migrator/migrations/kyma-environment-broker/202009230900_add_orchestration_id_to_operation.down.sql
+++ b/components/schema-migrator/migrations/kyma-environment-broker/202009230900_add_orchestration_id_to_operation.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE operations DROP COLUMN orchestration_id;

--- a/components/schema-migrator/migrations/kyma-environment-broker/202009230900_add_orchestration_id_to_operation.up.sql
+++ b/components/schema-migrator/migrations/kyma-environment-broker/202009230900_add_orchestration_id_to_operation.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE operations
+    ADD COLUMN orchestration_id varchar(64);


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Remove RuntimeOperation is not a separate object, it is a type in operation hierarchy. UpgradeKymaOperation inherits from RuntimeOperation which inherits from Operation.
- RuntimeObject contains OrchestrationID (new column in operations table)
- New operation in the storage which allows to summarize how number of operations per status for given orchestration id
- Orchestration contains Parameters as an object instead of serialized JSON
- Orchestration does not contain RuntimeOperations

**Related issue(s)**
Related: 