### PR TITLE
Succeed upgrade of deprovisioned instances

### DIFF
--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go
@@ -103,8 +103,8 @@ func (s *InitialisationStep) Run(operation internal.UpgradeKymaOperation, log lo
 		operation.RuntimeID = instance.RuntimeID
 		return s.checkRuntimeStatus(operation, instance, log.WithField("runtimeID", instance.RuntimeID))
 	case dberr.IsNotFound(err):
-		log.Info("instance not exist")
-		return s.operationManager.OperationFailed(operation, "instance was not found")
+		log.Info("instance does not exist, it may have been deprovisioned")
+		return s.operationManager.OperationSucceeded(operation, "instance was not found")
 	default:
 		log.Errorf("unable to get instance from storage: %s", err)
 		return operation, s.timeSchedule.Retry, nil

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-321"
     kyma_environment_broker:
       dir:
-      version: "PR-325"
+      version: "PR-332"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**

With kyma upgrade orchestrations it's possible that a runtime gets deprovisioned while the upgrade operation is waiting in the queue for processing. This is even more likely with maintenance window schedule where operations are pending until the next consecutive window. 
When such situation is detected, the upgrade operation should be marked succeeded (skipped) instead of failed.