### PR TITLE
add label `app:kcp` for kyma-env-broker

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/_helpers.tpl
+++ b/resources/kcp/charts/kyma-environment-broker/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "kyma-env-broker.labels" -}}
+app: {{ include "kyma-env-broker.name" . }}
 app.kubernetes.io/name: {{ include "kyma-env-broker.name" . }}
 helm.sh/chart: {{ include "kyma-env-broker.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
to fix the `source_app=unknown` issue which appeared in the message of [IstioRequests-SourceAppFailures-5xx alerts](https://sap-ti.slack.com/archives/CSR4HDWEL/p1604455748068600)

`✔{destination_app="provisioner",destination_workload="kcp-provisioner",source_app="unknown",source_workload="kcp-kyma-environment-broker"}
`

btw, for details, pls see [task 809](https://github.tools.sap/kyma/backlog/issues/809) and [task 925](https://github.tools.sap/kyma/backlog/issues/925)