### PR TITLE
Fix for upgrade concurrency issue in Provisioner

### DIFF
--- a/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
+++ b/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
@@ -344,7 +344,7 @@ func testUpgradeRuntimeAndRollback(t *testing.T, ctx context.Context, resolver *
 	assert.Equal(t, runtimeID, *upgradeRuntimeOp.RuntimeID)
 
 	// wait for queue to process operation
-	time.Sleep(2 * waitPeriod)
+	time.Sleep(8 * waitPeriod)
 
 	// assert db content
 	readSession := dbsFactory.NewReadSession()

--- a/components/provisioner/internal/operations/stages/upgrade/upgrade_kyma.go
+++ b/components/provisioner/internal/operations/stages/upgrade/upgrade_kyma.go
@@ -51,7 +51,7 @@ func (s *UpgradeKymaStep) Run(cluster model.Cluster, _ model.Operation, logger l
 		installErr := installationSDK.InstallationError{}
 		if errors.As(err, &installErr) {
 			logger.Warnf("Upgrade already in progress, proceeding to next step...")
-			return operations.StageResult{Stage: s.nextStep, Delay: 0}, nil
+			return operations.StageResult{Stage: s.nextStep, Delay: 30 * time.Second}, nil
 		}
 
 		return operations.StageResult{}, fmt.Errorf("error: failed to check installation CR state: %s", err.Error())
@@ -75,8 +75,8 @@ func (s *UpgradeKymaStep) Run(cluster model.Cluster, _ model.Operation, logger l
 
 	if installationState.State == "InProgress" {
 		logger.Warnf("Upgrade already in progress, proceeding to next step...")
-		return operations.StageResult{Stage: s.nextStep, Delay: 0}, nil
+		return operations.StageResult{Stage: s.nextStep, Delay: 30 * time.Second}, nil
 	}
 
-	return operations.StageResult{Stage: s.nextStep, Delay: 0}, nil
+	return operations.StageResult{Stage: s.nextStep, Delay: 30 * time.Second}, nil
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -27,7 +27,7 @@ global:
     tests:
       provisioner:
         dir:
-        version: "PR-326"
+        version: "PR-368"
       e2e_provisioning:
         dir:
         version: "PR-314"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

UpgradeKymaStep which is a first step in upgrade doesn't requeue  operation. As a result operation occupies a queue and can starve upgrades waiting in the queue (and they will timeout instantaneously after picking from the queue). 

Changes proposed in this pull request:

- Concurrency level for upgrade operation increased

