### PR TITLE
change deprovisioning_failed_total in dashboard.json

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -972,7 +972,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "delta(compass_keb_operations_deprovisioning_failed_total[40m])",
+          "expr": "delta(compass_keb_operations_deprovisioning_failed_total[40m])>=0",
           "interval": "",
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
This patch is in order to avoid the _negative_ vaule of the delta(compass_keb_operations_deprovisioning_failed_total[40m]) 

When it's _negative_ value, it means that the deprovisioning failed account is decreasing , maybe during that phase series of the SKRs are deleted because of gardener issue....
grafana link: https://grafana.cp.kyma.cloud.sap/d/_MIdIJiZh/kcp-kyma-environment-broker?orgId=1&from=now-30d&to=now&refresh=10s

<img width="590" alt="Screen Shot 2020-11-18 at 3 54 09 PM" src="https://user-images.githubusercontent.com/44886703/99501157-57472880-29b6-11eb-8499-9a67bf1991a0.png">
