### PR TITLE
Upgrade HTTP clients - treat connection error as a temporary

### DIFF
--- a/components/kyma-environment-broker/internal/ias/client.go
+++ b/components/kyma-environment-broker/internal/ias/client.go
@@ -11,7 +11,6 @@ import (
 
 	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
 
-	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 )
 
@@ -79,14 +78,11 @@ func (c *Client) SetDefaultAuthenticatingIDP(payload DefaultAuthIDPConfig) error
 	return c.call(PathServiceProviders, payload)
 }
 
-func (c *Client) GetCompany() (_ *Company, err error) {
+func (c *Client) GetCompany() (*Company, error) {
 	company := &Company{}
 	request := &Request{Method: http.MethodGet, Path: PathCompanyGlobal}
 
 	response, err := c.do(request)
-	defer func() {
-		err = multierror.Append(err, errors.Wrap(c.closeResponseBody(response), "while trying to close body reader")).ErrorOrNil()
-	}()
 	if err != nil {
 		return company, errors.Wrap(err, "while making request to ias platform about company")
 	}
@@ -96,10 +92,14 @@ func (c *Client) GetCompany() (_ *Company, err error) {
 		return company, errors.Wrap(err, "while decoding response body with company data")
 	}
 
+	if err := c.closeResponseBody(response); err != nil {
+		return company, kebError.AsTemporaryError(err, "while closing response body with company data")
+	}
+
 	return company, nil
 }
 
-func (c *Client) CreateServiceProvider(serviceName, companyID string) (err error) {
+func (c *Client) CreateServiceProvider(serviceName, companyID string) error {
 	payload := fmt.Sprintf("sp_name=%s&company_id=%s", serviceName, companyID)
 	request := &Request{
 		Method:  http.MethodPost,
@@ -109,34 +109,36 @@ func (c *Client) CreateServiceProvider(serviceName, companyID string) (err error
 	}
 
 	response, err := c.do(request)
-	defer func() {
-		err = multierror.Append(err, errors.Wrap(c.closeResponseBody(response), "while trying to close body reader")).ErrorOrNil()
-	}()
 	if err != nil {
 		return errors.Wrap(err, "while making request with ServiceProvider creation")
+	}
+
+	if err := c.closeResponseBody(response); err != nil {
+		return kebError.AsTemporaryError(err, "while closing response body for ServiceProvider creation")
 	}
 
 	return nil
 }
 
-func (c *Client) DeleteServiceProvider(spID string) (err error) {
+func (c *Client) DeleteServiceProvider(spID string) error {
 	request := &Request{
 		Method: http.MethodPut,
 		Path:   fmt.Sprintf("%s?sp_id=%s", PathDelete, spID),
 		Delete: true,
 	}
 	response, err := c.do(request)
-	defer func() {
-		err = multierror.Append(err, errors.Wrap(c.closeResponseBody(response), "while trying to close body reader")).ErrorOrNil()
-	}()
 	if err != nil {
 		return errors.Wrap(err, "while making request to delete ServiceProvider")
+	}
+
+	if err := c.closeResponseBody(response); err != nil {
+		return kebError.AsTemporaryError(err, "while closing response body for ServiceProvider deletion")
 	}
 
 	return nil
 }
 
-func (c *Client) DeleteSecret(payload SecretsRef) (err error) {
+func (c *Client) DeleteSecret(payload SecretsRef) error {
 	request, err := c.jsonRequest(PathDeleteSecret, http.MethodDelete, payload)
 	if err != nil {
 		return errors.Wrapf(err, "while creating json request for path %s", PathDeleteSecret)
@@ -144,17 +146,18 @@ func (c *Client) DeleteSecret(payload SecretsRef) (err error) {
 	request.Delete = true
 
 	response, err := c.do(request)
-	defer func() {
-		err = multierror.Append(err, errors.Wrap(c.closeResponseBody(response), "while trying to close body reader")).ErrorOrNil()
-	}()
 	if err != nil {
 		return errors.Wrap(err, "while making request to delete ServiceProvider secrets")
+	}
+
+	if err := c.closeResponseBody(response); err != nil {
+		return kebError.AsTemporaryError(err, "while closing response body for Secret deletion")
 	}
 
 	return nil
 }
 
-func (c *Client) GenerateServiceProviderSecret(secretCfg SecretConfiguration) (_ *ServiceProviderSecret, err error) {
+func (c *Client) GenerateServiceProviderSecret(secretCfg SecretConfiguration) (*ServiceProviderSecret, error) {
 	secretResponse := &ServiceProviderSecret{}
 	request, err := c.jsonRequest(PathServiceProviders, http.MethodPut, secretCfg)
 	if err != nil {
@@ -162,9 +165,6 @@ func (c *Client) GenerateServiceProviderSecret(secretCfg SecretConfiguration) (_
 	}
 
 	response, err := c.do(request)
-	defer func() {
-		err = multierror.Append(err, errors.Wrap(c.closeResponseBody(response), "while trying to close body reader")).ErrorOrNil()
-	}()
 	if err != nil {
 		return secretResponse, errors.Wrap(err, "while creating ServiceProvider secret")
 	}
@@ -172,6 +172,10 @@ func (c *Client) GenerateServiceProviderSecret(secretCfg SecretConfiguration) (_
 	err = json.NewDecoder(response.Body).Decode(secretResponse)
 	if err != nil {
 		return secretResponse, errors.Wrap(err, "while decoding response with secret provider")
+	}
+
+	if err := c.closeResponseBody(response); err != nil {
+		return secretResponse, kebError.AsTemporaryError(err, "while closing response body for ServiceProviderSecret generating")
 	}
 
 	return secretResponse, nil
@@ -192,11 +196,12 @@ func (c *Client) call(path string, payload interface{}) (err error) {
 	}
 
 	response, err := c.do(request)
-	defer func() {
-		err = multierror.Append(err, errors.Wrap(c.closeResponseBody(response), "while trying to close body reader")).ErrorOrNil()
-	}()
 	if err != nil {
 		return errors.Wrapf(err, "while making request for path %s", path)
+	}
+
+	if err := c.closeResponseBody(response); err != nil {
+		return kebError.AsTemporaryError(err, "while closing response body for call method")
 	}
 
 	return nil
@@ -233,7 +238,7 @@ func (c *Client) do(sciReq *Request) (*http.Response, error) {
 
 	response, err := c.httpClient.Do(req)
 	if err != nil {
-		return &http.Response{}, errors.Wrap(err, "while making request")
+		return &http.Response{}, kebError.AsTemporaryError(err, "while making request")
 	}
 
 	switch response.StatusCode {

--- a/components/kyma-environment-broker/internal/lms/client.go
+++ b/components/kyma-environment-broker/internal/lms/client.go
@@ -150,6 +150,15 @@ func (c *client) CreateTenant(input CreateTenantInput) (o CreateTenantOutput, er
 	if err != nil {
 		return CreateTenantOutput{}, kebError.AsTemporaryError(err, "while calling Create Tenant endpoint")
 	}
+	defer func() {
+		if drainErr := iosafety.DrainReader(resp.Body); drainErr != nil {
+			err = kebError.AsTemporaryError(drainErr, "while trying to drain body reader")
+		}
+
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = kebError.AsTemporaryError(closeErr, "while trying to close body reader")
+		}
+	}()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	var output struct {
@@ -169,14 +178,6 @@ func (c *client) CreateTenant(input CreateTenantInput) (o CreateTenantOutput, er
 			resp.StatusCode, output.Error, output.Message)
 	}
 
-	if err := iosafety.DrainReader(resp.Body); err != nil {
-		return CreateTenantOutput{}, kebError.AsTemporaryError(err, "while trying to drain body reader")
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return CreateTenantOutput{}, kebError.AsTemporaryError(err, "while trying to close body reader")
-	}
-
 	return CreateTenantOutput{ID: output.ID}, nil
 }
 
@@ -191,6 +192,15 @@ func (c *client) GetTenantStatus(tenantID string) (status TenantStatus, err erro
 	if err != nil {
 		return TenantStatus{}, kebError.AsTemporaryError(err, "while calling Get Tenant Status endpoint")
 	}
+	defer func() {
+		if drainErr := iosafety.DrainReader(resp.Body); drainErr != nil {
+			err = kebError.AsTemporaryError(drainErr, "while trying to drain body reader")
+		}
+
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = kebError.AsTemporaryError(closeErr, "while trying to close body reader")
+		}
+	}()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	var tenantStatus TenantStatus
@@ -204,14 +214,6 @@ func (c *client) GetTenantStatus(tenantID string) (status TenantStatus, err erro
 		return TenantStatus{}, errors.Errorf("error when calling get tenant status endpoint,"+
 			" status code: %d, body: %s",
 			resp.StatusCode, body)
-	}
-
-	if err := iosafety.DrainReader(resp.Body); err != nil {
-		return TenantStatus{}, kebError.AsTemporaryError(err, "while trying to drain body reader")
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return TenantStatus{}, kebError.AsTemporaryError(err, "while trying to close body reader")
 	}
 
 	return tenantStatus, nil
@@ -228,6 +230,15 @@ func (c *client) GetTenantInfo(tenantID string) (status TenantInfo, err error) {
 	if err != nil {
 		return TenantInfo{}, kebError.AsTemporaryError(err, "while calling Get Tenant endpoint")
 	}
+	defer func() {
+		if drainErr := iosafety.DrainReader(resp.Body); drainErr != nil {
+			err = kebError.AsTemporaryError(drainErr, "while trying to drain body reader")
+		}
+
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = kebError.AsTemporaryError(closeErr, "while trying to close body reader")
+		}
+	}()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	var response TenantInfo
@@ -241,14 +252,6 @@ func (c *client) GetTenantInfo(tenantID string) (status TenantInfo, err error) {
 		return TenantInfo{}, errors.Errorf("error when calling get tenant info endpoint,"+
 			" status code: %d, body: %s",
 			resp.StatusCode, body)
-	}
-
-	if err := iosafety.DrainReader(resp.Body); err != nil {
-		return TenantInfo{}, kebError.AsTemporaryError(err, "while trying to drain body reader")
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return TenantInfo{}, kebError.AsTemporaryError(err, "while trying to close body reader")
 	}
 
 	return response, nil
@@ -265,6 +268,15 @@ func (c *client) GetCertificateByURL(url string) (cert string, found bool, err e
 	if err != nil {
 		return "", false, kebError.AsTemporaryError(err, "while calling Get Certificate endpoint (%s)", url)
 	}
+	defer func() {
+		if drainErr := iosafety.DrainReader(resp.Body); drainErr != nil {
+			err = kebError.AsTemporaryError(drainErr, "while trying to drain body reader")
+		}
+
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = kebError.AsTemporaryError(closeErr, "while trying to close body reader")
+		}
+	}()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	var certResponse struct {
@@ -284,14 +296,6 @@ func (c *client) GetCertificateByURL(url string) (cert string, found bool, err e
 	err = json.Unmarshal(body, &certResponse)
 	if err != nil {
 		return "", false, errors.Wrapf(err, "while unmarshalling response: %s", string(body))
-	}
-
-	if err := iosafety.DrainReader(resp.Body); err != nil {
-		return "", false, kebError.AsTemporaryError(err, "while trying to drain body reader")
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return "", false, kebError.AsTemporaryError(err, "while trying to close body reader")
 	}
 
 	return certResponse.Cert, true, nil
@@ -332,6 +336,15 @@ func (c *client) RequestCertificate(tenantID string, subject pkix.Name) (string,
 	if err != nil {
 		return "", privateKey, kebError.AsTemporaryError(err, "while calling Request Certificate endpoint")
 	}
+	defer func() {
+		if drainErr := iosafety.DrainReader(resp.Body); drainErr != nil {
+			err = kebError.AsTemporaryError(drainErr, "while trying to drain body reader")
+		}
+
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			err = kebError.AsTemporaryError(closeErr, "while trying to close body reader")
+		}
+	}()
 
 	body, err := ioutil.ReadAll(resp.Body)
 	var response struct {
@@ -347,14 +360,6 @@ func (c *client) RequestCertificate(tenantID string, subject pkix.Name) (string,
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		return "", []byte{}, errors.Wrapf(err, "while unmarshalling response: %s", string(body))
-	}
-
-	if err := iosafety.DrainReader(resp.Body); err != nil {
-		return "", []byte{}, kebError.AsTemporaryError(err, "while trying to drain body reader")
-	}
-
-	if err := resp.Body.Close(); err != nil {
-		return "", []byte{}, kebError.AsTemporaryError(err, "while trying to close body reader")
 	}
 
 	return response.CallbackURL, privateKey, nil

--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -15,6 +15,7 @@ import (
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 
 	"crypto/x509/pkix"
+
 	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"

--- a/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/lms_cert_step.go
@@ -1,22 +1,21 @@
 package provisioning
 
 import (
+	"encoding/base64"
 	"errors"
+	"fmt"
 	"regexp"
 	"time"
 
-	"crypto/x509/pkix"
-
-	"fmt"
-
-	"encoding/base64"
-
-	"github.com/google/uuid"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/lms"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
+
+	"crypto/x509/pkix"
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
@@ -48,6 +47,7 @@ func NewLmsCertificatesStep(certProvider LmsClient, os storage.Operations, isMan
 		LmsStep: LmsStep{
 			operationManager: process.NewProvisionOperationManager(os),
 			isMandatory:      isMandatory,
+			expirationTime:   lmsTimeout,
 		},
 		provider:            certProvider,
 		normalizationRegexp: regexp.MustCompile("[^a-zA-Z0-9]+"),
@@ -83,12 +83,12 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, l logrus.Fie
 	// check if LMS tenant is ready
 	status, err := s.provider.GetTenantStatus(operation.Lms.TenantID)
 	if err != nil {
-		logger.Errorf("Unable to get LMS Tenant status: %s", err.Error())
-		if time.Since(operation.Lms.RequestedAt) > lmsTimeout {
-			logger.Errorf("Setting LMS operation failed - tenant provisioning timed out, last error: %s", err.Error())
-			return s.failLmsAndUpdate(operation, "Getting LMS Tenant status failed")
-		}
-		return operation, tenantReadyRetryInterval, nil
+		return s.handleError(
+			operation,
+			logger,
+			time.Since(operation.Lms.RequestedAt),
+			"Unable to get LMS Tenant status",
+			err)
 	}
 	if !(status.ElasticsearchDNSResolves && status.KibanaDNSResolves) {
 		logger.Infof("LMS tenant not ready: elasticDNS=%v, kibanaDNS=%v", status.ElasticsearchDNSResolves, status.KibanaDNSResolves)
@@ -101,12 +101,12 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, l logrus.Fie
 
 	tenantInfo, err := s.provider.GetTenantInfo(operation.Lms.TenantID)
 	if err != nil {
-		logger.Errorf("Unable to get LMS Tenant info: %s", err.Error())
-		if time.Since(operation.Lms.RequestedAt) > lmsTimeout {
-			logger.Errorf("Setting LMS operation failed - tenant provisioning timed out, last error: %s", err.Error())
-			return s.failLmsAndUpdate(operation, "LMS Tenant provisioning timeout")
-		}
-		return operation, tenantReadyRetryInterval, nil
+		return s.handleError(
+			operation,
+			logger,
+			time.Since(operation.Lms.RequestedAt),
+			"Unable to get LMS Tenant info",
+			err)
 	}
 
 	// request certificates
@@ -196,6 +196,20 @@ func (s *lmsCertStep) Run(operation internal.ProvisioningOperation, l logrus.Fie
 type LmsStep struct {
 	operationManager *process.ProvisionOperationManager
 	isMandatory      bool
+	expirationTime   time.Duration
+}
+
+func (s *LmsStep) handleError(operation internal.ProvisioningOperation, log logrus.FieldLogger, since time.Duration, msg string, err error) (internal.ProvisioningOperation, time.Duration, error) {
+	log.Errorf("%s: %s", msg, err)
+	switch {
+	case kebError.IsTemporaryError(err):
+		return s.operationManager.RetryOperation(operation, msg, 10*time.Second, time.Minute*30, log)
+	default:
+		if since < s.expirationTime {
+			return operation, tenantReadyRetryInterval, nil
+		}
+		return s.failLmsAndUpdate(operation, "getting LMS tenant failed")
+	}
 }
 
 func (s *LmsStep) failLmsAndUpdate(operation internal.ProvisioningOperation, msg string) (internal.ProvisioningOperation, time.Duration, error) {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-220"
     kyma_environment_broker:
       dir:
-      version: "PR-217"
+      version: "PR-258"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**
PR changes HTTP clients for external services bahavior. Now steps are repeated if the execution of `Do()` method from HTTP client returns an error.

The provisioning process consists of 13 steps of which 7 of them uses HTTP client
- _provideLmsTenantStep_, _lmsCertStep_,  _InternalEvaluationStep_ - error from client treat as temporary already (all errors, no matter what kind of error), handling of temporary errors has been added, other errors are repeated for a shorter period of time
- _EDPRegistrationStep_
- _IASRegistrationStep_
- _CreateRuntimeStep_ - already support temporary error for network connection
- _InitialisationStep_ - already support temporary error for network connection

**Related issue(s)**
[#193](https://github.com/kyma-project/control-plane/issues/193)
