### PR TITLE
Fix runtimes upgrade state

### DIFF
--- a/components/kyma-environment-broker/cmd/cli/command/runtime.go
+++ b/components/kyma-environment-broker/cmd/cli/command/runtime.go
@@ -132,7 +132,7 @@ func runtimeStatus(obj interface{}) string {
 
 	upgradeCount := rt.Status.UpgradingKyma.Count
 	if upgradeCount > 0 {
-		// Take the last upgrade operation, assuming that Data is sorted by CreatedBy DESC.
+		// Take the first upgrade operation, assuming that Data is sorted by CreatedBy DESC.
 		switch rt.Status.UpgradingKyma.Data[0].State {
 		case inProgress:
 			return "upgrading"

--- a/components/kyma-environment-broker/cmd/cli/command/runtime.go
+++ b/components/kyma-environment-broker/cmd/cli/command/runtime.go
@@ -132,8 +132,8 @@ func runtimeStatus(obj interface{}) string {
 
 	upgradeCount := rt.Status.UpgradingKyma.Count
 	if upgradeCount > 0 {
-		// Take the last upgrade operation, assuming that Data is sorted by CreatedBy ASC.
-		switch rt.Status.UpgradingKyma.Data[upgradeCount-1].State {
+		// Take the last upgrade operation, assuming that Data is sorted by CreatedBy DESC.
+		switch rt.Status.UpgradingKyma.Data[0].State {
 		case inProgress:
 			return "upgrading"
 		case failed:


### PR DESCRIPTION
**Description**

Take the first kyma upgrade operation when determining state on CLI side as the operations are sorted by CreatedAt DESC on KEB side.

