### PR TITLE
KEB saves operation in initialisation step

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
@@ -83,6 +83,12 @@ func (s *InitialisationStep) run(operation internal.DeprovisioningOperation, log
 		return s.operationManager.OperationFailed(operation, err.Error())
 	}
 
+	operation, repeat, _ := s.operationManager.UpdateOperation(operation)
+	if repeat != 0 {
+		log.Errorf("cannot save the operation")
+		return operation, time.Second, nil
+	}
+
 	instance, err := s.instanceStorage.GetByID(operation.InstanceID)
 	switch {
 	case err == nil:

--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation_test.go
@@ -67,8 +67,10 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, time.Duration(0), repeat)
 		assert.Equal(t, domain.Succeeded, operation.State)
+
 		storedOp, err := memoryStorage.Operations().GetDeprovisioningOperationByID(operation.ID)
 		assert.Equal(t, operation, *storedOp)
+		assert.NoError(t, err)
 	})
 
 	t.Run("Should delete instance when operation has succeeded due to runtime not existing", func(t *testing.T) {

--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation_test.go
@@ -67,6 +67,8 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, time.Duration(0), repeat)
 		assert.Equal(t, domain.Succeeded, operation.State)
+		storedOp, err := memoryStorage.Operations().GetDeprovisioningOperationByID(operation.ID)
+		assert.Equal(t, operation, *storedOp)
 	})
 
 	t.Run("Should delete instance when operation has succeeded due to runtime not existing", func(t *testing.T) {
@@ -104,6 +106,10 @@ func TestInitialisationStep_Run(t *testing.T) {
 		inst, err := memoryStorage.Instances().GetByID(operation.InstanceID)
 		assert.Error(t, err)
 		assert.Nil(t, inst)
+
+		storedOp, err := memoryStorage.Operations().GetDeprovisioningOperationByID(operation.ID)
+		assert.Equal(t, operation, *storedOp)
+		assert.NoError(t, err)
 	})
 
 }

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
@@ -65,6 +65,10 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.Equal(t, time.Duration(0), repeat)
 		assert.Equal(t, domain.Succeeded, upgradeOperation.State)
 
+		storedOp, err := memoryStorage.Operations().GetUpgradeKymaOperationByID(upgradeOperation.ID)
+		assert.Equal(t, upgradeOperation, *storedOp)
+		assert.NoError(t, err)
+
 	})
 
 	t.Run("should initialize UpgradeRuntimeInput request when run", func(t *testing.T) {
@@ -99,6 +103,10 @@ func TestInitialisationStep_Run(t *testing.T) {
 		inputBuilder.AssertNumberOfCalls(t, "CreateUpgradeInput", 1)
 		assert.Equal(t, time.Duration(0), repeat)
 		assert.NotNil(t, op.InputCreator)
+
+		storedOp, err := memoryStorage.Operations().GetUpgradeKymaOperationByID(op.ID)
+		assert.Equal(t, op, *storedOp)
+		assert.NoError(t, err)
 	})
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-295"
     kyma_environment_broker:
       dir:
-      version: "PR-301"
+      version: "PR-305"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- initialisation steps must save modified operation to the storage

