### PR TITLE
Make shoot domain gardener parameter as optional

### DIFF
--- a/components/kyma-environment-broker/common/gardener/config.go
+++ b/components/kyma-environment-broker/common/gardener/config.go
@@ -2,6 +2,6 @@ package gardener
 
 type Config struct {
 	Project        string `envconfig:"default=gardenerProject"`
-	ShootDomain    string
+	ShootDomain    string `envconfig:"optional"`
 	KubeconfigPath string `envconfig:"default=./dev/kubeconfig.yaml"`
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-405"
     kyma_environments_cleanup_job:
       dir:
-      version: "PR-407"
+      version: "PR-416"
     kyma_environments_subaccount_cleanup_job:
       dir:
       version: "PR-407"


### PR DESCRIPTION
Changes proposed in this pull request:

- Make shoot domain gardener parameter optional, because Gardener config is used by two application and only one of them require this parameter.