### PR TITLE
Update KCP documentation CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,7 +45,7 @@
 /tools/cli @ebensom @fhivemind @lauraanddola @life0215 @lumi017 @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
 
 # All .md files
-*.md @klaudiagrz @kazydek @bszwarc @mmitoraj @majakurcius @alexandra-simeonova
+*.md @klaudiagrz @kazydek @mmitoraj @majakurcius @alexandra-simeonova @superojla
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @aerfio @pPrecel @magicmatatjahu


### PR DESCRIPTION
**Description**

Since Barbara Sz. (@bszwarc) left us in September and is no longer an active contributor, she should be removed from CODEOWNERS.  
At the same time, Justyna Sz. (@superojla) joined us in September and has been contributing to Kyma documentation, so it's time to add her to CODEOWNERS. 

Changes proposed in this pull request:

- Remove @bszwarc from documentation CODEOWNERS
- Add @superojla to documentation CODEOWNERS
