### PR TITLE
Fix contract between KEB and CIS

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -356,7 +356,7 @@ func main() {
 		broker.NewDeprovision(db.Instances(), db.Operations(), deprovisionQueue, logs),
 		broker.NewUpdate(logs),
 		broker.NewGetInstance(db.Instances(), logs),
-		broker.NewLastOperation(db.Operations(), logs),
+		broker.NewLastOperation(db.Operations(), db.Instances(), logs),
 		broker.NewBind(logs),
 		broker.NewUnbind(logs),
 		broker.NewGetBinding(logs),

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision.go
@@ -47,10 +47,10 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 	switch {
 	case err == nil:
 	case dberr.IsNotFound(err):
-		logger.Warn("instance does not exists")
+		logger.Warn("instance does not exist")
 		return domain.DeprovisionServiceSpec{
 			IsAsync: false,
-		}, nil
+		}, apiresponses.NewFailureResponse(errors.Errorf("instance does not exist"), http.StatusGone, fmt.Sprintf("instance with ID %s is not found in DB", instanceID))
 	default:
 		logger.Errorf("unable to get instance from a storage: %s", err)
 		return domain.DeprovisionServiceSpec{}, apiresponses.NewFailureResponse(fmt.Errorf("unable to get instance from the storage"), http.StatusInternalServerError, fmt.Sprintf("could not deprovision runtime, instanceID %s", instanceID))

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision.go
@@ -48,9 +48,7 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 	case err == nil:
 	case dberr.IsNotFound(err):
 		logger.Warn("instance does not exist")
-		return domain.DeprovisionServiceSpec{
-			IsAsync: false,
-		}, apiresponses.NewFailureResponse(errors.Errorf("instance does not exist"), http.StatusGone, fmt.Sprintf("instance with ID %s is not found in DB", instanceID))
+		return domain.DeprovisionServiceSpec{}, apiresponses.NewFailureResponse(errors.Errorf("instance does not exist"), http.StatusGone, fmt.Sprintf("instance with ID %s is not found in DB", instanceID))
 	default:
 		logger.Errorf("unable to get instance from a storage: %s", err)
 		return domain.DeprovisionServiceSpec{}, apiresponses.NewFailureResponse(fmt.Errorf("unable to get instance from the storage"), http.StatusInternalServerError, fmt.Sprintf("could not deprovision runtime, instanceID %s", instanceID))

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision.go
@@ -48,7 +48,9 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 	case err == nil:
 	case dberr.IsNotFound(err):
 		logger.Warn("instance does not exist")
-		return domain.DeprovisionServiceSpec{}, apiresponses.NewFailureResponse(errors.Errorf("instance does not exist"), http.StatusGone, fmt.Sprintf("instance with ID %s is not found in DB", instanceID))
+		return domain.DeprovisionServiceSpec{
+			IsAsync: false,
+		}, nil
 	default:
 		logger.Errorf("unable to get instance from a storage: %s", err)
 		return domain.DeprovisionServiceSpec{}, apiresponses.NewFailureResponse(fmt.Errorf("unable to get instance from the storage"), http.StatusInternalServerError, fmt.Sprintf("could not deprovision runtime, instanceID %s", instanceID))

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision_test.go
@@ -2,7 +2,6 @@ package broker
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker/automock"
@@ -11,7 +10,6 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v7/domain"
-	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,10 +33,7 @@ func TestDeprovisionEndpoint_DeprovisionNotExistingInstance(t *testing.T) {
 	_, err := svc.Deprovision(context.TODO(), "inst-0001", domain.DeprovisionDetails{}, true)
 
 	// then
-	assert.Error(t, err)
-	failureResp, ok := err.(*apiresponses.FailureResponse)
-	require.True(t, ok)
-	assert.Equal(t, http.StatusGone, failureResp.ValidatedStatusCode(nil))
+	assert.NoError(t, err)
 }
 
 func TestDeprovisionEndpoint_DeprovisionExistingInstance(t *testing.T) {

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision_test.go
@@ -2,6 +2,7 @@ package broker
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker/automock"
@@ -10,6 +11,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/pivotal-cf/brokerapi/v7/domain"
+	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -33,7 +35,10 @@ func TestDeprovisionEndpoint_DeprovisionNotExistingInstance(t *testing.T) {
 	_, err := svc.Deprovision(context.TODO(), "inst-0001", domain.DeprovisionDetails{}, true)
 
 	// then
-	assert.NoError(t, err)
+	assert.Error(t, err)
+	failureResp, ok := err.(*apiresponses.FailureResponse)
+	require.True(t, ok)
+	assert.Equal(t, http.StatusGone, failureResp.ValidatedStatusCode(nil))
 }
 
 func TestDeprovisionEndpoint_DeprovisionExistingInstance(t *testing.T) {

--- a/components/kyma-environment-broker/internal/broker/instance_last_operation.go
+++ b/components/kyma-environment-broker/internal/broker/instance_last_operation.go
@@ -2,9 +2,11 @@ package broker
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
 
 	"github.com/pivotal-cf/brokerapi/v7/domain"
 	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
@@ -14,13 +16,15 @@ import (
 
 type LastOperationEndpoint struct {
 	operationStorage storage.Operations
+	instancesStorage storage.Instances
 
 	log logrus.FieldLogger
 }
 
-func NewLastOperation(os storage.Operations, log logrus.FieldLogger) *LastOperationEndpoint {
+func NewLastOperation(os storage.Operations, is storage.Instances, log logrus.FieldLogger) *LastOperationEndpoint {
 	return &LastOperationEndpoint{
 		operationStorage: os,
+		instancesStorage: is,
 		log:              log.WithField("service", "LastOperationEndpoint"),
 	}
 }
@@ -29,6 +33,20 @@ func NewLastOperation(os storage.Operations, log logrus.FieldLogger) *LastOperat
 //   GET /v2/service_instances/{instance_id}/last_operation
 func (b *LastOperationEndpoint) LastOperation(ctx context.Context, instanceID string, details domain.PollDetails) (domain.LastOperation, error) {
 	logger := b.log.WithField("instanceID", instanceID).WithField("operationID", details.OperationData)
+
+	if details.OperationData == "" {
+		_, err := b.instancesStorage.GetByID(instanceID)
+		switch {
+		case err == nil:
+			err = errors.New("operation data must be provided for asynchronous operations")
+			return domain.LastOperation{}, apiresponses.NewFailureResponse(err, http.StatusBadRequest, err.Error())
+		case dberr.IsNotFound(err):
+			return domain.LastOperation{}, apiresponses.NewFailureResponse(errors.Errorf("instance does not exist"), http.StatusGone, fmt.Sprintf("instance with ID %s is not found in DB", instanceID))
+		default:
+			logger.Errorf("unable to get instance from a storage: %s", err)
+			return domain.LastOperation{}, apiresponses.NewFailureResponse(errors.Errorf("unable to get instance from the storage"), http.StatusInternalServerError, fmt.Sprintf("could not get instance from DB, instanceID %s", instanceID))
+		}
+	}
 
 	operation, err := b.operationStorage.GetOperationByID(details.OperationData)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/broker/instance_last_operation_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_last_operation_test.go
@@ -27,7 +27,7 @@ func TestLastOperation_LastOperation(t *testing.T) {
 	assert.NoError(t, err)
 
 	// #create LastOperation endpoint
-	lastOperationEndpoint := broker.NewLastOperation(memoryStorage.Operations(), logrus.StandardLogger())
+	lastOperationEndpoint := broker.NewLastOperation(memoryStorage.Operations(), memoryStorage.Instances(), logrus.StandardLogger())
 
 	// when
 	response, err := lastOperationEndpoint.LastOperation(context.TODO(), instID, domain.PollDetails{OperationData: operationID})

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-286"
     kyma_environment_broker:
       dir:
-      version: "PR-334"
+      version: "PR-342"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**

Currently when a deprovision request is sent from CIS to Kyma service broker for an instance which doesn't exist (has been deprovisioned internally), Kyma responds with `200 OK` and empty JSON body. This seems to be valid response ([see the spec.](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-10)) even if client requests async processing with accepts_incomplete=true .
CIS seems to treat `200 OK` same as `202 Accepted` and starts to poll `service_instance/last_operation` API with empty `operation_id` parameter ([which it shouldn’t do](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#parameters)). Kyma returns `500 Internal Server Error`, [which is also not correct](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-1).


Changes proposed in this pull request:

- Respond `410 Gone` for deprovision request when the instance does not exist
- Validate operation ID presence in `service_instance/last_operation` API, if omitted
     - Respond `400 Bad Request` when instance exists, as the operation must have belonged to an async provision / deprovision operation
     - Respond `410 Gone` when instance does not exists
     - Respond with `500 Internal Server Error` in cause of any failure.

