### PR TITLE
Fix the TW alias in the documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -27,7 +27,7 @@ about: Suggest an improvement or report a bug in the documentation
 
 **Assignees**
 
-@technical-writers
+@kyma-project/technical-writers
 
 **Attachments**
 


### PR DESCRIPTION
**Description**

It was discovered that the documentation issue template included a wrong alias for Technical Writers, which resulted in mis-assignment. This PR fixes the issue.

Changes proposed in this pull request:

- Fix the TW alias in **Assignees** in the documentation issue template

**Related issue(s)**

Fixes kyma-project/kyma#9920
