### PR TITLE
Bump alpine to 3.12.3 in schema migrator image

### DIFF
--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -5,7 +5,8 @@ ARG MIGRATE_VER=4.5.0
 
 WORKDIR /migrate
 
-RUN apk --no-cache add bash postgresql-client>12.5-r0 curl
+RUN apk --no-cache add bash postgresql-client 
+RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN wget https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VER}/migrate.linux-amd64.tar.gz -O - | tar -xz
 RUN mv migrate.linux-amd64 /usr/local/bin/migrate
 

--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12.0
+FROM alpine:3.12.3
 LABEL source=git@github.com:kyma-project/control-plane.git
 
 ARG MIGRATE_VER=4.5.0

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -5,7 +5,7 @@ global:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:
       dir:
-      version: "PR-353"
+      version: "PR-408"
     provisioner:
       dir:
       version: "737d74a8"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump alpine to 3.12.3 in schema migrator image
- Install curl from edge (7.74.0-r0) as 7.69.1-r1  has vulnerabilities detected

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
