### PR TITLE
Change failure information for the operation in create runtime step

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
@@ -71,7 +71,7 @@ func (s *CreateRuntimeStep) Run(operation internal.ProvisioningOperation, log lo
 			return operation, 5 * time.Second, nil
 		case err != nil:
 			log.Errorf("call to Provisioner failed: %s", err)
-			return s.operationManager.OperationFailed(operation, "invalid operation data - cannot create provisioning input")
+			return s.operationManager.OperationFailed(operation, "call to the provisioner service failed")
 		}
 
 		operation.ProvisionerOperationID = *provisionerResponse.ID

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-220"
     kyma_environment_broker:
       dir:
-      version: "PR-257"
+      version: "PR-274"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- change failure information for the operation in the `create runtime` step. The current information is misleading.