### PR TITLE
Version mapping for PR must be lowercase

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/builder_test.go
+++ b/components/kyma-environment-broker/internal/process/input/builder_test.go
@@ -118,15 +118,15 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		// given
 		componentsProvider := &automock.ComponentListProvider{}
 		componentsProvider.On("AllComponents", "1.10").Return([]v1alpha1.KymaComponent{}, nil).Once()
-		componentsProvider.On("AllComponents", "PR-1").Return([]v1alpha1.KymaComponent{}, nil).Once()
+		componentsProvider.On("AllComponents", "pr-1").Return([]v1alpha1.KymaComponent{}, nil).Once()
 		defer componentsProvider.AssertExpectations(t)
 
 		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider, Config{}, "1.10", fixTrialRegionMapping())
 		assert.NoError(t, err)
-		pp := fixProvisioningParameters(broker.GCPPlanID, "PR-1")
+		pp := fixProvisioningParameters(broker.GCPPlanID, "pr-1")
 
 		// when
-		input, err := ibf.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "PR-1", Origin: internal.Parameters})
+		input, err := ibf.CreateProvisionInput(pp, internal.RuntimeVersionData{Version: "pr-1", Origin: internal.Parameters})
 
 		// Then
 		assert.NoError(t, err)

--- a/components/kyma-environment-broker/internal/runtime/provider.go
+++ b/components/kyma-environment-broker/internal/runtime/provider.go
@@ -165,6 +165,9 @@ func (r *ComponentsListProvider) checkStatusCode(resp *http.Response) error {
 
 func (r *ComponentsListProvider) getInstallerYamlURL(kymaVersion string) string {
 	if r.isOnDemandRelease(kymaVersion) {
+		if strings.HasPrefix(kymaVersion, "pr-") {
+			kymaVersion = strings.ToUpper(kymaVersion)
+		}
 		return fmt.Sprintf(onDemandInstallerURLFormat, kymaVersion)
 	}
 	return fmt.Sprintf(releaseInstallerURLFormat, kymaVersion)
@@ -173,12 +176,12 @@ func (r *ComponentsListProvider) getInstallerYamlURL(kymaVersion string) string 
 // isOnDemandRelease returns true if the version is recognized as on-demand.
 //
 // Detection rules:
-//   For pull requests: PR-<number>
+//   For pull requests: pr-<number>
 //   For changes to the master branch: master-<commit_sha>
 //
 // source: https://github.com/kyma-project/test-infra/blob/master/docs/prow/prow-architecture.md#generate-development-artifacts
 func (r *ComponentsListProvider) isOnDemandRelease(version string) bool {
-	isOnDemandVersion := strings.HasPrefix(version, "PR-") ||
+	isOnDemandVersion := strings.HasPrefix(version, "pr-") ||
 		strings.HasPrefix(version, "master-")
 	return isOnDemandVersion
 }

--- a/docs/kyma-environment-broker/03-08-kyma-versions.md
+++ b/docs/kyma-environment-broker/03-08-kyma-versions.md
@@ -18,13 +18,13 @@ metadata:
   namespace: "kcp-system"
 data:
   GA_3e64ebae-38b5-46a0-b1ed-9ccee153a0ae: "1.15.0-rc1"
-  SA_df29c526-0c3d-4e2c-ba41-8b69cde41961: "PR-3721"
+  SA_df29c526-0c3d-4e2c-ba41-8b69cde41961: "pr-3721"
   SA_4abbc9b5-055a-4571-b762-9d61b4b8a2e7: "master-1ab234"
 ```
 
 This ConfigMap contains a default version for a global account and a subaccount. The **3e64ebae-38b5-46a0-b1ed-9ccee153a0ae** parameter is a global account ID, and the value is the Kyma version specified for this global account. The **df29c526-0c3d-4e2c-ba41-8b69cde41961** and **4abbc9b5-055a-4571-b762-9d61b4b8a2e7** parameters are a subaccount IDs, and the values are the Kyma versions specified for those subaccounts. 
 
-The Kyma version value could be either a Github tag (e.g. `1.15.0-rc1` or `1.16.0`), a version built from a pull request (e.g. `PR-3721`) or a version from `master` branch with example commit hash `1ab234`.
+The Kyma version value could be either a Github tag (e.g. `1.15.0-rc1` or `1.16.0`), a version built from a pull request (e.g. `pr-3721`) or a version from `master` branch with example commit hash `1ab234`.
 
 You can also specify a Kyma version using the **kymaVersion** provisioning parameter, for example:
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "737d74a8"
     kyma_environment_broker:
       dir:
-      version: "PR-384"
+      version: "PR-404"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-131"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When performing account version mapping, you can't use uppercase for ConfigMaps `metadata.name` field:
```
Error from server (Invalid): error when creating "overrides": ConfigMap "tracing-global-overrides-PR-123" is invalid: metadata.name: Invalid value: "tracing-global-overrides-PR-123": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
```

On the other hand, the uppercase format is needed for fetching `kyma-installer.yaml` file properly:
https://github.com/kyma-project/control-plane/blob/9465c2f0d2e65053657d94d2769602f82b02d15f/components/kyma-environment-broker/internal/runtime/provider.go#L166-L171

Changes proposed in this pull request:

- Changed `kymaVersion` string handling when processing versions from PR to lowercase for example `pr-123`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
