### PR TITLE
Fix AVS trial eval removal during deprovisioning

### DIFF
--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -96,8 +96,8 @@ func (c *Client) AddTag(evaluationID int64, tag *Tag) (*BasicEvaluationCreateRes
 	return &responseObject, nil
 }
 
-func (c *Client) RemoveReferenceFromParentEval(evaluationId int64) (err error) {
-	absoluteURL := fmt.Sprintf("%s/child/%d", appendId(c.avsConfig.ApiEndpoint, c.avsConfig.ParentId), evaluationId)
+func (c *Client) RemoveReferenceFromParentEval(parentID, evaluationID int64) (err error) {
+	absoluteURL := fmt.Sprintf("%s/child/%d", appendId(c.avsConfig.ApiEndpoint, parentID), evaluationID)
 	response, err := c.deleteRequest(absoluteURL)
 	if err == nil {
 		return nil
@@ -112,7 +112,7 @@ func (c *Client) RemoveReferenceFromParentEval(evaluationId int64) (err error) {
 		var responseObject avsNonSuccessResp
 		err := json.NewDecoder(response.Body).Decode(&responseObject)
 		if err != nil {
-			return errors.Wrapf(err, "while decoding avs non success response body for ID: %d", evaluationId)
+			return errors.Wrapf(err, "while decoding avs non success response body for ID: %d", evaluationID)
 		}
 
 		if strings.Contains(strings.ToLower(responseObject.Message), "does not contain subevaluation") {
@@ -120,7 +120,7 @@ func (c *Client) RemoveReferenceFromParentEval(evaluationId int64) (err error) {
 		}
 	}
 
-	return fmt.Errorf("unexpected response for evaluationId: %d while deleting reference from parent evaluation, error: %s", evaluationId, err)
+	return fmt.Errorf("unexpected response for evaluationId: %d while deleting reference from parent evaluation, error: %s", evaluationID, err)
 }
 
 func (c *Client) DeleteEvaluation(evaluationId int64) (err error) {

--- a/components/kyma-environment-broker/internal/avs/client_test.go
+++ b/components/kyma-environment-broker/internal/avs/client_test.go
@@ -163,7 +163,7 @@ func TestClient_RemoveReferenceFromParentEval(t *testing.T) {
 		assert.NoError(t, err)
 
 		// When
-		err = client.RemoveReferenceFromParentEval(resp.Id)
+		err = client.RemoveReferenceFromParentEval(parentEvaluationID, resp.Id)
 
 		// Then
 		assert.NoError(t, err)
@@ -181,7 +181,7 @@ func TestClient_RemoveReferenceFromParentEval(t *testing.T) {
 		assert.NoError(t, err)
 
 		// When
-		err = client.RemoveReferenceFromParentEval(111)
+		err = client.RemoveReferenceFromParentEval(parentEvaluationID, 111)
 
 		// then
 		assert.Error(t, err)

--- a/components/kyma-environment-broker/internal/avs/client_test.go
+++ b/components/kyma-environment-broker/internal/avs/client_test.go
@@ -186,6 +186,25 @@ func TestClient_RemoveReferenceFromParentEval(t *testing.T) {
 		// then
 		assert.Error(t, err)
 	})
+	t.Run("should return error when parent evaluation does not contain subevaluation", func(t *testing.T) {
+		// Given
+		server := newServer(t)
+		mockServer := fixHTTPServer(server)
+		client, err := NewClient(context.TODO(), Config{
+			OauthTokenEndpoint: fmt.Sprintf("%s/oauth/token", mockServer.URL),
+			ApiEndpoint:        fmt.Sprintf("%s/api/v2/evaluationmetadata", mockServer.URL),
+			ParentId:           parentEvaluationID,
+		}, logrus.New())
+		assert.NoError(t, err)
+
+		// When
+		err = client.RemoveReferenceFromParentEval(int64(9999), 111)
+
+		// then
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "400")
+	})
+
 }
 
 func TestClient_AddTag(t *testing.T) {
@@ -408,7 +427,7 @@ func (s *server) removeReferenceFromParentEval(w http.ResponseWriter, r *http.Re
 
 	_, exists := s.evaluations.parentIDrefs[parentID]
 	if !exists {
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusBadRequest)
 	}
 
 	s.evaluations.removeParentRef(parentID, evalID)

--- a/components/kyma-environment-broker/internal/avs/delegator.go
+++ b/components/kyma-environment-broker/internal/avs/delegator.go
@@ -109,7 +109,7 @@ func (del *Delegator) DeleteAvsEvaluation(deProvisioningOperation internal.Depro
 		return deProvisioningOperation, nil
 	}
 
-	if err := del.tryDeleting(assistant, deProvisioningOperation.Avs, logger); err != nil {
+	if err := del.tryDeleting(assistant, deProvisioningOperation, logger); err != nil {
 		return deProvisioningOperation, err
 	}
 
@@ -122,15 +122,16 @@ func (del *Delegator) DeleteAvsEvaluation(deProvisioningOperation internal.Depro
 	return *updatedDeProvisioningOp, nil
 }
 
-func (del *Delegator) tryDeleting(assistant EvalAssistant, lifecycleData internal.AvsLifecycleData, logger logrus.FieldLogger) error {
-	evaluationId := assistant.GetEvaluationId(lifecycleData)
-	err := del.client.RemoveReferenceFromParentEval(evaluationId)
+func (del *Delegator) tryDeleting(assistant EvalAssistant, deProvisioningOperation internal.DeprovisioningOperation, logger logrus.FieldLogger) error {
+	evaluationID := assistant.GetEvaluationId(deProvisioningOperation.Avs)
+	parentID := assistant.ProvideParentId(deProvisioningOperation.ProvisioningParameters)
+	err := del.client.RemoveReferenceFromParentEval(parentID, evaluationID)
 	if err != nil {
 		logger.Errorf("error while deleting reference for evaluation %v", err)
 		return err
 	}
 
-	err = del.client.DeleteEvaluation(evaluationId)
+	err = del.client.DeleteEvaluation(evaluationID)
 	if err != nil {
 		logger.Errorf("error while deleting evaluation %v", err)
 	}

--- a/components/kyma-environment-broker/internal/avs/eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/eval_assistant.go
@@ -13,6 +13,7 @@ type EvalAssistant interface {
 	SetEvalId(lifecycleData *internal.AvsLifecycleData, evalId int64)
 	IsAlreadyDeleted(lifecycleData internal.AvsLifecycleData) bool
 	GetEvaluationId(lifecycleData internal.AvsLifecycleData) int64
+	ProvideParentId(pp internal.ProvisioningParameters) int64
 	markDeleted(lifecycleData *internal.AvsLifecycleData)
 	provideRetryConfig() *RetryConfig
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-419"
     kyma_environment_broker:
       dir:
-      version: "PR-423"
+      version: "PR-426"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
**Description**

Wrong parent evaluation ID is being used when trying to remove trial evaluation from parent (compound) evaluation.
