### PR TITLE
Bump alpine to 3.12.3 in KEB images

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.cleanup
+++ b/components/kyma-environment-broker/Dockerfile.cleanup
@@ -18,7 +18,7 @@ RUN apk --update add ca-certificates
 FROM alpine:3.12.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
-RUN apk --no-cache add curl
+RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /bin/environments-cleanup /bin/environments-cleanup

--- a/components/kyma-environment-broker/Dockerfile.cleanup
+++ b/components/kyma-environment-broker/Dockerfile.cleanup
@@ -15,7 +15,7 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 # Final image
-FROM alpine:3.12.0
+FROM alpine:3.12.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 RUN apk --no-cache add curl

--- a/components/kyma-environment-broker/Dockerfile.sac
+++ b/components/kyma-environment-broker/Dockerfile.sac
@@ -18,7 +18,7 @@ RUN apk --update add ca-certificates
 FROM alpine:3.12.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
-RUN apk --no-cache add curl
+RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /bin/accountcleanup /bin/accountcleanup

--- a/components/kyma-environment-broker/Dockerfile.sac
+++ b/components/kyma-environment-broker/Dockerfile.sac
@@ -15,7 +15,7 @@ FROM alpine:latest as certs
 RUN apk --update add ca-certificates
 
 # Final image
-FROM alpine:3.12.0
+FROM alpine:3.12.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 RUN apk --no-cache add curl

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,10 +14,10 @@ global:
       version: "PR-384"
     kyma_environments_cleanup_job:
       dir:
-      version: "PR-131"
+      version: "PR-407"
     kyma_environments_subaccount_cleanup_job:
       dir:
-      version: "PR-262"
+      version: "PR-407"
     subscription_cleanup_job:
       dir:
       version: "PR-313"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump alpine to 3.12.3 in KEB images
- Install curl from edge (7.74.0-r0) as 7.69.1-r1 has vulnerabilities detected

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
