### PR TITLE
Exclude internal secrets from being cleaned up

### DIFF
--- a/components/kyma-environment-broker/common/hyperscaler/account_pool_test.go
+++ b/components/kyma-environment-broker/common/hyperscaler/account_pool_test.go
@@ -321,26 +321,10 @@ func newTestAccountPoolWithSecretInternal() (AccountPool, v1.SecretInterface) {
 		},
 	}
 
-	shoot1 := &gardener_types.Shoot{
-		ObjectMeta: machineryv1.ObjectMeta{
-			Name:      "shoot1",
-			Namespace: testNamespace,
-		},
-		Spec: gardener_types.ShootSpec{
-			SecretBindingName: "secret1",
-		},
-		Status: gardener_types.ShootStatus{
-			LastOperation: &gardener_types.LastOperation{
-				State: gardener_types.LastOperationStateSucceeded,
-				Type:  gardener_types.LastOperationTypeReconcile,
-			},
-		},
-	}
-
 	mockClient := fake.NewSimpleClientset(secret1)
 	mockSecrets := mockClient.CoreV1().Secrets(testNamespace)
 
-	gardenerFake := gardener_fake.NewSimpleClientset(shoot1)
+	gardenerFake := gardener_fake.NewSimpleClientset()
 	mockShoots := gardenerFake.CoreV1beta1().Shoots(testNamespace)
 
 	pool := NewAccountPool(mockSecrets, mockShoots)

--- a/components/kyma-environment-broker/common/hyperscaler/account_provider.go
+++ b/components/kyma-environment-broker/common/hyperscaler/account_provider.go
@@ -60,6 +60,15 @@ func (p *accountProvider) MarkUnusedGardenerSecretAsDirty(hyperscalerType Type, 
 		return errors.New("failed to release subscription for tenant. Gardener Account pool is not configured")
 	}
 
+	internal, err := p.gardenerPool.IsSecretInternal(hyperscalerType, tenantName)
+	if err != nil {
+		return err
+	}
+
+	if internal {
+		return nil
+	}
+
 	dirty, err := p.gardenerPool.IsSecretDirty(hyperscalerType, tenantName)
 	if err != nil {
 		return err

--- a/components/kyma-environment-broker/common/hyperscaler/account_provider_test.go
+++ b/components/kyma-environment-broker/common/hyperscaler/account_provider_test.go
@@ -36,6 +36,23 @@ func TestMarkUnusedGardenerSecretAsDirty(t *testing.T) {
 		assert.Equal(t, secret.Labels["dirty"], "true")
 	})
 
+	t.Run("should not mark secret as dirty if internal", func(t *testing.T) {
+		//given
+		//given
+		pool, secretMock := newTestAccountPoolWithSecretInternal()
+
+		accountProvider := NewAccountProvider(pool, nil)
+
+		//when
+		err := accountProvider.MarkUnusedGardenerSecretAsDirty(Type("azure"), "tenant1")
+
+		//then
+		require.NoError(t, err)
+		secret, err := secretMock.Get("secret1", machineryv1.GetOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, secret.Labels["dirty"], "")
+	})
+
 	t.Run("should not mark secret as dirty if used by a cluster", func(t *testing.T) {
 		//given
 		pool, secretMock := newTestAccountPoolWithSingleShoot()

--- a/components/kyma-environment-broker/common/hyperscaler/account_provider_test.go
+++ b/components/kyma-environment-broker/common/hyperscaler/account_provider_test.go
@@ -38,7 +38,6 @@ func TestMarkUnusedGardenerSecretAsDirty(t *testing.T) {
 
 	t.Run("should not mark secret as dirty if internal", func(t *testing.T) {
 		//given
-		//given
 		pool, secretMock := newTestAccountPoolWithSecretInternal()
 
 		accountProvider := NewAccountProvider(pool, nil)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-220"
     kyma_environment_broker:
       dir:
-      version: "PR-248"
+      version: "PR-251"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-220"
     kyma_environment_broker:
       dir:
-      version: "PR-245"
+      version: "PR-248"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- HAP now checks if secret is labeled as internal before marking it as dirty. This is because some secrets (for example dedicated e2e test secret) should not be returned to the pool despite being unused.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
