### PR TITLE
Make orchestration states external

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -19,7 +19,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/hyperscaler"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/hyperscaler/azure"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	orchestrationExt "github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/appinfo"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/auditlog"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs"
@@ -431,10 +431,10 @@ func processOperationsInProgressByType(opType dbmodel.OperationType, op storage.
 }
 
 func reprocessOrchestrations(op storage.Orchestrations, queue *process.Queue, log logrus.FieldLogger) error {
-	if err := processOrchestration(internal.InProgress, op, queue, log); err != nil {
+	if err := processOrchestration(orchestrationExt.InProgress, op, queue, log); err != nil {
 		return errors.Wrap(err, "while processing in progress orchestrations")
 	}
-	if err := processOrchestration(internal.Pending, op, queue, log); err != nil {
+	if err := processOrchestration(orchestrationExt.Pending, op, queue, log); err != nil {
 		return errors.Wrap(err, "while processing pending orchestrations")
 	}
 	return nil

--- a/components/kyma-environment-broker/cmd/broker/orchestration_test.go
+++ b/components/kyma-environment-broker/cmd/broker/orchestration_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 )
 
 func TestOrchestration_OneRuntimeHappyPath(t *testing.T) {
@@ -13,13 +13,13 @@ func TestOrchestration_OneRuntimeHappyPath(t *testing.T) {
 	otherRuntimeID := suite.CreateProvisionedRuntime(RuntimeOptions{})
 	orchestrationID := suite.CreateOrchestration(runtimeID)
 
-	suite.WaitForOrchestrationState(orchestrationID, internal.InProgress)
+	suite.WaitForOrchestrationState(orchestrationID, orchestration.InProgress)
 
 	// when
 	suite.FinishUpgradeOperationByProvisioner(runtimeID)
 
 	// then
-	suite.WaitForOrchestrationState(orchestrationID, internal.Succeeded)
+	suite.WaitForOrchestrationState(orchestrationID, orchestration.Succeeded)
 
 	suite.AssertRuntimeUpgraded(runtimeID)
 	suite.AssertRuntimeNotUpgraded(otherRuntimeID)

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
+	"github.com/pivotal-cf/brokerapi/v7/domain"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -177,7 +178,7 @@ func (s *OrchestrationSuite) CreateProvisionedRuntime(options RuntimeOptions) st
 	require.NoError(s.t, err)
 	provisioningOperation := internal.ProvisioningOperation{
 		Operation: internal.Operation{
-			State:      internal.Succeeded,
+			State:      domain.Succeeded,
 			ID:         uuid.New(),
 			InstanceID: instanceID,
 		},
@@ -218,7 +219,7 @@ func (s *OrchestrationSuite) CreateOrchestration(runtimeID string) string {
 	now := time.Now()
 	o := internal.Orchestration{
 		OrchestrationID: uuid.New(),
-		State:           internal.Pending,
+		State:           orchestration.Pending,
 		Description:     "started processing of Kyma upgrade",
 		Parameters: orchestration.Parameters{
 			Targets: orchestration.TargetSpec{

--- a/components/kyma-environment-broker/cmd/cli/command/orchestration.go
+++ b/components/kyma-environment-broker/cmd/cli/command/orchestration.go
@@ -12,7 +12,6 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/cmd/cli/logger"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/cmd/cli/printer"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/spf13/cobra"
 )
 
@@ -33,10 +32,10 @@ type orchestrationDetails struct {
 }
 
 var cliStates = map[string]string{
-	"pending":    internal.Pending,
-	"failed":     internal.Failed,
-	"succeeded":  internal.Succeeded,
-	"inprogress": internal.InProgress,
+	"pending":    orchestration.Pending,
+	"failed":     orchestration.Failed,
+	"succeeded":  orchestration.Succeeded,
+	"inprogress": orchestration.InProgress,
 }
 
 var orchestrationColumns = []printer.Column{

--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -18,6 +18,14 @@ const (
 	StateParam = "state"
 )
 
+// Orchestration states
+const (
+	Pending    = "pending"
+	InProgress = "in progress"
+	Succeeded  = "succeeded"
+	Failed     = "failed"
+)
+
 // ListParameters hold attributes of list orchestrations / operations queries.
 type ListParameters struct {
 	Page     int

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -202,15 +202,8 @@ type Orchestration struct {
 }
 
 func (o *Orchestration) IsFinished() bool {
-	return o.State == Succeeded || o.State == Failed
+	return o.State == orchestration.Succeeded || o.State == orchestration.Failed
 }
-
-const (
-	Pending    = "pending"
-	InProgress = "in progress"
-	Succeeded  = "succeeded"
-	Failed     = "failed"
-)
 
 // Runtime is the data type which captures the needed runtime specific attributes to perform orchestrations on a given runtime.
 type Runtime struct {
@@ -377,7 +370,7 @@ func (do *UpgradeKymaOperation) SetProvisioningParameters(parameters Provisionin
 }
 
 func (o *Operation) IsFinished() bool {
-	return o.State != InProgress
+	return o.State != domain.InProgress
 }
 
 type ComponentConfigurationInputList []*gqlschema.ComponentConfigurationInput

--- a/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
@@ -197,7 +197,7 @@ func (h *kymaHandler) createOrchestration(w http.ResponseWriter, r *http.Request
 	now := time.Now()
 	o := internal.Orchestration{
 		OrchestrationID: uuid.New().String(),
-		State:           internal.Pending,
+		State:           orchestration.Pending,
 		Description:     "started processing of Kyma upgrade",
 		Parameters:      params,
 		CreatedAt:       now,

--- a/components/kyma-environment-broker/internal/orchestration/kyma/manager.go
+++ b/components/kyma-environment-broker/internal/orchestration/kyma/manager.go
@@ -88,7 +88,7 @@ func (u *upgradeKymaManager) Execute(orchestrationID string) (time.Duration, err
 
 func (u *upgradeKymaManager) resolveOperations(o *internal.Orchestration, params orchestrationExt.Parameters) ([]internal.UpgradeKymaOperation, error) {
 	var result []internal.UpgradeKymaOperation
-	if o.State == internal.Pending {
+	if o.State == orchestrationExt.Pending {
 		runtimes, err := u.resolver.Resolve(params.Targets)
 		if err != nil {
 			return result, errors.Wrap(err, "while resolving targets")
@@ -141,9 +141,9 @@ func (u *upgradeKymaManager) resolveOperations(o *internal.Orchestration, params
 		}
 
 		if len(runtimes) != 0 {
-			o.State = internal.InProgress
+			o.State = orchestrationExt.InProgress
 		} else {
-			o.State = internal.Succeeded
+			o.State = orchestrationExt.Succeeded
 		}
 		o.Description = fmt.Sprintf("Scheduled %d operations", len(runtimes))
 
@@ -182,7 +182,7 @@ func (u *upgradeKymaManager) filterOperationsInProgress(ops []internal.UpgradeKy
 
 func (u *upgradeKymaManager) failOrchestration(o *internal.Orchestration, err error) (time.Duration, error) {
 	u.log.Errorf("orchestration %s failed: %s", o.OrchestrationID, err)
-	return u.updateOrchestration(o, internal.Failed, err.Error()), nil
+	return u.updateOrchestration(o, orchestrationExt.Failed, err.Error()), nil
 }
 
 func (u *upgradeKymaManager) updateOrchestration(o *internal.Orchestration, state, description string) time.Duration {
@@ -222,9 +222,9 @@ func (u *upgradeKymaManager) waitForCompletion(o *internal.Orchestration) error 
 		return errors.Wrap(err, "while waiting for scheduled operations to finish")
 	}
 
-	orchestrationState := internal.Succeeded
+	orchestrationState := orchestrationExt.Succeeded
 	if stats[domain.Failed] > 0 {
-		orchestrationState = internal.Failed
+		orchestrationState = orchestrationExt.Failed
 	}
 
 	o.State = orchestrationState

--- a/components/kyma-environment-broker/internal/orchestration/kyma/manager_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/kyma/manager_test.go
@@ -32,7 +32,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		}).Return([]internal.Runtime{}, nil)
 
 		id := "id"
-		err := store.Orchestrations().Insert(internal.Orchestration{OrchestrationID: id, State: internal.Pending})
+		err := store.Orchestrations().Insert(internal.Orchestration{OrchestrationID: id, State: orchestration.Pending})
 		require.NoError(t, err)
 
 		svc := kyma.NewUpgradeKymaManager(store.Orchestrations(), store.Operations(), nil, resolver, 20*time.Millisecond, logrus.New())
@@ -44,7 +44,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		o, err := store.Orchestrations().GetByID(id)
 		require.NoError(t, err)
 
-		assert.Equal(t, internal.Succeeded, o.State)
+		assert.Equal(t, orchestration.Succeeded, o.State)
 	})
 	t.Run("InProgress", func(t *testing.T) {
 		// given
@@ -56,7 +56,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		id := "id"
 		err := store.Orchestrations().Insert(internal.Orchestration{
 			OrchestrationID: id,
-			State:           internal.InProgress,
+			State:           orchestration.InProgress,
 			Parameters: orchestration.Parameters{
 				Strategy: orchestration.StrategySpec{
 					Type:     orchestration.ParallelStrategy,
@@ -75,7 +75,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		o, err := store.Orchestrations().GetByID(id)
 		require.NoError(t, err)
 
-		assert.Equal(t, internal.Succeeded, o.State)
+		assert.Equal(t, orchestration.Succeeded, o.State)
 
 	})
 
@@ -90,7 +90,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		id := "id"
 		err := store.Orchestrations().Insert(internal.Orchestration{
 			OrchestrationID: id,
-			State:           internal.Pending,
+			State:           orchestration.Pending,
 			Parameters: orchestration.Parameters{
 				DryRun: true,
 			}})
@@ -105,7 +105,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		o, err := store.Orchestrations().GetByID(id)
 		require.NoError(t, err)
 
-		assert.Equal(t, internal.Succeeded, o.State)
+		assert.Equal(t, orchestration.Succeeded, o.State)
 
 	})
 
@@ -142,7 +142,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 
 		givenO := internal.Orchestration{
 			OrchestrationID: id,
-			State:           internal.InProgress,
+			State:           orchestration.InProgress,
 			Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{
 				Type:     orchestration.ParallelStrategy,
 				Schedule: orchestration.Immediate,
@@ -160,7 +160,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 		o, err := store.Orchestrations().GetByID(id)
 		require.NoError(t, err)
 
-		assert.Equal(t, internal.Succeeded, o.State)
+		assert.Equal(t, orchestration.Succeeded, o.State)
 
 	})
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-336"
     kyma_environment_broker:
       dir:
-      version: "PR-334"
+      version: "PR-344"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**

Needed to move KCP CLI out from `components/kyma-environment-broker` to `components/cli`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
