### PR TITLE
Enable internal AVS for trials in separate group

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -275,9 +275,8 @@ func main() {
 			disabled: cfg.XSUAA.Disabled,
 		},
 		{
-			weight: 2,
-			step: provisioning.NewSkipForTrialPlanStep(db.Operations(),
-				provisioning.NewInternalEvaluationStep(avsDel, internalEvalAssistant)),
+			weight:   2,
+			step:     provisioning.NewInternalEvaluationStep(avsDel, internalEvalAssistant),
 			disabled: cfg.Avs.Disabled,
 		},
 		{

--- a/components/kyma-environment-broker/internal/avs/config.go
+++ b/components/kyma-environment-broker/internal/avs/config.go
@@ -27,4 +27,12 @@ type Config struct {
 	GardenerShootNameTagClassId int
 	GardenerSeedNameTagClassId  int
 	RegionTagClassId            int
+	TrialApiKey                 string `envconfig:"optional"`
+	TrialInternalTesterAccessId int64  `envconfig:"optional"`
+	TrialParentId               int64  `envconfig:"optional"`
+	TrialGroupId                int64  `envconfig:"optional"`
+}
+
+func (c Config) IsTrialConfigured() bool {
+	return c.TrialApiKey != "" && c.TrialInternalTesterAccessId != 0 && c.TrialParentId != 0 && c.TrialGroupId != 0
 }

--- a/components/kyma-environment-broker/internal/avs/delegator.go
+++ b/components/kyma-environment-broker/internal/avs/delegator.go
@@ -15,12 +15,6 @@ type Delegator struct {
 	avsConfig         Config
 	client            *Client
 	operationsStorage storage.Operations
-	configForModel    *configForModel
-}
-
-type configForModel struct {
-	groupId  int64
-	parentId int64
 }
 
 type avsNonSuccessResp struct {
@@ -34,10 +28,6 @@ func NewDelegator(client *Client, avsConfig Config, operationsStorage storage.Op
 		avsConfig:         avsConfig,
 		client:            client,
 		operationsStorage: operationsStorage,
-		configForModel: &configForModel{
-			groupId:  avsConfig.GroupId,
-			parentId: avsConfig.ParentId,
-		},
 	}
 }
 
@@ -52,7 +42,7 @@ func (del *Delegator) CreateEvaluation(logger logrus.FieldLogger, operation inte
 		updatedOperation = operation
 	} else {
 		logger.Infof("making avs calls to create the Evaluation")
-		evaluationObject, err := evalAssistant.CreateBasicEvaluationRequest(operation, del.configForModel, url)
+		evaluationObject, err := evalAssistant.CreateBasicEvaluationRequest(operation, url)
 		if err != nil {
 			logger.Errorf("step failed with error %v", err)
 			return operation, 5 * time.Second, nil
@@ -77,7 +67,11 @@ func (del *Delegator) CreateEvaluation(logger logrus.FieldLogger, operation inte
 		updatedOperation, d = del.operationManager.UpdateOperation(operation)
 	}
 
-	evalAssistant.AppendOverrides(updatedOperation.InputCreator, updatedOperation.Avs.AvsEvaluationInternalId)
+	provisionParams, err := updatedOperation.GetProvisioningParameters()
+	if err != nil {
+		return del.operationManager.OperationFailed(updatedOperation, err.Error())
+	}
+	evalAssistant.AppendOverrides(updatedOperation.InputCreator, updatedOperation.Avs.AvsEvaluationInternalId, provisionParams)
 
 	return updatedOperation, d, nil
 }

--- a/components/kyma-environment-broker/internal/avs/eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/eval_assistant.go
@@ -7,8 +7,8 @@ import (
 )
 
 type EvalAssistant interface {
-	CreateBasicEvaluationRequest(operations internal.ProvisioningOperation, configForModel *configForModel, url string) (*BasicEvaluationCreateRequest, error)
-	AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64)
+	CreateBasicEvaluationRequest(operations internal.ProvisioningOperation, url string) (*BasicEvaluationCreateRequest, error)
+	AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64, pp internal.ProvisioningParameters)
 	IsAlreadyCreated(lifecycleData internal.AvsLifecycleData) bool
 	SetEvalId(lifecycleData *internal.AvsLifecycleData, evalId int64)
 	IsAlreadyDeleted(lifecycleData internal.AvsLifecycleData) bool

--- a/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
@@ -20,11 +20,11 @@ func NewExternalEvalAssistant(avsConfig Config) *ExternalEvalAssistant {
 	}
 }
 
