### PR TITLE
Configure evaluation purpose for trial runtimes

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -174,7 +174,9 @@ func (f *InputBuilderFactory) initProvisionRuntimeInput(provider HyperscalerInpu
 	}
 
 	provisionInput.ClusterConfig.GardenerConfig.KubernetesVersion = f.config.KubernetesVersion
-	provisionInput.ClusterConfig.GardenerConfig.Purpose = &f.config.DefaultGardenerShootPurpose
+	if provisionInput.ClusterConfig.GardenerConfig.Purpose == nil {
+		provisionInput.ClusterConfig.GardenerConfig.Purpose = &f.config.DefaultGardenerShootPurpose
+	}
 	if f.config.MachineImage != "" {
 		provisionInput.ClusterConfig.GardenerConfig.MachineImage = &f.config.MachineImage
 	}

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -14,6 +14,8 @@ var europeAzure = "westeurope"
 var usAzure = "eastus"
 var asiaAzure = "southeastasia"
 
+var trialPurpose = "evaluation"
+
 var toAzureSpecific = map[string]*string{
 	string(broker.Europe): &europeAzure,
 	string(broker.Us):     &usAzure,
@@ -95,6 +97,7 @@ func (p *AzureTrialInput) Defaults() *gqlschema.ClusterConfigInput {
 			AutoScalerMax:  2,
 			MaxSurge:       1,
 			MaxUnavailable: 1,
+			Purpose:        &trialPurpose,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-321"
     kyma_environment_broker:
       dir:
-      version: "PR-325"
+      version: "PR-330"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Default shoot purpose applies only if not set by provider specific defaults
- Set evaluation purpose as default for trial plan
