### PR TITLE
Fix AVS external evaluation creation

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/external_eval.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/external_eval.go
@@ -24,6 +24,7 @@ func NewExternalEvalCreator(delegator *avs.Delegator, disabled bool, assistant *
 
 func (eec *ExternalEvalCreator) createEval(operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
 	if eec.disabled {
+		logger.Infof("Creating AVS external evaluation is disabled")
 		return operation, 0, nil
 	} else {
 		return eec.delegator.CreateEvaluation(logger, operation, eec.assistant, url)

--- a/components/kyma-environment-broker/internal/process/provisioning/external_eval.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/external_eval.go
@@ -24,7 +24,7 @@ func NewExternalEvalCreator(delegator *avs.Delegator, disabled bool, assistant *
 
 func (eec *ExternalEvalCreator) createEval(operation internal.ProvisioningOperation, url string, logger logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
 	if eec.disabled {
-		logger.Infof("Creating AVS external evaluation is disabled")
+		logger.Infof("creating AVS external evaluation is disabled")
 		return operation, 0, nil
 	} else {
 		return eec.delegator.CreateEvaluation(logger, operation, eec.assistant, url)

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/servicemanager"
 
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -218,7 +218,7 @@ func (s *InitialisationStep) launchPostActions(operation internal.ProvisioningOp
 	// action #2
 	tags, operation, repeat, err := s.createTagsForRuntime(operation, instance)
 	if err != nil || repeat != 0 {
-		log.Errorf("while adding Tags to Evaluation: %s", err)
+		log.Errorf("while creating Tags for Evaluation: %s", err)
 		return operation, repeat, nil
 	}
 	operation, repeat, err = s.internalEvalUpdater.AddTagsToEval(tags, operation, "", log)
@@ -243,6 +243,24 @@ func (s *InitialisationStep) launchPostActions(operation internal.ProvisioningOp
 	}
 
 	return s.operationManager.OperationSucceeded(operation, msg)
+}
+
+func (s *InitialisationStep) createExternalEval(operation internal.ProvisioningOperation, instance *internal.Instance, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
+	pp, err := operation.GetProvisioningParameters()
+	if err != nil {
+		log.Errorf("cannot fetch provisioning parameters from operation: %s", err)
+		return s.operationManager.OperationFailed(operation, "invalid operation provisioning parameters")
+	}
+	if pp.PlanID == broker.TrialPlanID {
+		log.Info("skipping AVS external evaluation creation for trial plan")
+		return operation, 0, nil
+	}
+	log.Infof("creating external evaluation for instance %", instance.InstanceID)
+	operation, repeat, err := s.externalEvalCreator.createEval(operation, instance.DashboardURL, log)
+	if err != nil || repeat != 0 {
+		return operation, repeat, nil
+	}
+	return operation, 0, nil
 }
 
 func (s *InitialisationStep) createTagsForRuntime(operation internal.ProvisioningOperation, instance *internal.Instance) ([]*avs.Tag, internal.ProvisioningOperation, time.Duration, error) {

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -85,9 +85,6 @@ func (s *InitialisationStep) Name() string {
 }
 
 func (s *InitialisationStep) Run(operation internal.ProvisioningOperation, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
-	if operation.ProvisioningParameters.PlanID == broker.TrialPlanID {
-		s.externalEvalCreator.disabled = true
-	}
 	operation.SMClientFactory = s.serviceManagerClientFactory
 
 	inst, err := s.instanceStorage.GetByID(operation.InstanceID)
@@ -210,9 +207,12 @@ func (s *InitialisationStep) handleDashboardURL(instance *internal.Instance, log
 
 func (s *InitialisationStep) launchPostActions(operation internal.ProvisioningOperation, instance *internal.Instance, log logrus.FieldLogger, msg string) (internal.ProvisioningOperation, time.Duration, error) {
 	// action #1
-	operation, repeat, err := s.externalEvalCreator.createEval(operation, instance.DashboardURL, log)
-	if err != nil || repeat != 0 {
-		return operation, repeat, nil
+	if operation.ProvisioningParameters.PlanID != broker.TrialPlanID {
+		log.Infof("creating external evaluation for instance %", instance.InstanceID)
+		operation, repeat, err := s.externalEvalCreator.createEval(operation, instance.DashboardURL, log)
+		if err != nil || repeat != 0 {
+			return operation, repeat, nil
+		}
 	}
 
 	// action #2

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "737d74a8"
     kyma_environment_broker:
       dir:
-      version: "PR-413"
+      version: "PR-405"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-407"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Provisioning a SKR with `TrialPlanID` caused setting the `disabled` flag in `externalEvalCreator` to `false` permanently

Changes proposed in this pull request:

- Fixed AVS external evaluation creation

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