-func (eea *ExternalEvalAssistant) CreateBasicEvaluationRequest(operations internal.ProvisioningOperation, configForModel *configForModel, url string) (*BasicEvaluationCreateRequest, error) {
-	return newBasicEvaluationCreateRequest(operations, eea, configForModel, url)
+func (eea *ExternalEvalAssistant) CreateBasicEvaluationRequest(operations internal.ProvisioningOperation, url string) (*BasicEvaluationCreateRequest, error) {
+	return newBasicEvaluationCreateRequest(operations, eea, url)
 }
 
-func (eea *ExternalEvalAssistant) AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64) {
+func (eea *ExternalEvalAssistant) AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64, _ internal.ProvisioningParameters) {
 	//do nothing
 }
 
@@ -36,8 +36,16 @@ func (eea *ExternalEvalAssistant) ProvideSuffix() string {
 	return "ext"
 }
 
-func (eea *ExternalEvalAssistant) ProvideTesterAccessId() int64 {
+func (eea *ExternalEvalAssistant) ProvideTesterAccessId(_ internal.ProvisioningParameters) int64 {
 	return eea.avsConfig.ExternalTesterAccessId
+}
+
+func (eea *ExternalEvalAssistant) ProvideGroupId(_ internal.ProvisioningParameters) int64 {
+	return eea.avsConfig.GroupId
+}
+
+func (eea *ExternalEvalAssistant) ProvideParentId(_ internal.ProvisioningParameters) int64 {
+	return eea.avsConfig.ParentId
 }
 
 func (eea *ExternalEvalAssistant) ProvideTags() []*Tag {

--- a/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 )
 
@@ -26,11 +27,15 @@ func NewInternalEvalAssistant(avsConfig Config) *InternalEvalAssistant {
 	}
 }
 
-func (iec *InternalEvalAssistant) CreateBasicEvaluationRequest(operations internal.ProvisioningOperation, configForModel *configForModel, url string) (*BasicEvaluationCreateRequest, error) {
-	return newBasicEvaluationCreateRequest(operations, iec, configForModel, url)
+func (iec *InternalEvalAssistant) CreateBasicEvaluationRequest(operations internal.ProvisioningOperation, url string) (*BasicEvaluationCreateRequest, error) {
+	return newBasicEvaluationCreateRequest(operations, iec, url)
 }
 
-func (iec *InternalEvalAssistant) AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64) {
+func (iec *InternalEvalAssistant) AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64, pp internal.ProvisioningParameters) {
+	apiKey := iec.avsConfig.ApiKey
+	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+		apiKey = iec.avsConfig.TrialApiKey
+	}
 	inputCreator.AppendOverrides(ComponentName, []*gqlschema.ConfigEntryInput{
 		{
 			Key:   EvaluationIdKey,
@@ -38,7 +43,7 @@ func (iec *InternalEvalAssistant) AppendOverrides(inputCreator internal.Provisio
 		},
 		{
 			Key:   AvsBridgeAPIKey,
-			Value: iec.avsConfig.ApiKey,
+			Value: apiKey,
 		},
 	})
 }
@@ -51,8 +56,25 @@ func (iec *InternalEvalAssistant) ProvideSuffix() string {
 	return "int"
 }
 
