### PR TITLE
Implement kubeconfig-service client

### DIFF
--- a/components/kubeconfig-service/go.mod
+++ b/components/kubeconfig-service/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/stretchr/testify v1.5.1
 	github.com/vrischmann/envconfig v1.2.0
+	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/apiserver v0.17.2
 )

--- a/components/kubeconfig-service/pkg/client/client.go
+++ b/components/kubeconfig-service/pkg/client/client.go
@@ -1,0 +1,75 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"html"
+	"io"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2"
+)
+
+// Client is the interface to interact with the kubeconfig-service as an HTTP client using OIDC ID token in JWT format.
+type Client interface {
+	GetKubeConfig(tenantID, runtimeID string) (string, error)
+}
+
+type client struct {
+	url        string
+	httpClient *http.Client
+}
+
+// NewClient constructs and returns new Client for kubeconfig-service
+// It takes the following arguments:
+//   - ctx  : context in which the http request will be executed
+//   - url  : base url of the kubeconfig-service API
+//   - auth : TokenSource object which provides the ID token for the HTTP request
+func NewClient(ctx context.Context, url string, auth oauth2.TokenSource) Client {
+	c := &client{
+		url:        url,
+		httpClient: oauth2.NewClient(ctx, auth),
+	}
+	return c
+}
+
+// GetKubeConfig
+func (c *client) GetKubeConfig(tenantID, runtimeID string) (string, error) {
+	url := fmt.Sprintf("%s/kubeconfig/%s/%s", c.url, tenantID, runtimeID)
+
+	resp, err := c.httpClient.Get(url)
+	if err != nil {
+		return "", errors.Wrapf(err, "while calling %s", url)
+	}
+
+	// Drain response body and close, return error to context if there isn't any.
+	defer func() {
+		derr := drainResponseBody(resp.Body)
+		if err == nil {
+			err = derr
+		}
+		cerr := resp.Body.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("calling %s returned %s status", url, resp.Status)
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", errors.Wrap(err, "while reading response body")
+	}
+	return html.UnescapeString(string(body)), nil
+}
+
+func drainResponseBody(body io.Reader) error {
+	if body == nil {
+		return nil
+	}
+	_, err := io.Copy(ioutil.Discard, io.LimitReader(body, 4096))
+	return err
+}

--- a/components/kubeconfig-service/pkg/client/client.go
+++ b/components/kubeconfig-service/pkg/client/client.go
@@ -28,11 +28,10 @@ type client struct {
 //   - url  : base url of the kubeconfig-service API
 //   - auth : TokenSource object which provides the ID token for the HTTP request
 func NewClient(ctx context.Context, url string, auth oauth2.TokenSource) Client {
-	c := &client{
+	return &client{
 		url:        url,
 		httpClient: oauth2.NewClient(ctx, auth),
 	}
-	return c
 }
 
 // GetKubeConfig

--- a/components/kubeconfig-service/pkg/client/client_test.go
+++ b/components/kubeconfig-service/pkg/client/client_test.go
@@ -40,7 +40,8 @@ special-chars-to-escape: "abcdefgh<0123456789>ijkl*:_mnopqrst"`
 		called = true
 
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(testKubeConfig))
+		_, err := w.Write([]byte(testKubeConfig))
+		require.NoError(t, err)
 	}))
 	defer ts.Close()
 

--- a/components/kubeconfig-service/pkg/client/client_test.go
+++ b/components/kubeconfig-service/pkg/client/client_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+type FakeTokenSource string
+
+var fixToken FakeTokenSource = "fake-token-1234"
+
+func (t FakeTokenSource) Token() (*oauth2.Token, error) {
+	return &oauth2.Token{
+		AccessToken: string(t),
+		Expiry:      time.Now().Add(time.Duration(12 * time.Hour)),
+	}, nil
+}
+func TestClient_GetKubeConfig(t *testing.T) {
+	// given
+	testTenant := "test-tenant-id-0001"
+	testRuntime := "test-runtime-id-0001"
+	testKubeConfig := `---
+yaml-like: true
+multi-line: "also true"
+special-chars-to-escape: "abcdefgh<0123456789>ijkl*:_mnopqrst"`
+	called := false
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, fmt.Sprintf("/kubeconfig/%s/%s", testTenant, testRuntime), r.URL.Path)
+
+		assert.Equal(t, r.Header.Get("Authorization"), fmt.Sprintf("Bearer %s", fixToken))
+		called = true
+
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(testKubeConfig))
+	}))
+	defer ts.Close()
+
+	client := NewClient(context.TODO(), ts.URL, fixToken)
+
+	// when
+	kc, err := client.GetKubeConfig(testTenant, testRuntime)
+
+	// then
+	require.NoError(t, err)
+	assert.True(t, called)
+	assert.Equal(t, testKubeConfig, kc)
+}

--- a/components/kubeconfig-service/pkg/client/client_test.go
+++ b/components/kubeconfig-service/pkg/client/client_test.go
@@ -17,6 +17,17 @@ type FakeTokenSource string
 
 var fixToken FakeTokenSource = "fake-token-1234"
 
+const (
+	testTenant     = "test-tenant-id-0001"
+	testRuntime    = "test-runtime-id-0001"
+	testKubeConfig = `---
+yaml-like: true
+multi-line: |-
+  lorem impsum
+  donor
+special-chars-to-escape: "abcdefgh<0123456789>ijkl*:_mnopqrst"`
+)
+
 func (t FakeTokenSource) Token() (*oauth2.Token, error) {
 	return &oauth2.Token{
 		AccessToken: string(t),
@@ -25,12 +36,7 @@ func (t FakeTokenSource) Token() (*oauth2.Token, error) {
 }
 func TestClient_GetKubeConfig(t *testing.T) {
 	// given
-	testTenant := "test-tenant-id-0001"
-	testRuntime := "test-runtime-id-0001"
-	testKubeConfig := `---
-yaml-like: true
-multi-line: "also true"
-special-chars-to-escape: "abcdefgh<0123456789>ijkl*:_mnopqrst"`
+
 	called := false
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)


### PR DESCRIPTION
**Description**

Needed for the SKR CLI kubeconfig command.
Changes proposed in this pull request:

- Implement client based in terms of oauth2.TokenSource and http.Client
- Add simple unit test for sanity checking


**Related issue(s)**
#238 