### PR TITLE
Add Tags to internal AVS evaluation

### DIFF
--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -64,3 +64,7 @@ KEB binary allows you to override some configuration parameters. You can specify
 | **APP_LMS_MANDATORY** | Defines whether failing LMS activation will break provisioning. | `true` |
 | **APP_LMS_REGION** | Defines the region for the LMS system. If set, this region is always used. If empty, the region is mapped from the OSB API request. | None |
 | **APP_LMS_TOKEN** | Specifies the token for the LMS system. | None |
+| **APP_AVS_ADDITIONAL_TAGS_ENABLED** | Additional tags are added to internal Evalution after the cluster is provisioned. | `false` |
+| **APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID** | TagClass' ID of Tag containing cluster's Gardener shoot name. | None |
+| **APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID** | TagClass' ID of Tag containing cluster's Gardener seed name. | None |
+| **APP_AVS_REGION_TAG_CLASS_ID** | TagClass' ID of Tag containing cluster's region. | None |

--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -64,7 +64,7 @@ KEB binary allows you to override some configuration parameters. You can specify
 | **APP_LMS_MANDATORY** | Defines whether failing LMS activation will break provisioning. | `true` |
 | **APP_LMS_REGION** | Defines the region for the LMS system. If set, this region is always used. If empty, the region is mapped from the OSB API request. | None |
 | **APP_LMS_TOKEN** | Specifies the token for the LMS system. | None |
