### PR TITLE
fix for metris timeout(408) and not found(404) errors

### DIFF
--- a/components/metris/README.md
+++ b/components/metris/README.md
@@ -19,6 +19,7 @@ Metris is a metering component that collects data and sends them to EDP.
 | `--edp-workers` | **EDP_WORKERS** | Number of workers to send metrics | `5` |
 | `--edp-event-retry` | **EDP_RETRY** | Number of retries for sending an event | `5` |
 | `--provider-poll-interval` | **PROVIDER_POLLINTERVAL** | Interval at which metrics are fetched | `1m` |
+| `--provider-poll-duration` | **PROVIDER_POLLDURATION** | Time limit for requests made by the provider client | `5m` |
 | `--provider-workers` | **PROVIDER_WORKERS** | Number of workers to fetch metrics | `10` |
 | `--provider-buffer` | **PROVIDER_BUFFER** | Number of clusters that the buffer can have | `100` |
 | `--listen-addr` | **METRIS_LISTEN_ADDRESS** | Address and port the metrics and health HTTP endpoints will bind to | None |

--- a/components/metris/internal/gardener/handlers.go
+++ b/components/metris/internal/gardener/handlers.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 
 	gcorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	commonpkg "github.com/gardener/gardener/pkg/operation/common"
@@ -117,7 +118,12 @@ func (c *Controller) shootAddHandlerFunc(obj interface{}) {
 
 	cluster, err := c.newCluster(shoot)
 
-	logger := c.logger.With("account", cluster.AccountID).With("subaccount", cluster.SubAccountID).With("shoot", shoot.Name).With("technicalid", cluster.TechnicalID)
+	logger := c.logger.
+		With("account", cluster.AccountID).
+		With("subaccount", cluster.SubAccountID).
+		With("shoot", shoot.Name).
+		With("technicalid", cluster.TechnicalID).
+		With("trial", strconv.FormatBool(cluster.Trial))
 
 	if err != nil {
 		logger.With("error", err).Error("received a shoot add event, but there was missing informations")

--- a/components/metris/internal/provider/azure/azure.go
+++ b/components/metris/internal/provider/azure/azure.go
@@ -90,7 +90,22 @@ func (a *Azure) Run(ctx context.Context) {
 					workerlogger.Warnf("vm capabilities for region %s not found, some metrics won't be available", instance.cluster.Region)
 				}
 
-				a.gatherMetrics(ctx, workerlogger, instance, &vmcaps)
+				// check if resource group still exists in azure, sometime we miss gardener delete events
+				_, err := instance.client.GetResourceGroup(ctx, clusterid.(string), "", workerlogger)
+				if errors.Is(err, ErrResourceGroupNotFound) {
+					instance.retryAttempts++
+
+					// delete cluster from storage if it does not exist after `maxRetryAttempts`
+					if instance.retryAttempts > maxRetryAttempts {
+						a.instanceStorage.Delete(clusterid.(string))
+						workerlogger.Infof("removing cluster after %d attempts", maxRetryAttempts)
+					} else {
+						a.instanceStorage.Put(clusterid.(string), instance)
+						workerlogger.Warnf("can't find resource group in azure, attempts: %d/%d", instance.retryAttempts, maxRetryAttempts)
+					}
+				} else {
+					a.gatherMetrics(ctx, workerlogger, instance, &vmcaps)
+				}
 
 				a.queue.Done(clusterid)
 
@@ -152,7 +167,7 @@ func (a *Azure) clusterHandler(parentctx context.Context) {
 			// getting cluster and event hub resource group names.
 			rg, err := client.GetResourceGroup(parentctx, cluster.TechnicalID, "", logger)
 			if err != nil {
-				logger.Errorf("could not find cluster resource group, cluster may not be ready, retrying in %s: %s", a.config.PollInterval, err)
+				logger.Warnf("could not find cluster resource group, cluster may not be ready, retrying in %s: %s", a.config.PollInterval, err)
 				time.AfterFunc(a.config.PollInterval, func() { a.config.ClusterChannel <- cluster })
 
 				continue
@@ -165,10 +180,8 @@ func (a *Azure) clusterHandler(parentctx context.Context) {
 
 			rg, err = client.GetResourceGroup(parentctx, "", filter, logger)
 			if err != nil {
-				if cluster.Trial {
-					logger.Warn("trial cluster, could not find event hubs resource groups, metrics will not be reported for the event hubs")
-				} else {
-					logger.Errorf("could not find event hub resource groups, cluster may not be ready, retrying in %s: %s", a.config.PollInterval, err)
+				if !cluster.Trial {
+					logger.Warnf("could not find event hub resource groups, cluster may not be ready, retrying in %s: %s", a.config.PollInterval, err)
 					time.AfterFunc(a.config.PollInterval, func() { a.config.ClusterChannel <- cluster })
 
 					continue
@@ -240,17 +253,20 @@ func (a *Azure) gatherMetrics(parentctx context.Context, workerlogger log.Logger
 	workerlogger.Debug("getting metrics")
 
 	// Using a timeout context to prevent azure api to hang for too long,
-	// sometimes client get stuck waiting even with a max poll duration of 1 min.
+	// sometimes client get stuck waiting even with a max poll duration is set.
 	// If it reach the time limit, last successful event data will be returned.
-	ctx, cancel := context.WithTimeout(parentctx, maxPollingDuration)
+	ctx, cancel := context.WithTimeout(parentctx, a.config.PollingDuration)
 	defer cancel()
 
-	eventData.Compute = instance.getComputeMetrics(ctx, resourceGroupName, workerlogger, vmcaps)
-	eventData.Networking = instance.getNetworkMetrics(ctx, resourceGroupName, workerlogger)
-	eventData.EventHub = instance.getEventHubMetrics(ctx, a.config.PollInterval, eventHubResourceGroupName, workerlogger)
+	eventData.Compute = instance.getComputeMetrics(ctx, workerlogger, vmcaps)
+	eventData.Networking = instance.getNetworkMetrics(ctx, workerlogger)
+	eventData.EventHub = instance.getEventHubMetrics(ctx, a.config.PollInterval, workerlogger)
 
-	if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-		workerlogger.Warn("Azure REST API call timedout, sending last successful event data")
+	if errors.Is(ctx.Err(), context.Canceled) {
+		workerlogger.Warn("request got canceled")
+		return
+	} else if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		workerlogger.Warn("request timedout, sending last successful event data")
 
 		if instance.lastEvent == nil {
 			return

--- a/components/metris/internal/provider/azure/clients.go
+++ b/components/metris/internal/provider/azure/clients.go
@@ -87,7 +87,6 @@ func newClient(cluster *gardener.Cluster, logger log.Logger, tracelevel int, cli
 	baseclient.BaseURI = env.ResourceManagerEndpoint
 	baseclient.SubscriptionID = subscriptionID
 	baseclient.Authorizer = authz
-	baseclient.PollingDuration = maxPollingDuration
 	baseclient.RequestInspector = LogRequest(logger, tracelevel)
 	baseclient.ResponseInspector = LogResponse(logger, tracelevel)
 
@@ -113,7 +112,6 @@ func (c *baseClient) createResourcesBaseClient() *resources.BaseClient {
 	baseclient := resources.New(c.SubscriptionID)
 	baseclient.Authorizer = c.Authorizer
 	baseclient.BaseURI = c.BaseURI
-	baseclient.PollingDuration = c.PollingDuration
 	baseclient.RequestInspector = c.RequestInspector
 	baseclient.ResponseInspector = c.ResponseInspector
 
@@ -124,7 +122,6 @@ func (c *baseClient) createComputeBaseClient() *compute.BaseClient {
 	baseclient := compute.New(c.SubscriptionID)
 	baseclient.Authorizer = c.Authorizer
 	baseclient.BaseURI = c.BaseURI
-	baseclient.PollingDuration = c.PollingDuration
 	baseclient.RequestInspector = c.RequestInspector
 	baseclient.ResponseInspector = c.ResponseInspector
 
@@ -135,7 +132,6 @@ func (c *baseClient) createNetworkBaseClient() *network.BaseClient {
 	baseclient := network.New(c.SubscriptionID)
 	baseclient.Authorizer = c.Authorizer
 	baseclient.BaseURI = c.BaseURI
-	baseclient.PollingDuration = c.PollingDuration
 	baseclient.RequestInspector = c.RequestInspector
 	baseclient.ResponseInspector = c.ResponseInspector
 
@@ -146,7 +142,6 @@ func (c *baseClient) createInsightsBaseClient() *insights.BaseClient {
 	baseclient := insights.New(c.SubscriptionID)
 	baseclient.Authorizer = c.Authorizer
 	baseclient.BaseURI = c.BaseURI
-	baseclient.PollingDuration = c.PollingDuration
 	baseclient.RequestInspector = c.RequestInspector
 	baseclient.ResponseInspector = c.ResponseInspector
 
@@ -157,7 +152,6 @@ func (c *baseClient) createEventhubBaseClient() *eventhub.BaseClient {
 	baseclient := eventhub.New(c.SubscriptionID)
 	baseclient.Authorizer = c.Authorizer
 	baseclient.BaseURI = c.BaseURI
-	baseclient.PollingDuration = c.PollingDuration
 	baseclient.RequestInspector = c.RequestInspector
 	baseclient.ResponseInspector = c.ResponseInspector
 

--- a/components/metris/internal/provider/azure/instance.go
+++ b/components/metris/internal/provider/azure/instance.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kyma-project/control-plane/components/metris/internal/log"
 )
 
-func (i *Instance) getComputeMetrics(ctx context.Context, resourceGroupName string, logger log.Logger, vmcaps *vmCapabilities) *Compute {
+func (i *Instance) getComputeMetrics(ctx context.Context, logger log.Logger, vmcaps *vmCapabilities) *Compute {
 	var (
 		caps   = *vmcaps
 		vms    []compute.VirtualMachine
@@ -37,7 +37,7 @@ func (i *Instance) getComputeMetrics(ctx context.Context, resourceGroupName stri
 		i.lastEvent.Compute = result
 	}
 
-	vms, err = i.client.GetVirtualMachines(ctx, resourceGroupName)
+	vms, err = i.client.GetVirtualMachines(ctx, i.clusterResourceGroupName)
 	if err != nil {
 		logger.Warnf("could not get virtual machines information, using information from last successful event: %s", err)
 
@@ -76,7 +76,7 @@ func (i *Instance) getComputeMetrics(ctx context.Context, resourceGroupName stri
 		}
 	}
 
-	disks, err = i.client.GetDisks(ctx, resourceGroupName)
+	disks, err = i.client.GetDisks(ctx, i.clusterResourceGroupName)
 	if err != nil {
 		logger.With("error", err).Warn("could not get disk information, getting information from last successful event")
 
@@ -93,7 +93,7 @@ func (i *Instance) getComputeMetrics(ctx context.Context, resourceGroupName stri
 	return result
 }
 
-func (i *Instance) getNetworkMetrics(ctx context.Context, resourceGroupName string, logger log.Logger) *Networking {
+func (i *Instance) getNetworkMetrics(ctx context.Context, logger log.Logger) *Networking {
 	var (
 		result = &Networking{
 			ProvisionedLoadBalancers: 0,
@@ -110,7 +110,7 @@ func (i *Instance) getNetworkMetrics(ctx context.Context, resourceGroupName stri
 		i.lastEvent.Networking = result
 	}
 
-	lbs, err = i.client.GetLoadBalancers(ctx, resourceGroupName)
+	lbs, err = i.client.GetLoadBalancers(ctx, i.clusterResourceGroupName)
 	if err != nil {
 		logger.With("error", err).Warn("could not get loadbalancer infornation, getting information from last successful event")
 
@@ -119,7 +119,7 @@ func (i *Instance) getNetworkMetrics(ctx context.Context, resourceGroupName stri
 		result.ProvisionedLoadBalancers += uint32(len(lbs))
 	}
 
-	vnets, err = i.client.GetVirtualNetworks(ctx, resourceGroupName)
+	vnets, err = i.client.GetVirtualNetworks(ctx, i.clusterResourceGroupName)
 	if err != nil {
 		logger.With("error", err).Warn("could not get vnet infornation, getting information from last successful event")
 
@@ -128,7 +128,7 @@ func (i *Instance) getNetworkMetrics(ctx context.Context, resourceGroupName stri
 		result.ProvisionedVnets += uint32(len(vnets))
 	}
 
-	publicIPs, err = i.client.GetPublicIPAddresses(ctx, resourceGroupName)
+	publicIPs, err = i.client.GetPublicIPAddresses(ctx, i.clusterResourceGroupName)
 	if err != nil {
 		logger.With("error", err).Warn("could not get public ip infornation, getting information from last successful event")
 
@@ -140,7 +140,7 @@ func (i *Instance) getNetworkMetrics(ctx context.Context, resourceGroupName stri
 	return result
 }
 
-func (i *Instance) getEventHubMetrics(ctx context.Context, pollinterval time.Duration, resourceGroupName string, logger log.Logger) *EventHub {
+func (i *Instance) getEventHubMetrics(ctx context.Context, pollinterval time.Duration, logger log.Logger) *EventHub {
 	var (
 		result = &EventHub{
 			NumberNamespaces:     0,
@@ -157,11 +157,11 @@ func (i *Instance) getEventHubMetrics(ctx context.Context, pollinterval time.Dur
 		i.lastEvent.EventHub = result
 	}
 
-	if resourceGroupName == "" {
+	if i.eventHubResourceGroupName == "" {
 		return i.lastEvent.EventHub
 	}
 
-	ehns, eherr := i.client.GetEHNamespaces(ctx, resourceGroupName)
+	ehns, eherr := i.client.GetEHNamespaces(ctx, i.eventHubResourceGroupName)
 	if eherr != nil {
 		logger.With("error", eherr).Warn("eventhub namespace error, getting information from last successful event")
 

--- a/components/metris/internal/provider/azure/instance_test.go
+++ b/components/metris/internal/provider/azure/instance_test.go
@@ -201,8 +201,8 @@ func TestInstance_getComputeMetrics(t *testing.T) {
 		tt := tt // pin
 
 		t.Run(tt.name, func(t *testing.T) {
-			i := &Instance{cluster: tt.fields.cluster, client: tt.fields.client, lastEvent: tt.fields.lastEvent}
-			got := i.getComputeMetrics(context.Background(), tt.args.resourceGroupName, noopLogger, tt.args.vmcaps)
+			i := &Instance{cluster: tt.fields.cluster, client: tt.fields.client, lastEvent: tt.fields.lastEvent, clusterResourceGroupName: tt.args.resourceGroupName}
+			got := i.getComputeMetrics(context.Background(), noopLogger, tt.args.vmcaps)
 
 			asserts.ElementsMatch(tt.want.VMTypes, got.VMTypes)
 			asserts.Equal(tt.want.ProvisionedCpus, got.ProvisionedCpus)
@@ -262,8 +262,8 @@ func TestInstance_getNetworkMetrics(t *testing.T) {
 		tt := tt // pin
 
 		t.Run(tt.name, func(t *testing.T) {
-			i := &Instance{cluster: tt.fields.cluster, client: tt.fields.client, lastEvent: tt.fields.lastEvent}
-			got := i.getNetworkMetrics(context.Background(), tt.args.resourceGroupName, noopLogger)
+			i := &Instance{cluster: tt.fields.cluster, client: tt.fields.client, lastEvent: tt.fields.lastEvent, clusterResourceGroupName: tt.args.resourceGroupName}
+			got := i.getNetworkMetrics(context.Background(), noopLogger)
 			asserts.Equal(tt.want, got)
 		})
 	}
@@ -332,8 +332,8 @@ func TestInstance_getEventHubMetrics(t *testing.T) {
 		tt := tt // pinned
 
 		t.Run(tt.name, func(t *testing.T) {
-			i := &Instance{cluster: tt.fields.cluster, client: tt.fields.client, lastEvent: tt.fields.lastEvent}
-			got := i.getEventHubMetrics(context.Background(), tt.args.pollinterval, tt.args.resourceGroupName, noopLogger)
+			i := &Instance{cluster: tt.fields.cluster, client: tt.fields.client, lastEvent: tt.fields.lastEvent, eventHubResourceGroupName: tt.args.resourceGroupName}
+			got := i.getEventHubMetrics(context.Background(), tt.args.pollinterval, noopLogger)
 			asserts.Equal(tt.want, got)
 		})
 	}

--- a/components/metris/internal/provider/azure/types.go
+++ b/components/metris/internal/provider/azure/types.go
@@ -37,9 +37,6 @@ const (
 	// tagNameSubAccountID is the subAccountID tag name use for tagging resource group.
 	tagNameSubAccountID string = "SubAccountID"
 
-	// maxPollingDuration is the maximum polling time for the REST API client.
-	maxPollingDuration = 1 * time.Minute
-
 	// diskSizeFactor is to calculate rounded value of disk size in gigabytes, example 17Gb->32Gb, 33Gb->64Gb.
 	diskSizeFactor float64 = 32
 
@@ -50,6 +47,9 @@ const (
 	PT1M TimeGrain = "PT1M"
 	// PT5M ...
 	PT5M TimeGrain = "PT5M"
+
+	// maximum number of failed attempt to get metrics, after that instance is remove from cache/storage.
+	maxRetryAttempts int = 5
 )
 
 // TimeGrain enumerates the values for time grain.
@@ -102,6 +102,8 @@ type Instance struct {
 	clusterResourceGroupName string
 	// eventHubResourceGroupName store the Azure Event Hub resource group name associated with the subaccountid.
 	eventHubResourceGroupName string
+	// retryAttempts store the number of retry attempts to get metrics.
+	retryAttempts int
 }
 
 //go:generate mockery --name AuthConfig

--- a/components/metris/internal/provider/types.go
+++ b/components/metris/internal/provider/types.go
@@ -14,7 +14,8 @@ type Factory func(config *Config) Provider
 
 // Config holds providers base configuration.
 type Config struct {
-	PollInterval     time.Duration `kong:"help='Interval at which metrics are fetch.',env='PROVIDER_POLLINTERVAL',required=true,default='1m'"`
+	PollInterval     time.Duration `kong:"help='Interval at which metrics are fetch.',env='PROVIDER_POLLINTERVAL',required=false,default='1m'"`
+	PollingDuration  time.Duration `kong:"help='Time limit for requests made by the provider client.',env='PROVIDER_POLLDURATION',required=false,default='5m'"`
 	Workers          int           `kong:"help='Number of workers to fetch metrics.',env='PROVIDER_WORKERS',required=true,default=10"`
 	Buffer           int           `kong:"help='Number of cluster that the buffer can have.',env='PROVIDER_BUFFER',required=true,default=100"`
 	ClientTraceLevel int           `kong:"help='Provider client trace level (0=disabled, 1=headers, 2=body)',env='PROVIDER_CLIENT_TRACE_LEVEL',default=0,hidden=true"`

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -23,7 +23,7 @@ global:
       version: "PR-313"
     metris:
       dir:
-      version: "PR-328"
+      version: "PR-339"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:
- add poll duration parameter with 5m default instead of 1m constant value  (408 errors)
- add logic to remove cluster from storage when not found in Azure but never got a Gardener delete event (404 errors)
- add some debug information about request time
- remove unnecessary code

**Related issue(s)**
