### PR TITLE
add compass_keb_upgrade_result

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/metrics.go
+++ b/components/kyma-environment-broker/internal/metrics/metrics.go
@@ -16,6 +16,7 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 
 	sub.Subscribe(process.ProvisioningStepProcessed{}, opResultCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opResultCollector.OnDeprovisioningStepProcessed)
+	sub.Subscribe(process.UpgradeKymaStepProcessed{}, opResultCollector.OnUpgradeStepProcessed)
 	sub.Subscribe(process.ProvisioningStepProcessed{}, opDurationCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opDurationCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.ProvisioningStepProcessed{}, stepResultCollector.OnProvisioningStepProcessed)

--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -16,19 +16,35 @@ const (
 	resultFailed     float64 = 0
 	resultSucceeded  float64 = 1
 	resultInProgress float64 = 2
+	resultPending    float64 = 3
+	resultCanceling  float64 = 4
+	resultCanceled   float64 = 5
+)
+
+type LastOperationState = domain.LastOperationState
+
+const (
+	Pending   LastOperationState = "pending"
+	Canceling LastOperationState = "canceling"
+	Canceled  LastOperationState = "canceled"
 )
 
 // OperationResultCollector provides the following metrics:
 // - compass_keb_provisioning_result{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}
 // - compass_keb_deprovisioning_result{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}
+// - compass_keb_upgrade_result{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}
 // These gauges show the status of the operation.
 // The value of the gauge could be:
 // 0 - Failed
 // 1 - Succeeded
 // 2 - In progress
+// 3 - Pending
+// 4 - Canceling
+// 5 - Canceled
 type OperationResultCollector struct {
 	provisioningResultGauge   *prometheus.GaugeVec
 	deprovisioningResultGauge *prometheus.GaugeVec
+	upgradeResultGauge        *prometheus.GaugeVec
 }
 
 func NewOperationResultCollector() *OperationResultCollector {
@@ -45,17 +61,55 @@ func NewOperationResultCollector() *OperationResultCollector {
 			Name:      "deprovisioning_result",
 			Help:      "Result of the deprovisioning",
 		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		upgradeResultGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "upgrade_result",
+			Help:      "Result of the upgrade",
+		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
 	}
 }
 
 func (c *OperationResultCollector) Describe(ch chan<- *prometheus.Desc) {
 	c.provisioningResultGauge.Describe(ch)
 	c.deprovisioningResultGauge.Describe(ch)
+	c.upgradeResultGauge.Describe(ch)
 }
 
 func (c *OperationResultCollector) Collect(ch chan<- prometheus.Metric) {
 	c.provisioningResultGauge.Collect(ch)
 	c.deprovisioningResultGauge.Collect(ch)
+	c.upgradeResultGauge.Collect(ch)
+}
+
+func (c *OperationResultCollector) OnUpgradeStepProcessed(ctx context.Context, ev interface{}) error {
+	stepProcessed, ok := ev.(process.UpgradeKymaStepProcessed)
+	if !ok {
+		return fmt.Errorf("expected UpgradeStepProcessed but got %+v", ev)
+	}
+
+	var resultValue float64
+	switch stepProcessed.Operation.State {
+	case domain.InProgress:
+		resultValue = resultInProgress
+	case domain.Succeeded:
+		resultValue = resultSucceeded
+	case domain.Failed:
+		resultValue = resultFailed
+	case Pending:
+		resultValue = resultPending
+	case Canceling:
+		resultValue = resultCanceling
+	case Canceled:
+		resultValue = resultCanceled
+	}
+	op := stepProcessed.Operation
+	pp := op.ProvisioningParameters
+	c.upgradeResultGauge.
+		WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		Set(resultValue)
+
+	return nil
 }
 
 func (c *OperationResultCollector) OnProvisioningStepProcessed(ctx context.Context, ev interface{}) error {

--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -66,7 +66,7 @@ func NewOperationResultCollector() *OperationResultCollector {
 			Subsystem: prometheusSubsystem,
 			Name:      "upgrade_result",
 			Help:      "Result of the upgrade",
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"instance_id", "global_account_id", "plan_id"}),
 	}
 }
 
@@ -106,7 +106,7 @@ func (c *OperationResultCollector) OnUpgradeStepProcessed(ctx context.Context, e
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
 	c.upgradeResultGauge.
-		WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		WithLabelValues(op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 
 	return nil

--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -66,7 +66,7 @@ func NewOperationResultCollector() *OperationResultCollector {
 			Subsystem: prometheusSubsystem,
 			Name:      "upgrade_result",
 			Help:      "Result of the upgrade",
-		}, []string{"instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
 	}
 }
 
@@ -106,7 +106,7 @@ func (c *OperationResultCollector) OnUpgradeStepProcessed(ctx context.Context, e
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
 	c.upgradeResultGauge.
-		WithLabelValues(op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		WithLabelValues(op.Operation.ID, op.Operation.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 
 	return nil


### PR DESCRIPTION
1. Implement the [task 927](https://github.tools.sap/kyma/backlog/issues/927)
2. Looks like the [definition of domain](https://github.com/pivotal-cf/brokerapi/blob/master/v7/domain/service_broker.go#L63) doesn't include the `pending/canceled/canceling`, hence, added the `const var`  as below for `switch/case`

```
type LastOperationState = domain.LastOperationState

const (
	Pending   LastOperationState = "pending"
	Canceling LastOperationState = "canceling"
	Canceled  LastOperationState = "canceled"
)
```