-| **APP_AVS_ADDITIONAL_TAGS_ENABLED** | Additional tags are added to internal Evalution after the cluster is provisioned. | `false` |
-| **APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID** | TagClass' ID of Tag containing cluster's Gardener shoot name. | None |
-| **APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID** | TagClass' ID of Tag containing cluster's Gardener seed name. | None |
-| **APP_AVS_REGION_TAG_CLASS_ID** | TagClass' ID of Tag containing cluster's region. | None |
+| **APP_AVS_ADDITIONAL_TAGS_ENABLED** | Specifies additional tags that are added to the internal Evaluation after the cluster is provisioned. | `false` |
+| **APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID** | Specifies the **TagClassId** of the tag that contains Gardener cluster's shoot name. | None |
+| **APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID** | Specifies the **TagClassId** of the tag that contains Gardener cluster's seed name. | None |
+| **APP_AVS_REGION_TAG_CLASS_ID** | Specifies the **TagClassId** of the tag that contains Gardener cluster's region. | None |

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -211,6 +211,7 @@ func main() {
 	externalEvalAssistant := avs.NewExternalEvalAssistant(cfg.Avs)
 	internalEvalAssistant := avs.NewInternalEvalAssistant(cfg.Avs)
 	externalEvalCreator := provisioning.NewExternalEvalCreator(avsDel, cfg.Avs.Disabled, externalEvalAssistant)
+	internalEvalUpdater := provisioning.NewInternalEvalUpdater(avsDel, internalEvalAssistant)
 
 	clientHTTPForIAS := httputil.NewClient(60, cfg.IAS.SkipCertVerification)
 	if cfg.IAS.TLSRenegotiationEnable {
@@ -238,7 +239,7 @@ func main() {
 	globalAccountVersionMapping := runtimeversion.NewGlobalAccountVersionMapping(ctx, cli, cfg.VersionConfig.Namespace, cfg.VersionConfig.Name, logs)
 	runtimeVerConfigurator := runtimeversion.NewRuntimeVersionConfigurator(cfg.KymaVersion, globalAccountVersionMapping)
 	provisioningInit := provisioning.NewInitialisationStep(db.Operations(), db.Instances(),
-		provisionerClient, directorClient, inputFactory, externalEvalCreator, iasTypeSetter, cfg.Provisioning.Timeout,
+		provisionerClient, directorClient, inputFactory, externalEvalCreator, internalEvalUpdater, iasTypeSetter, cfg.Provisioning.Timeout,
 		runtimeVerConfigurator, serviceManagerClientFactory)
 	provisionManager.InitStep(provisioningInit)
 

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -211,7 +211,7 @@ func main() {
 	externalEvalAssistant := avs.NewExternalEvalAssistant(cfg.Avs)
 	internalEvalAssistant := avs.NewInternalEvalAssistant(cfg.Avs)
 	externalEvalCreator := provisioning.NewExternalEvalCreator(avsDel, cfg.Avs.Disabled, externalEvalAssistant)
-	internalEvalUpdater := provisioning.NewInternalEvalUpdater(avsDel, internalEvalAssistant)
+	internalEvalUpdater := provisioning.NewInternalEvalUpdater(avsDel, internalEvalAssistant, cfg.Avs)
 
 	clientHTTPForIAS := httputil.NewClient(60, cfg.IAS.SkipCertVerification)
 	if cfg.IAS.TLSRenegotiationEnable {

--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -65,7 +65,7 @@ func (c *Client) CreateEvaluation(evaluationRequest *BasicEvaluationCreateReques
 	return &responseObject, nil
 }
 
-func (c *Client) GetEvaluation(evaluationID string) (_ *BasicEvaluationCreateResponse, err error) {
+func (c *Client) GetEvaluation(evaluationID string) (*BasicEvaluationCreateResponse, error) {
 	var responseObject BasicEvaluationCreateResponse
 
 	request, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/%s", c.avsConfig.ApiEndpoint, evaluationID), nil)

--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -33,7 +33,7 @@ func NewClient(ctx context.Context, avsConfig Config, log logrus.FieldLogger) (*
 	}, nil
 }
 
-func (c *Client) CreateEvaluation(evaluationRequest *BasicEvaluationCreateRequest) (_ *BasicEvaluationCreateResponse, err error) {
+func (c *Client) CreateEvaluation(evaluationRequest *BasicEvaluationCreateRequest) (*BasicEvaluationCreateResponse, error) {
 	var responseObject BasicEvaluationCreateResponse
 
 	objAsBytes, err := json.Marshal(evaluationRequest)
@@ -92,7 +92,7 @@ func (c *Client) GetEvaluation(evaluationID string) (*BasicEvaluationCreateRespo
 	return &responseObject, nil
 }
 
-func (c *Client) UpdateEvaluation(evaluationID string, evaluationRequest *BasicEvaluationCreateRequest) (_ *BasicEvaluationCreateResponse, err error) {
+func (c *Client) UpdateEvaluation(evaluationID string, evaluationRequest *BasicEvaluationCreateRequest) (*BasicEvaluationCreateResponse, error) {
 	var responseObject BasicEvaluationCreateResponse
 
 	objAsBytes, err := json.Marshal(evaluationRequest)

--- a/components/kyma-environment-broker/internal/avs/client_test.go
+++ b/components/kyma-environment-broker/internal/avs/client_test.go
@@ -10,21 +10,18 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	"gopkg.in/yaml.v2"
-
 	"github.com/gorilla/mux"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/oauth2"
 )
 
 const (
-	evaluationID              = 997
-	existingEvaluationName    = "test-eval-name"
-	parentEvaluationID        = 42
-	updatedParentEvaluationID = 24
-	accessToken               = "1234abcd"
-	tokenType                 = "test"
+	parentEvaluationID     = 42
+	evaluationName         = "test_evaluation"
+	existingEvaluationName = "test-eval-name"
+	accessToken            = "1234abcd"
+	tokenType              = "test"
 )
 
 func TestClient_CreateEvaluation(t *testing.T) {
@@ -40,13 +37,14 @@ func TestClient_CreateEvaluation(t *testing.T) {
 
 		// When
 		response, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
-			Name:     "test_evaluation",
+			Name:     evaluationName,
 			ParentId: parentEvaluationID,
 		})
 
 		// Then
 		assert.NoError(t, err)
-		assert.Equal(t, "test_evaluation", response.Name)
+		assert.Equal(t, evaluationName, response.Name)
+		assert.NotEmpty(t, server.evaluations.parentIDrefs[parentEvaluationID])
 	})
 
 	t.Run("create evaluation with token reset", func(t *testing.T) {
@@ -62,13 +60,14 @@ func TestClient_CreateEvaluation(t *testing.T) {
 
 		// When
 		response, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
-			Name:     "test_evaluation",
+			Name:     evaluationName,
 			ParentId: parentEvaluationID,
 		})
 
 		// Then
 		assert.NoError(t, err)
 		assert.Equal(t, "test_evaluation", response.Name)
+		assert.NotEmpty(t, server.evaluations.parentIDrefs[parentEvaluationID])
 	})
 
 	t.Run("401 error during creating evaluation", func(t *testing.T) {
@@ -95,7 +94,7 @@ func TestClient_CreateEvaluation(t *testing.T) {
 }
 
 func TestClient_DeleteEvaluation(t *testing.T) {
-	t.Run("delete existing evaluation", func(t *testing.T) {
+	t.Run("should delete existing evaluation", func(t *testing.T) {
 		// Given
 		server := newServer(t)
 		mockServer := fixHTTPServer(server)
@@ -106,20 +105,20 @@ func TestClient_DeleteEvaluation(t *testing.T) {
 		}, logrus.New())
 		assert.NoError(t, err)
 
-		_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
+		resp, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
 			Name: "test_evaluation",
 		})
 		assert.NoError(t, err)
 
 		// When
-		err = client.DeleteEvaluation(evaluationID)
+		err = client.DeleteEvaluation(resp.Id)
 
 		// Then
 		assert.NoError(t, err)
-		assert.Empty(t, server.evaluation)
+		assert.Empty(t, server.evaluations.basicEvals)
 	})
 
-	t.Run("delete not existing evaluation", func(t *testing.T) {
+	t.Run("should return error when trying to delete not existing evaluation", func(t *testing.T) {
 		// Given
 		server := newServer(t)
 		mockServer := fixHTTPServer(server)
@@ -131,7 +130,8 @@ func TestClient_DeleteEvaluation(t *testing.T) {
 		assert.NoError(t, err)
 
 		_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
-			Name: "test_evaluation",
+			Name:     "test_evaluation",
+			ParentId: parentEvaluationID,
 		})
 		assert.NoError(t, err)
 
@@ -140,73 +140,13 @@ func TestClient_DeleteEvaluation(t *testing.T) {
 
 		// Then
 		assert.NoError(t, err)
-		assert.Empty(t, server.evaluation[123])
+		assert.Empty(t, server.evaluations.basicEvals[123])
 	})
 }
 
 func TestClient_RemoveReferenceFromParentEval(t *testing.T) {
-	// Given
-	server := newServer(t)
-	mockServer := fixHTTPServer(server)
-	client, err := NewClient(context.TODO(), Config{
-		OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
-		ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
-		ParentId:           parentEvaluationID,
-	}, logrus.New())
-	assert.NoError(t, err)
-
-	_, err = client.CreateEvaluation(&BasicEvaluationCreateRequest{
-		Name: "test_evaluation",
-	})
-	assert.NoError(t, err)
-
-	// When
-	err = client.RemoveReferenceFromParentEval(evaluationID)
-
-	// Then
-	assert.NoError(t, err)
-	assert.Empty(t, server.evaluation[evaluationID])
-}
-
-func TestClient_RemoveReferenceFromParentEval_WrongApiURLError(t *testing.T) {
-	// Given
-	server := newServer(t)
-	mockServer := fixHTTPServer(server)
-	client, err := NewClient(context.TODO(), Config{
-		OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
-		ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", "http://not-existing"),
-		ParentId:           parentEvaluationID,
-	}, logrus.New())
-	assert.NoError(t, err)
-
-	// When
-	err = client.RemoveReferenceFromParentEval(evaluationID)
-	assert.Error(t, err)
-}
-
-func TestClient_GetEvaluation(t *testing.T) {
-	t.Run("should return evaluation when one exists", func(t *testing.T) {
-		// given
-		server := newServer(t)
-		server.evaluation[evaluationID] = parentEvaluationID
-		mockServer := fixHTTPServer(server)
-		client, err := NewClient(context.TODO(), Config{
-			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
-			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
-			ParentId:           parentEvaluationID,
-		}, logrus.New())
-		assert.NoError(t, err)
-
-		// when
-		eval, err := client.GetEvaluation(strconv.Itoa(evaluationID))
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, existingEvaluationName, eval.Name)
-	})
-
-	t.Run("should return 404 when evaluation does not exist", func(t *testing.T) {
-		// given
+	t.Run("should remove reference from parent eval", func(t *testing.T) {
+		// Given
 		server := newServer(t)
 		mockServer := fixHTTPServer(server)
 		client, err := NewClient(context.TODO(), Config{
@@ -216,43 +156,40 @@ func TestClient_GetEvaluation(t *testing.T) {
 		}, logrus.New())
 		assert.NoError(t, err)
 
-		// when
-		eval, err := client.GetEvaluation(strconv.Itoa(evaluationID))
+		resp, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
+			Name:     "test_evaluation",
+			ParentId: parentEvaluationID,
+		})
+		assert.NoError(t, err)
+
+		// When
+		err = client.RemoveReferenceFromParentEval(resp.Id)
+
+		// Then
+		assert.NoError(t, err)
+		assert.Empty(t, server.evaluations.parentIDrefs[parentEvaluationID])
+	})
+	t.Run("should return error when wrong api url provided", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", "http://not-existing"),
+			ParentId:           parentEvaluationID,
+		}, logrus.New())
+		assert.NoError(t, err)
+
+		// When
+		err = client.RemoveReferenceFromParentEval(111)
 
 		// then
 		assert.Error(t, err)
-		assert.Equal(t, "", eval.Name)
-		assert.Contains(t, err.Error(), "404")
 	})
 }
 
-func TestClient_UpdateEvaluation(t *testing.T) {
-	t.Run("should update evaluation when one exists", func(t *testing.T) {
-		// given
-		server := newServer(t)
-		server.evaluation[evaluationID] = parentEvaluationID
-		mockServer := fixHTTPServer(server)
-		client, err := NewClient(context.TODO(), Config{
-			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
-			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
-			ParentId:           parentEvaluationID,
-		}, logrus.New())
-		assert.NoError(t, err)
-
-		// when
-		eval, err := client.UpdateEvaluation(strconv.Itoa(evaluationID), &BasicEvaluationCreateRequest{
-			Name:     "test_evaluation",
-			ParentId: updatedParentEvaluationID,
-		})
-
-		// then
-		assert.NoError(t, err)
-		assert.Equal(t, existingEvaluationName, eval.Name)
-		assert.NotEqual(t, parentEvaluationID, server.evaluation[evaluationID])
-		assert.Equal(t, int64(updatedParentEvaluationID), server.evaluation[evaluationID])
-	})
-
-	t.Run("should return 500 when evaluation does not exist", func(t *testing.T) {
+func TestClient_AddTag(t *testing.T) {
+	t.Run("should add tag to existing evaluation", func(t *testing.T) {
 		// given
 		server := newServer(t)
 		mockServer := fixHTTPServer(server)
@@ -263,29 +200,60 @@ func TestClient_UpdateEvaluation(t *testing.T) {
 		}, logrus.New())
 		assert.NoError(t, err)
 
-		// when
-		eval, err := client.UpdateEvaluation(strconv.Itoa(evaluationID), &BasicEvaluationCreateRequest{
+		response, err := client.CreateEvaluation(&BasicEvaluationCreateRequest{
 			Name:     "test_evaluation",
-			ParentId: updatedParentEvaluationID,
+			ParentId: parentEvaluationID,
 		})
+		assert.NoError(t, err)
+
+		fixedTag := fixTag()
+
+		// when
+		eval, err := client.AddTag(response.Id, fixedTag)
 
 		// then
-		assert.Error(t, err)
-		assert.Equal(t, "", eval.Name)
-		assert.Contains(t, err.Error(), "500")
+		assert.NoError(t, err)
+		assert.Equal(t, fixedTag, eval.Tags[0])
 	})
+}
+
+// evaluationRepository represents BasicEvaluations in AVS
+//where basicEvals is mapping BasicEvaluation ID to BasicEvaluation (Subevaluation) definition
+//and parentIDrefs is mapping CompoundEvaluation ID (parentID) to BasicEvaluations (Subevaluations) IDs
+type evaluationRepository struct {
+	basicEvals   map[int64]*BasicEvaluationCreateResponse
+	parentIDrefs map[int64][]int64
+}
+
+func (er *evaluationRepository) addEvaluation(parentID int64, eval *BasicEvaluationCreateResponse) {
+	er.basicEvals[eval.Id] = eval
+	er.parentIDrefs[parentID] = append(er.parentIDrefs[parentID], eval.Id)
+}
+
+func (er *evaluationRepository) removeParentRef(parentID, evalID int64) {
+	refs := er.parentIDrefs[parentID]
+
+	for i, evalWithRef := range refs {
+		if evalID == evalWithRef {
+			refs[i] = refs[len(refs)-1]
+			er.parentIDrefs[parentID] = refs[:len(refs)-1]
+		}
+	}
 }
 
 type server struct {
 	t            *testing.T
-	evaluation   map[int64]int64
+	evaluations  *evaluationRepository
 	tokenExpired int
 }
 
 func newServer(t *testing.T) *server {
 	return &server{
-		t:          t,
-		evaluation: make(map[int64]int64, 0),
+		t: t,
+		evaluations: &evaluationRepository{
+			basicEvals:   make(map[int64]*BasicEvaluationCreateResponse, 0),
+			parentIDrefs: make(map[int64][]int64, 0),
+		},
 	}
 }
 
@@ -296,7 +264,7 @@ func fixHTTPServer(srv *server) *httptest.Server {
 	r.HandleFunc("/api/v2/evaluationmetadata", srv.createEvaluation).Methods(http.MethodPost)
 	r.HandleFunc("/api/v2/evaluationmetadata/{evalId}", srv.deleteEvaluation).Methods(http.MethodDelete)
 	r.HandleFunc("/api/v2/evaluationmetadata/{evalId}", srv.getEvaluation).Methods(http.MethodGet)
-	r.HandleFunc("/api/v2/evaluationmetadata/{evalId}", srv.updateEvaluation).Methods(http.MethodPut)
+	r.HandleFunc("/api/v2/evaluationmetadata/{evalId}/tag", srv.addTagToEvaluation).Methods(http.MethodPost)
 	r.HandleFunc("/api/v2/evaluationmetadata/{parentId}/child/{evalId}", srv.removeReferenceFromParentEval).Methods(http.MethodDelete)
 
 	return httptest.NewServer(r)
@@ -342,12 +310,11 @@ func (s *server) createEvaluation(w http.ResponseWriter, r *http.Request) {
 	err := json.NewDecoder(r.Body).Decode(&requestObj)
 	assert.NoError(s.t, err)
 
-	s.evaluation[evaluationID] = parentEvaluationID
+	evalCreateResponse := createResponseObj(requestObj)
+	s.evaluations.addEvaluation(requestObj.ParentId, evalCreateResponse)
 
-	response := BasicEvaluationCreateResponse{
-		Name: requestObj.Name,
-	}
-	responseObjAsBytes, _ := json.Marshal(response)
+	createdEval := s.evaluations.basicEvals[evalCreateResponse.Id]
+	responseObjAsBytes, _ := json.Marshal(createdEval)
 	_, err = w.Write(responseObjAsBytes)
 	assert.NoError(s.t, err)
 
@@ -366,7 +333,7 @@ func (s *server) getEvaluation(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-	_, exists := s.evaluation[evalId]
+	_, exists := s.evaluations.basicEvals[evalId]
 	if !exists {
 		w.WriteHeader(http.StatusNotFound)
 	}
@@ -379,14 +346,14 @@ func (s *server) getEvaluation(w http.ResponseWriter, r *http.Request) {
 	assert.NoError(s.t, err)
 }
 
-func (s *server) updateEvaluation(w http.ResponseWriter, r *http.Request) {
+func (s *server) addTagToEvaluation(w http.ResponseWriter, r *http.Request) {
 	assert.Equal(s.t, r.Header.Get("Content-Type"), "application/json")
 	if !s.hasAccess(r.Header.Get("Authorization")) {
 		w.WriteHeader(http.StatusUnauthorized)
 		return
 	}
 
-	var requestObj BasicEvaluationCreateRequest
+	var requestObj *Tag
 	err := json.NewDecoder(r.Body).Decode(&requestObj)
 	assert.NoError(s.t, err)
 
@@ -395,17 +362,14 @@ func (s *server) updateEvaluation(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
 	}
-	_, exists := s.evaluation[evalId]
+	evaluation, exists := s.evaluations.basicEvals[evalId]
 	if !exists {
-		w.WriteHeader(http.StatusInternalServerError) // avs API returns 500 when trying to update non-existing evaluation
+		w.WriteHeader(http.StatusNotFound)
 	}
 
-	s.evaluation[evalId] = requestObj.ParentId
+	evaluation.Tags = append(evaluation.Tags, requestObj)
 
-	response := BasicEvaluationCreateResponse{
-		Name: existingEvaluationName,
-	}
-	responseObjAsBytes, _ := yaml.Marshal(response)
+	responseObjAsBytes, _ := json.Marshal(evaluation)
 	_, err = w.Write(responseObjAsBytes)
 	assert.NoError(s.t, err)
 }
@@ -420,8 +384,8 @@ func (s *server) deleteEvaluation(w http.ResponseWriter, r *http.Request) {
 	id, err := strconv.ParseInt(vars["evalId"], 10, 64)
 	assert.NoError(s.t, err)
 
-	if _, ok := s.evaluation[id]; ok {
-		s.evaluation = map[int64]int64{}
+	if _, exists := s.evaluations.basicEvals[id]; exists {
+		delete(s.evaluations.basicEvals, id)
 		w.WriteHeader(http.StatusOK)
 		return
 	}
@@ -436,17 +400,69 @@ func (s *server) removeReferenceFromParentEval(w http.ResponseWriter, r *http.Re
 	}
 
 	vars := mux.Vars(r)
-	n, err := strconv.ParseInt(vars["parentId"], 10, 64)
+	parentID, err := strconv.ParseInt(vars["parentId"], 10, 64)
 	assert.NoError(s.t, err)
 
-	id, err := strconv.ParseInt(vars["evalId"], 10, 64)
+	evalID, err := strconv.ParseInt(vars["evalId"], 10, 64)
 	assert.NoError(s.t, err)
 
-	if s.evaluation[id] == n {
-		delete(s.evaluation, id)
-		w.WriteHeader(http.StatusOK)
-		return
+	_, exists := s.evaluations.parentIDrefs[parentID]
+	if !exists {
+		w.WriteHeader(http.StatusNotFound)
 	}
 
-	w.WriteHeader(http.StatusNotFound)
+	s.evaluations.removeParentRef(parentID, evalID)
+}
+
+func fixTag() *Tag {
+	return &Tag{
+		Content:    "test-tag",
+		TagClassId: 111111,
+	}
+}
+
+func createResponseObj(requestObj BasicEvaluationCreateRequest) *BasicEvaluationCreateResponse {
+	parsedThreshold, err := strconv.ParseInt(requestObj.Threshold, 10, 64)
+	if err != nil {
+		parsedThreshold = int64(1234)
+	}
+
+	timeUnixEpoch, id := generateId()
+
+	evalCreateResponse := &BasicEvaluationCreateResponse{
+		DefinitionType:             requestObj.DefinitionType,
+		Name:                       requestObj.Name,
+		Description:                requestObj.Description,
+		Service:                    requestObj.Service,
+		URL:                        requestObj.URL,
+		CheckType:                  requestObj.CheckType,
+		Interval:                   requestObj.Interval,
+		TesterAccessId:             requestObj.TesterAccessId,
+		Timeout:                    requestObj.Timeout,
+		ReadOnly:                   requestObj.ReadOnly,
+		ContentCheck:               requestObj.ContentCheck,
+		ContentCheckType:           requestObj.ContentCheck,
+		Threshold:                  parsedThreshold,
+		GroupId:                    requestObj.GroupId,
+		Visibility:                 requestObj.Visibility,
+		DateCreated:                timeUnixEpoch,
+		DateChanged:                timeUnixEpoch,
+		Owner:                      "abc@xyz.corp",
+		Status:                     "ACTIVE",
+		Alerts:                     nil,
+		Tags:                       requestObj.Tags,
+		Id:                         id,
+		LegacyCheckId:              id,
+		InternalInterval:           60,
+		AuthType:                   "AUTH_NONE",
+		IndividualOutageEventsOnly: false,
+		IdOnTester:                 "",
+	}
+	return evalCreateResponse
+}
+
+func generateId() (int64, int64) {
+	timeUnixEpoch := time.Now().Unix()
+	id := time.Now().Unix()
+	return timeUnixEpoch, id
 }

--- a/components/kyma-environment-broker/internal/avs/client_test.go
+++ b/components/kyma-environment-broker/internal/avs/client_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+	"gopkg.in/yaml.v2"
 
 	"github.com/gorilla/mux"
 	"github.com/stretchr/testify/assert"
@@ -404,7 +405,7 @@ func (s *server) updateEvaluation(w http.ResponseWriter, r *http.Request) {
 	response := BasicEvaluationCreateResponse{
 		Name: existingEvaluationName,
 	}
-	responseObjAsBytes, _ := json.Marshal(response)
+	responseObjAsBytes, _ := yaml.Marshal(response)
 	_, err = w.Write(responseObjAsBytes)
 	assert.NoError(s.t, err)
 }

--- a/components/kyma-environment-broker/internal/avs/config.go
+++ b/components/kyma-environment-broker/internal/avs/config.go
@@ -23,6 +23,7 @@ type Config struct {
 	ExternalTesterService       string `envconfig:"optional"`
 	ExternalTesterTags          []*Tag `envconfig:"optional"`
 	ParentId                    int64
+	AdditionalTagsEnabled       bool
 	GardenerShootNameTagClassId int
 	GardenerSeedNameTagClassId  int
 	RegionTagClassId            int

--- a/components/kyma-environment-broker/internal/avs/config.go
+++ b/components/kyma-environment-broker/internal/avs/config.go
@@ -7,20 +7,23 @@ type Tag struct {
 }
 
 type Config struct {
-	OauthTokenEndpoint     string
-	OauthUsername          string
-	OauthPassword          string
-	OauthClientId          string
-	ApiEndpoint            string
-	DefinitionType         string `envconfig:"default=BASIC"`
-	ApiKey                 string
-	Disabled               bool `envconfig:"default=false"`
-	InternalTesterAccessId int64
-	InternalTesterService  string `envconfig:"optional"`
-	InternalTesterTags     []*Tag `envconfig:"optional"`
-	GroupId                int64
-	ExternalTesterAccessId int64
-	ExternalTesterService  string `envconfig:"optional"`
-	ExternalTesterTags     []*Tag `envconfig:"optional"`
-	ParentId               int64
+	OauthTokenEndpoint          string
+	OauthUsername               string
+	OauthPassword               string
+	OauthClientId               string
+	ApiEndpoint                 string
+	DefinitionType              string `envconfig:"default=BASIC"`
+	ApiKey                      string
+	Disabled                    bool `envconfig:"default=false"`
+	InternalTesterAccessId      int64
+	InternalTesterService       string `envconfig:"optional"`
+	InternalTesterTags          []*Tag `envconfig:"optional"`
+	GroupId                     int64
+	ExternalTesterAccessId      int64
+	ExternalTesterService       string `envconfig:"optional"`
+	ExternalTesterTags          []*Tag `envconfig:"optional"`
+	ParentId                    int64
+	GardenerShootNameTagClassId int
+	GardenerSeedNameTagClassId  int
+	RegionTagClassId            int
 }

--- a/components/kyma-environment-broker/internal/avs/delegator.go
+++ b/components/kyma-environment-broker/internal/avs/delegator.go
@@ -104,7 +104,7 @@ func (del *Delegator) GetEvaluation(logger logrus.FieldLogger, operation interna
 	default:
 		errMsg := "cannot get AVS evaluation"
 		logger.Errorf("%s: %s", errMsg, err)
-		op, duration, err :=  del.operationManager.OperationFailed(operation, errMsg)
+		op, duration, err := del.operationManager.OperationFailed(operation, errMsg)
 		return op, &BasicEvaluationCreateResponse{}, duration, err
 	}
 
@@ -113,8 +113,8 @@ func (del *Delegator) GetEvaluation(logger logrus.FieldLogger, operation interna
 	return updatedOperation, evalResp, d, nil
 }
 
-func (del *Delegator) UpdateEvaluation(logger logrus.FieldLogger, operation internal.ProvisioningOperation,  evaluation *BasicEvaluationCreateResponse, evalAssistant EvalAssistant, url string) (internal.ProvisioningOperation, time.Duration, error) {
-	logger.Infof("starting the update avs internal id [%d] and avs external id [%d]", operation.Avs.AvsEvaluationInternalId, operation.Avs.AVSEvaluationExternalId)
+func (del *Delegator) UpdateEvaluation(logger logrus.FieldLogger, operation internal.ProvisioningOperation, evaluation *BasicEvaluationCreateResponse, evalAssistant EvalAssistant, url string) (internal.ProvisioningOperation, time.Duration, error) {
+	logger.Infof("starting the update avs internal id [%d]", operation.Avs.AvsEvaluationInternalId)
 
 	var updatedOperation internal.ProvisioningOperation
 	d := 0 * time.Second
@@ -139,7 +139,8 @@ func (del *Delegator) UpdateEvaluation(logger logrus.FieldLogger, operation inte
 	}
 	logger.Infof("making avs calls to update the Evaluation")
 
-	updateResp, err := del.client.UpdateEvaluation(updatedEvaluation)
+	evalId := evalAssistant.GetEvaluationId(operation.Avs)
+	updateResp, err := del.client.UpdateEvaluation(strconv.FormatInt(evalId, 10), updatedEvaluation)
 	switch {
 	case err == nil:
 	case kebError.IsTemporaryError(err):
@@ -153,7 +154,7 @@ func (del *Delegator) UpdateEvaluation(logger logrus.FieldLogger, operation inte
 		return del.operationManager.OperationFailed(operation, errMsg)
 	}
 
-	logger.Infof("Successfully updated evaluation %s", updateResp.Id)
+	logger.Infof("Successfully updated evaluation %s", strconv.FormatInt(updateResp.Id, 10))
 
 	updatedOperation, d = del.operationManager.UpdateOperation(operation)
 

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -41,16 +41,16 @@ type KymaVersionConfigurator interface {
 }
 
 type InitialisationStep struct {
-	operationManager       *process.ProvisionOperationManager
-	instanceStorage        storage.Instances
-	provisionerClient      provisioner.Client
-	directorClient         DirectorClient
-	inputBuilder           input.CreatorForPlan
-	externalEvalCreator    *ExternalEvalCreator
-	internalEvalUpdater    *InternalEvalUpdater
-	iasType                *IASType
-	provisioningTimeout    time.Duration
-	runtimeVerConfigurator RuntimeVersionConfiguratorForProvisioning
+	operationManager            *process.ProvisionOperationManager
+	instanceStorage             storage.Instances
+	provisionerClient           provisioner.Client
+	directorClient              DirectorClient
+	inputBuilder                input.CreatorForPlan
+	externalEvalCreator         *ExternalEvalCreator
+	internalEvalUpdater         *InternalEvalUpdater
+	iasType                     *IASType
+	provisioningTimeout         time.Duration
+	runtimeVerConfigurator      RuntimeVersionConfiguratorForProvisioning
 	serviceManagerClientFactory *servicemanager.ClientFactory
 }
 
@@ -66,16 +66,16 @@ func NewInitialisationStep(os storage.Operations,
 	rvc RuntimeVersionConfiguratorForProvisioning,
 	smcf *servicemanager.ClientFactory) *InitialisationStep {
 	return &InitialisationStep{
-		operationManager:       process.NewProvisionOperationManager(os),
-		instanceStorage:        is,
-		provisionerClient:      pc,
-		directorClient:         dc,
-		inputBuilder:           b,
-		externalEvalCreator:    avsExternalEvalCreator,
-		internalEvalUpdater:    avsInternalEvalUpdater,
-		iasType:                iasType,
-		provisioningTimeout:    timeout,
-		runtimeVerConfigurator: rvc,
+		operationManager:            process.NewProvisionOperationManager(os),
+		instanceStorage:             is,
+		provisionerClient:           pc,
+		directorClient:              dc,
+		inputBuilder:                b,
+		externalEvalCreator:         avsExternalEvalCreator,
+		internalEvalUpdater:         avsInternalEvalUpdater,
+		iasType:                     iasType,
+		provisioningTimeout:         timeout,
+		runtimeVerConfigurator:      rvc,
 		serviceManagerClientFactory: smcf,
 	}
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -227,7 +227,7 @@ func (s *InitialisationStep) launchPostActions(operation internal.ProvisioningOp
 	}
 
 	// action #2
-	tags, operation, repeat, err := s.createTagsForRuntime(operation)
+	tags, operation, repeat, err := s.createTagsForRuntime(operation, instance)
 	if err != nil || repeat != 0 {
 		log.Errorf("while adding Tags to Evaluation: %s", err)
 		return operation, repeat, nil
@@ -256,11 +256,7 @@ func (s *InitialisationStep) launchPostActions(operation internal.ProvisioningOp
 	return s.operationManager.OperationSucceeded(operation, msg)
 }
 
-func (s *InitialisationStep) createTagsForRuntime(operation internal.ProvisioningOperation) ([]*avs.Tag, internal.ProvisioningOperation, time.Duration, error) {
-	instance, err := s.instanceStorage.GetByID(operation.InstanceID)
-	if err != nil {
-		return []*avs.Tag{}, operation, 10 * time.Second, err
-	}
+func (s *InitialisationStep) createTagsForRuntime(operation internal.ProvisioningOperation, instance *internal.Instance) ([]*avs.Tag, internal.ProvisioningOperation, time.Duration, error) {
 
 	status, err := s.provisionerClient.RuntimeStatus(instance.GlobalAccountID, operation.RuntimeID)
 	if err != nil {
@@ -268,20 +264,17 @@ func (s *InitialisationStep) createTagsForRuntime(operation internal.Provisionin
 	}
 
 	result := []*avs.Tag{
-		&avs.Tag{
-			Content:      ptr.ToString(status.RuntimeConfiguration.ClusterConfig.Name),
-			TagClassId:   s.internalEvalUpdater.avsConfig.GardenerShootNameTagClassId,
-			TagClassName: "gardener_shoot_name",
+		{
+			Content:    ptr.ToString(status.RuntimeConfiguration.ClusterConfig.Name),
+			TagClassId: s.internalEvalUpdater.avsConfig.GardenerShootNameTagClassId,
 		},
-		&avs.Tag{
-			Content:      ptr.ToString(status.RuntimeConfiguration.ClusterConfig.Seed),
-			TagClassId:   s.internalEvalUpdater.avsConfig.GardenerSeedNameTagClassId,
-			TagClassName: "gardener_seed_name",
+		{
+			Content:    ptr.ToString(status.RuntimeConfiguration.ClusterConfig.Seed),
+			TagClassId: s.internalEvalUpdater.avsConfig.GardenerSeedNameTagClassId,
 		},
-		&avs.Tag{
-			Content:      ptr.ToString(status.RuntimeConfiguration.ClusterConfig.Region),
-			TagClassId:   s.internalEvalUpdater.avsConfig.RegionTagClassId,
-			TagClassName: "region",
+		{
+			Content:    ptr.ToString(status.RuntimeConfiguration.ClusterConfig.Region),
+			TagClassId: s.internalEvalUpdater.avsConfig.RegionTagClassId,
 		},
 	}
 

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
@@ -280,7 +280,7 @@ func fixAvsEvaluation() *avs.BasicEvaluationCreateResponse {
 		Status:           "ACTIVE",
 		Alerts:           nil,
 		Tags: []*avs.Tag{
-			&avs.Tag{
+			{
 				Content:      "already-exist-tag",
 				TagClassId:   123456,
 				TagClassName: "already-exist-tag-classname",

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation_test.go
@@ -80,11 +80,7 @@ func TestInitialisationStep(t *testing.T) {
 		externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
 		externalEvalCreator := NewExternalEvalCreator(avsDel, false, externalEvalAssistant)
 		internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
-		InternalEvalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avs.Config{
-			GardenerShootNameTagClassId: 11111,
-			GardenerSeedNameTagClassId:  22222,
-			RegionTagClassId:            33333,
-		})
+		InternalEvalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avsConfig)
 		iasType := NewIASType(nil, true)
 
 		rvc := &automock.RuntimeVersionConfiguratorForProvisioning{}
@@ -112,6 +108,8 @@ func TestInitialisationStep(t *testing.T) {
 		inDB, err := memoryStorage.Operations().GetProvisioningOperationByID(operation.ID)
 		assert.NoError(t, err)
 		assert.Contains(t, mockAvsSvc.evals, inDB.Avs.AVSEvaluationExternalId)
+		assert.Contains(t, mockAvsSvc.evals, inDB.Avs.AvsEvaluationInternalId)
+		assert.Equal(t, 4, len(mockAvsSvc.evals[inDB.Avs.AvsEvaluationInternalId].Tags))
 	})
 
 	t.Run("run unintialized", func(t *testing.T) {
@@ -159,11 +157,7 @@ func TestInitialisationStep(t *testing.T) {
 		externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
 		externalEvalCreator := NewExternalEvalCreator(avsDel, false, externalEvalAssistant)
 		internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
-		InternalEvalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avs.Config{
-			GardenerShootNameTagClassId: 11111,
-			GardenerSeedNameTagClassId:  22222,
-			RegionTagClassId:            33333,
-		})
+		InternalEvalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avsConfig)
 		iasType := NewIASType(nil, true)
 
 		rvc := &automock.RuntimeVersionConfiguratorForProvisioning{}
@@ -191,6 +185,8 @@ func TestInitialisationStep(t *testing.T) {
 		inDB, err := memoryStorage.Operations().GetProvisioningOperationByID(operation.ID)
 		assert.NoError(t, err)
 		assert.Contains(t, mockAvsSvc.evals, inDB.Avs.AVSEvaluationExternalId)
+		assert.Contains(t, mockAvsSvc.evals, inDB.Avs.AvsEvaluationInternalId)
+		assert.Equal(t, 4, len(mockAvsSvc.evals[inDB.Avs.AvsEvaluationInternalId].Tags))
 	})
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
@@ -223,7 +223,7 @@ func avsConfig(mockOauthServer *httptest.Server, mockAvsServer *httptest.Server)
 		ExternalTesterAccessId: 5678,
 		ExternalTesterService:  dummyStrAvsTest,
 		ExternalTesterTags: []*avs.Tag{
-			&avs.Tag{
+			{
 				Content:      dummyStrAvsTest,
 				TagClassId:   123,
 				TagClassName: dummyStrAvsTest,

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
@@ -229,9 +229,13 @@ func avsConfig(mockOauthServer *httptest.Server, mockAvsServer *httptest.Server)
 				TagClassName: dummyStrAvsTest,
 			},
 		},
-		GroupId:  5555,
-		ParentId: 9101112,
-		ApiKey:   dummyStrAvsTest,
+		GroupId:                     5555,
+		ParentId:                    9101112,
+		ApiKey:                      dummyStrAvsTest,
+		AdditionalTagsEnabled:       true,
+		GardenerSeedNameTagClassId:  111111,
+		GardenerShootNameTagClassId: 111112,
+		RegionTagClassId:            111113,
 	}
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
@@ -11,27 +11,25 @@ import (
 type InternalEvalUpdater struct {
 	delegator *avs.Delegator
 	assistant *avs.InternalEvalAssistant
+	avsConfig avs.Config
 }
 
-func NewInternalEvalUpdater(delegator *avs.Delegator, assistant *avs.InternalEvalAssistant) *InternalEvalUpdater {
+func NewInternalEvalUpdater(delegator *avs.Delegator, assistant *avs.InternalEvalAssistant, config avs.Config) *InternalEvalUpdater {
 	return &InternalEvalUpdater{
 		delegator: delegator,
 		assistant: assistant,
+		avsConfig: config,
 	}
 }
 
-func (ieu *InternalEvalUpdater) addEvalTags(operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
-	// get current Evaluation
+func (ieu *InternalEvalUpdater) AddTagsToEval(tags []*avs.Tag, operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
 	op, eval, duration, err := ieu.delegator.GetEvaluation(logger, operation, ieu.assistant)
 	if err != nil {
+		logger.Errorf("while getting Evaluations: %s", err)
 		return op, duration, err
 	}
 
-	eval.Tags = append(eval.Tags, &avs.Tag{
-		Content:      "test-content-region",
-		TagClassId:   61251099,
-		TagClassName: "region",
-	})
-	
-	return ieu.delegator.UpdateEvaluation(logger, operation, eval, ieu.assistant, url)
+	eval.Tags = append(eval.Tags, tags...)
+
+	return ieu.delegator.UpdateEvaluation(logger, op, eval, ieu.assistant, url)
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
@@ -23,6 +23,10 @@ func NewInternalEvalUpdater(delegator *avs.Delegator, assistant *avs.InternalEva
 }
 
 func (ieu *InternalEvalUpdater) AddTagsToEval(tags []*avs.Tag, operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
+	if !ieu.avsConfig.AdditionalTagsEnabled {
+		logger.Infof("Adding additional tags to AVS evaluation is disabled")
+		return operation, 0 * time.Second, nil
+	}
 	op, eval, duration, err := ieu.delegator.GetEvaluation(logger, operation, ieu.assistant)
 	if err != nil {
 		logger.Errorf("while getting Evaluations: %s", err)

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
@@ -1,0 +1,37 @@
+package provisioning
+
+import (
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs"
+	"github.com/sirupsen/logrus"
+)
+
+type InternalEvalUpdater struct {
+	delegator *avs.Delegator
+	assistant *avs.InternalEvalAssistant
+}
+
+func NewInternalEvalUpdater(delegator *avs.Delegator, assistant *avs.InternalEvalAssistant) *InternalEvalUpdater {
+	return &InternalEvalUpdater{
+		delegator: delegator,
+		assistant: assistant,
+	}
+}
+
+func (ieu *InternalEvalUpdater) addEvalTags(operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
+	// get current Evaluation
+	op, eval, duration, err := ieu.delegator.GetEvaluation(logger, operation, ieu.assistant)
+	if err != nil {
+		return op, duration, err
+	}
+
+	eval.Tags = append(eval.Tags, &avs.Tag{
+		Content:      "test-content-region",
+		TagClassId:   61251099,
+		TagClassName: "region",
+	})
+	
+	return ieu.delegator.UpdateEvaluation(logger, operation, eval, ieu.assistant, url)
+}

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater.go
@@ -27,13 +27,6 @@ func (ieu *InternalEvalUpdater) AddTagsToEval(tags []*avs.Tag, operation interna
 		logger.Infof("Adding additional tags to AVS evaluation is disabled")
 		return operation, 0 * time.Second, nil
 	}
-	op, eval, duration, err := ieu.delegator.GetEvaluation(logger, operation, ieu.assistant)
-	if err != nil {
-		logger.Errorf("while getting Evaluations: %s", err)
-		return op, duration, err
-	}
 
-	eval.Tags = append(eval.Tags, tags...)
-
-	return ieu.delegator.UpdateEvaluation(logger, op, eval, ieu.assistant, url)
+	return ieu.delegator.AddTags(logger, operation, ieu.assistant, tags)
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater_test.go
@@ -64,11 +64,7 @@ func TestInternalEvalUpdater_AddTagsToEval(t *testing.T) {
 	assert.NoError(t, err)
 	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
 	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
-	evalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avs.Config{
-		GardenerShootNameTagClassId: 11111,
-		GardenerSeedNameTagClassId:  22222,
-		RegionTagClassId:            33333,
-	})
+	evalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avsConfig)
 
 	// when
 	_, repeat, err := evalUpdater.AddTagsToEval([]*avs.Tag{

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_updater_test.go
@@ -1,0 +1,92 @@
+package provisioning
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/pivotal-cf/brokerapi/v7/domain"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	FixAvsEvaluationInternalId = int64(11111)
+	FixAvsEvaluationExternalId = int64(22222)
+)
+
+func TestInternalEvalUpdater_AddTagsToEval(t *testing.T) {
+	// given
+	log := logrus.New()
+	memoryStorage := storage.NewMemoryStorage()
+	operation := internal.ProvisioningOperation{
+		Operation: internal.Operation{
+			ID:          operationID,
+			InstanceID:  instanceID,
+			Description: "",
+			UpdatedAt:   time.Now(),
+			State:       domain.InProgress,
+		},
+		ProvisioningParameters: fixProvisioningParameters(t),
+		InputCreator:           newInputCreator(),
+		Avs: internal.AvsLifecycleData{
+			AvsEvaluationInternalId:      FixAvsEvaluationInternalId,
+			AVSEvaluationExternalId:      FixAvsEvaluationExternalId,
+			AVSInternalEvaluationDeleted: false,
+			AVSExternalEvaluationDeleted: false,
+		},
+	}
+
+	err := memoryStorage.Operations().InsertProvisioningOperation(operation)
+	assert.NoError(t, err)
+
+	mockOauthServer := newMockAvsOauthServer()
+	defer mockOauthServer.Close()
+	mockAvsSvc := newMockAvsService(t, true)
+	mockAvsSvc.startServer()
+	mockAvsSvc.evals[FixAvsEvaluationInternalId] = &avs.BasicEvaluationCreateResponse{
+		Name: "test-eval",
+		Tags: []*avs.Tag{
+			&avs.Tag{
+				Content:      "already-exist-tag",
+				TagClassId:   00,
+				TagClassName: "already-exist-class-name",
+			}},
+		Id: FixAvsEvaluationInternalId,
+	}
+	defer mockAvsSvc.server.Close()
+
+	avsConfig := avsConfig(mockOauthServer, mockAvsSvc.server)
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig, logrus.New())
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
+	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
+	evalUpdater := NewInternalEvalUpdater(avsDel, internalEvalAssistant, avs.Config{
+		GardenerShootNameTagClassId: 11111,
+		GardenerSeedNameTagClassId:  22222,
+		RegionTagClassId:            33333,
+	})
+
+	// when
+	_, repeat, err := evalUpdater.AddTagsToEval([]*avs.Tag{
+		&avs.Tag{
+			Content:      "first-tag",
+			TagClassId:   11,
+			TagClassName: "first-tag-class-name",
+		},
+		&avs.Tag{
+			Content:      "second-tag",
+			TagClassId:   22,
+			TagClassName: "second-tag-class-name",
+		},
+	}, operation, "", log)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), repeat)
+	assert.Equal(t, 3, len(mockAvsSvc.evals[FixAvsEvaluationInternalId].Tags))
+
+}

--- a/components/kyma-environment-broker/internal/provisioner/automock/client.go
+++ b/components/kyma-environment-broker/internal/provisioner/automock/client.go
@@ -96,6 +96,27 @@ func (_m *Client) RuntimeOperationStatus(accountID string, operationID string) (
 	return r0, r1
 }
 
+// RuntimeStatus provides a mock function with given fields: accountID, runtimeID
+func (_m *Client) RuntimeStatus(accountID string, runtimeID string) (gqlschema.RuntimeStatus, error) {
+	ret := _m.Called(accountID, runtimeID)
+
+	var r0 gqlschema.RuntimeStatus
+	if rf, ok := ret.Get(0).(func(string, string) gqlschema.RuntimeStatus); ok {
+		r0 = rf(accountID, runtimeID)
+	} else {
+		r0 = ret.Get(0).(gqlschema.RuntimeStatus)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(accountID, runtimeID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // UpgradeRuntime provides a mock function with given fields: accountID, runtimeID, config
 func (_m *Client) UpgradeRuntime(accountID string, runtimeID string, config gqlschema.UpgradeRuntimeInput) (gqlschema.OperationStatus, error) {
 	ret := _m.Called(accountID, runtimeID, config)

--- a/components/kyma-environment-broker/internal/provisioner/client.go
+++ b/components/kyma-environment-broker/internal/provisioner/client.go
@@ -27,6 +27,7 @@ type Client interface {
 	UpgradeRuntime(accountID, runtimeID string, config schema.UpgradeRuntimeInput) (schema.OperationStatus, error)
 	ReconnectRuntimeAgent(accountID, runtimeID string) (string, error)
 	RuntimeOperationStatus(accountID, operationID string) (schema.OperationStatus, error)
+	RuntimeStatus(accountID, runtimeID string) (schema.RuntimeStatus, error)
 }
 
 type client struct {
@@ -123,6 +124,19 @@ func (c *client) RuntimeOperationStatus(accountID, operationID string) (schema.O
 	err := c.executeRequest(req, &response)
 	if err != nil {
 		return schema.OperationStatus{}, errors.Wrap(err, "Failed to get Runtime operation status")
+	}
+	return response, nil
+}
+
+func (c *client) RuntimeStatus(accountID, runtimeID string) (schema.RuntimeStatus, error) {
+	query := c.queryProvider.runtimeStatus(runtimeID)
+	req := gcli.NewRequest(query)
+	req.Header.Add(accountIDKey, accountID)
+
+	var response schema.RuntimeStatus
+	err := c.executeRequest(req, &response)
+	if err != nil {
+		return schema.RuntimeStatus{}, errors.Wrap(err, "Failed to get Runtime status")
 	}
 	return response, nil
 }

--- a/components/kyma-environment-broker/internal/provisioner/fake_client.go
+++ b/components/kyma-environment-broker/internal/provisioner/fake_client.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	schema "github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 )
 
@@ -103,6 +104,21 @@ func (c *FakeClient) RuntimeOperationStatus(accountID, operationID string) (sche
 		return schema.OperationStatus{}, fmt.Errorf("operation not found")
 	}
 	return o, nil
+}
+
+func (c *FakeClient) RuntimeStatus(accountID, runtimeID string) (schema.RuntimeStatus, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return schema.RuntimeStatus{
+		RuntimeConfiguration: &schema.RuntimeConfig{
+			ClusterConfig: &schema.GardenerConfig{
+				Name:   ptr.String("fake-name"),
+				Region: ptr.String("fake-region"),
+				Seed:   ptr.String("fake-seed"),
+			},
+		},
+	}, nil
 }
 
 func (c *FakeClient) UpgradeRuntime(accountID, runtimeID string, config schema.UpgradeRuntimeInput) (schema.OperationStatus, error) {

--- a/components/kyma-environment-broker/internal/provisioner/query.go
+++ b/components/kyma-environment-broker/internal/provisioner/query.go
@@ -32,12 +32,12 @@ func (qp queryProvider) reconnectRuntimeAgent(runtimeID string) string {
 }`, runtimeID)
 }
 
-func (qp queryProvider) runtimeStatus(operationID string) string {
+func (qp queryProvider) runtimeStatus(runtimeID string) string {
 	return fmt.Sprintf(`query {
 	result: runtimeStatus(id: "%s") {
 	%s
 	}
-}`, operationID, runtimeStatusData())
+}`, runtimeID, runtimeStatusData())
 }
 
 func (qp queryProvider) runtimeOperationStatus(operationID string) string {
@@ -86,7 +86,7 @@ func clusterConfig() string {
 func providerSpecificConfig() string {
 	return fmt.Sprint(`
 		... on GCPProviderConfig { 
-			zone 
+			zones 
 		} 
 		... on AzureProviderConfig {
 			vnetCidr

--- a/components/kyma-environment-broker/internal/ptr/ptr.go
+++ b/components/kyma-environment-broker/internal/ptr/ptr.go
@@ -10,6 +10,13 @@ func String(str string) *string {
 	return &str
 }
 
+func ToString(s *string) string {
+	if s != nil {
+		return *s
+	}
+	return ""
+}
+
 func Integer(in int) *int {
 	return &in
 }

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -264,11 +264,11 @@ spec:
                   key: parentId
                   name: {{ .Values.avs.secretName }}
             - name: APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID
-              value: {{ .Values.avs.gardenerShootNameTagClassId }}
+              value: "{{ .Values.avs.gardenerShootNameTagClassId }}"
             - name: APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID
-              value: {{ .Values.avs.gardenerSeedNameTagClassId }}
+              value: "{{ .Values.avs.gardenerSeedNameTagClassId }}"
             - name: APP_AVS_REGION_TAG_CLASS_ID
-              value: {{ .Values.avs.regionTagClassId }}
+              value: "{{ .Values.avs.regionTagClassId }}"
             - name: APP_KYMA_VERSION
               value: {{ .Values.kymaVersion }}
             - name: APP_ENABLE_ON_DEMAND_VERSION

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -263,6 +263,12 @@ spec:
                 secretKeyRef:
                   key: parentId
                   name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID
+              value: {{ .Values.avs.gardenerShootNameTagClassId }}
+            - name: APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID
+              value: {{ .Values.avs.gardenerSeedNameTagClassId }}
+            - name: APP_AVS_REGION_TAG_CLASS_ID
+              value: {{ .Values.avs.regionTagClassId }}
             - name: APP_KYMA_VERSION
               value: {{ .Values.kymaVersion }}
             - name: APP_ENABLE_ON_DEMAND_VERSION

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -263,6 +263,8 @@ spec:
                 secretKeyRef:
                   key: parentId
                   name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_ADDITIONAL_TAGS_ENABLED
+              value: "{{ .Values.avs.additionalTagsEnabled }}"
             - name: APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID
               value: "{{ .Values.avs.gardenerShootNameTagClassId }}"
             - name: APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -121,6 +121,9 @@ avs:
   #     tag_name: value-B
   internalTesterTags: ""
   externalTesterTags: ""
+  gardenerSeedNameTagClassId: "0"
+  gardenerShootNameTagClassId: "0"
+  regionTagClassId: "0"
 
 lms:
   secretName: "lms-creds"

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -121,6 +121,7 @@ avs:
   #     tag_name: value-B
   internalTesterTags: ""
   externalTesterTags: ""
+  additionalTagsEnabled: "false"
   gardenerSeedNameTagClassId: "0"
   gardenerShootNameTagClassId: "0"
   regionTagClassId: "0"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "737d74a8"
     kyma_environment_broker:
       dir:
-      version: "PR-371"
+      version: "PR-361"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added `AddTags` method to AVS client
- Extend `mockAvsServer` with new action
- Added new post-action to `initialisation` step - adding Tags to internal AVS evaluation containing additional information from Provisioner: `gardener_seed_name`, `gardener_shoot_name` and `region` after cluster is provisioned

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