-func (iec *InternalEvalAssistant) ProvideTesterAccessId() int64 {
+func (iec *InternalEvalAssistant) ProvideTesterAccessId(pp internal.ProvisioningParameters) int64 {
+	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+		return iec.avsConfig.TrialInternalTesterAccessId
+	}
 	return iec.avsConfig.InternalTesterAccessId
+}
+
+func (iec *InternalEvalAssistant) ProvideGroupId(pp internal.ProvisioningParameters) int64 {
+	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+		return iec.avsConfig.TrialGroupId
+	}
+	return iec.avsConfig.GroupId
+}
+
+func (iec *InternalEvalAssistant) ProvideParentId(pp internal.ProvisioningParameters) int64 {
+	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+		return iec.avsConfig.TrialParentId
+	}
+	return iec.avsConfig.ParentId
 }
 
 func (iec *InternalEvalAssistant) ProvideCheckType() string {

--- a/components/kyma-environment-broker/internal/avs/model.go
+++ b/components/kyma-environment-broker/internal/avs/model.go
@@ -67,8 +67,7 @@ type BasicEvaluationCreateResponse struct {
 	IdOnTester                 string `json:"id_on_tester"`
 }
 
-func newBasicEvaluationCreateRequest(operation internal.ProvisioningOperation, evalTypeSpecificConfig ModelConfigurator,
-	configForModel *configForModel, url string) (*BasicEvaluationCreateRequest, error) {
+func newBasicEvaluationCreateRequest(operation internal.ProvisioningOperation, evalTypeSpecificConfig ModelConfigurator, url string) (*BasicEvaluationCreateRequest, error) {
 	provisionParams, err := operation.GetProvisioningParameters()
 	if err != nil {
 		return nil, err
@@ -85,16 +84,16 @@ func newBasicEvaluationCreateRequest(operation internal.ProvisioningOperation, e
 		URL:              url,
 		CheckType:        evalTypeSpecificConfig.ProvideCheckType(),
 		Interval:         interval,
-		TesterAccessId:   evalTypeSpecificConfig.ProvideTesterAccessId(),
+		TesterAccessId:   evalTypeSpecificConfig.ProvideTesterAccessId(provisionParams),
 		Tags:             evalTypeSpecificConfig.ProvideTags(),
 		Timeout:          timeout,
 		ReadOnly:         false,
 		ContentCheck:     contentCheck,
 		ContentCheckType: contentCheckType,
 		Threshold:        threshold,
-		GroupId:          configForModel.groupId,
+		GroupId:          evalTypeSpecificConfig.ProvideGroupId(provisionParams),
 		Visibility:       visibility,
-		ParentId:         configForModel.parentId,
+		ParentId:         evalTypeSpecificConfig.ProvideParentId(provisionParams),
 	}, nil
 }
 

--- a/components/kyma-environment-broker/internal/avs/model_configurator.go
+++ b/components/kyma-environment-broker/internal/avs/model_configurator.go
@@ -1,8 +1,12 @@
 package avs
 
+import "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+
 type ModelConfigurator interface {
 	ProvideSuffix() string
-	ProvideTesterAccessId() int64
+	ProvideTesterAccessId(pp internal.ProvisioningParameters) int64
+	ProvideGroupId(pp internal.ProvisioningParameters) int64
+	ProvideParentId(pp internal.ProvisioningParameters) int64
 	ProvideTags() []*Tag
 	ProvideNewOrDefaultServiceName(defaultServiceName string) string
 	ProvideCheckType() string

--- a/components/kyma-environment-broker/internal/avs/model_test.go
+++ b/components/kyma-environment-broker/internal/avs/model_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gorilla/mux"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -34,8 +35,8 @@ func TestAvsEvaluationConfigs(t *testing.T) {
 	externalEvalAssistant := NewExternalEvalAssistant(avsConfig)
 
 	// verify assistant configs
-	assert.Equal(internalEvalId, internalEvalAssistant.ProvideTesterAccessId())
-	assert.Equal(externalEvalId, externalEvalAssistant.ProvideTesterAccessId())
+	assert.Equal(internalEvalId, internalEvalAssistant.ProvideTesterAccessId(internal.ProvisioningParameters{}))
+	assert.Equal(externalEvalId, externalEvalAssistant.ProvideTesterAccessId(internal.ProvisioningParameters{}))
 
 	assert.Equal("int", internalEvalAssistant.ProvideSuffix())
 	assert.Equal("ext", externalEvalAssistant.ProvideSuffix())

--- a/components/kyma-environment-broker/internal/runtime/disabled_components.go
+++ b/components/kyma-environment-broker/internal/runtime/disabled_components.go
@@ -37,7 +37,6 @@ func NewDisabledComponentsProvider() DisabledComponentsProvider {
 		},
 		broker.TrialPlanID: {
 			components.KnativeEventingKafka: {},
-			components.AvSBridge:            {},
 		},
 	}
 }

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -92,7 +92,7 @@ spec:
               value: "{{ .Values.lms.environment }}"
             - name: APP_LMS_SAML_TENANT
               value: "{{ .Values.lms.samlTenant }}"
-            - name: APP_LMS_ENABLED_FOR_GLOBAL_ACCOUNTS 
+            - name: APP_LMS_ENABLED_FOR_GLOBAL_ACCOUNTS
               value: "{{ .Values.lms.enabledForGlobalAccounts }}"
             - name: APP_LMS_MANDATORY
               value: "{{ .Values.lms.mandatory }}"
@@ -264,6 +264,26 @@ spec:
               valueFrom:
                 secretKeyRef:
                   key: parentId
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_TRIAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: trialApiKey
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_TRIAL_INTERNAL_TESTER_ACCESS_ID
+              valueFrom:
+                secretKeyRef:
+                  key: trialInternalTesterAccessId
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_TRIAL_GROUP_ID
+              valueFrom:
+                secretKeyRef:
+                  key: trialGroupId
+                  name: {{ .Values.avs.secretName }}
+            - name: APP_AVS_TRIAL_PARENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: trialParentId
                   name: {{ .Values.avs.secretName }}
             - name: APP_AVS_ADDITIONAL_TAGS_ENABLED
               value: "{{ .Values.avs.additionalTagsEnabled }}"

--- a/resources/kcp/charts/kyma-environment-broker/templates/secrets.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/secrets.yaml
@@ -27,6 +27,10 @@ data:
   externalTesterTags: {{ include "avs.utils.joinTags" .Values.avs.externalTesterTags | b64enc | quote }}
   groupId: {{ .Values.avs.groupId | b64enc | quote }}
   parentId: {{ .Values.avs.parentId | b64enc | quote }}
+  trialApiKey: {{ .Values.avs.trialApiKey | b64enc | quote }}
+  trialInternalTesterAccessId: {{ .Values.avs.trialInternalTesterAccessId | b64enc | quote }}
+  trialGroupId: {{ .Values.avs.trialGroupId | b64enc | quote }}
+  trialParentId: {{ .Values.avs.trialParentId | b64enc | quote }}
 kind: Secret
 metadata:
   name: {{ .Values.avs.secretName }}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -129,6 +129,10 @@ avs:
   gardenerSeedNameTagClassId: "0"
   gardenerShootNameTagClassId: "0"
   regionTagClassId: "0"
+  trialApiKey: ""
+  trialInternalTesterAccessId: "0"
+  trialGroupId: "0"
+  trialParentId: "0"
 
 lms:
   secretName: "lms-creds"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "737d74a8"
     kyma_environment_broker:
       dir:
-      version: "PR-384"
+      version: "PR-397"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Introduce new AVS config values for trial group, push tester ID & key, parent (compound) evaluation
- Enable AVS internal step for trial plan.
