### PR TITLE
Fix KEB kyma upgrade errors

### DIFF
--- a/components/kyma-environment-broker/common/orchestration/strategies/parallel.go
+++ b/components/kyma-environment-broker/common/orchestration/strategies/parallel.go
@@ -1,6 +1,7 @@
 package strategies
 
 import (
+	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -122,7 +123,7 @@ func (p *ParallelOrchestrationStrategy) processOperation(op orchestration.Runtim
 			log = log.WithField("operationID", id)
 			defer func() {
 				if err := recover(); err != nil {
-					log.Errorf("panic error from process: %v", err)
+					log.Errorf("panic error from process: %v\n%s", err, debug.Stack())
 				}
 				p.dq[executionID].Done(key)
 			}()

--- a/components/kyma-environment-broker/internal/orchestration/handlers/converter.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/converter.go
@@ -47,14 +47,14 @@ func (c *Converter) UpgradeKymaOperationToDTO(op internal.UpgradeKymaOperation) 
 	}
 	return orchestration.OperationResponse{
 		OperationID:            op.Operation.ID,
-		RuntimeID:              op.InstanceDetails.RuntimeID,
+		RuntimeID:              op.RuntimeOperation.RuntimeID,
 		GlobalAccountID:        op.GlobalAccountID,
-		SubAccountID:           op.InstanceDetails.SubAccountID,
+		SubAccountID:           op.RuntimeOperation.SubAccountID,
 		OrchestrationID:        op.OrchestrationID,
 		ServicePlanID:          op.ProvisioningParameters.PlanID,
 		ServicePlanName:        plan.PlanDefinition.Name,
 		DryRun:                 op.DryRun,
-		ShootName:              op.InstanceDetails.ShootName,
+		ShootName:              op.RuntimeOperation.ShootName,
 		MaintenanceWindowBegin: op.MaintenanceWindowBegin,
 		MaintenanceWindowEnd:   op.MaintenanceWindowEnd,
 		State:                  string(op.Operation.State),

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step.go
@@ -57,7 +57,7 @@ func (s *UpgradeKymaStep) Run(operation internal.UpgradeKymaOperation, log logru
 	if operation.DryRun {
 		// runtimeID is set with prefix to indicate the fake runtime state
 		err = s.runtimeStateStorage.Insert(
-			internal.NewRuntimeState(fmt.Sprintf("%s%s", DryRunPrefix, operation.InstanceDetails.RuntimeID), operation.Operation.ID, requestInput.KymaConfig, nil),
+			internal.NewRuntimeState(fmt.Sprintf("%s%s", DryRunPrefix, operation.RuntimeOperation.RuntimeID), operation.Operation.ID, requestInput.KymaConfig, nil),
 		)
 		if err != nil {
 			return operation, 10 * time.Second, nil
@@ -68,7 +68,7 @@ func (s *UpgradeKymaStep) Run(operation internal.UpgradeKymaOperation, log logru
 	var provisionerResponse gqlschema.OperationStatus
 	if operation.ProvisionerOperationID == "" {
 		// trigger upgradeRuntime mutation
-		provisionerResponse, err := s.provisionerClient.UpgradeRuntime(operation.ProvisioningParameters.ErsContext.GlobalAccountID, operation.InstanceDetails.RuntimeID, requestInput)
+		provisionerResponse, err := s.provisionerClient.UpgradeRuntime(operation.ProvisioningParameters.ErsContext.GlobalAccountID, operation.RuntimeOperation.RuntimeID, requestInput)
 		if err != nil {
 			log.Errorf("call to provisioner failed: %s", err)
 			return operation, s.timeSchedule.Retry, nil

--- a/components/kyma-environment-broker/internal/runtimeversion/runtimeversion.go
+++ b/components/kyma-environment-broker/internal/runtimeversion/runtimeversion.go
@@ -31,7 +31,7 @@ func (rvc *RuntimeVersionConfigurator) ForProvisioning(op internal.ProvisioningO
 }
 
 func (rvc *RuntimeVersionConfigurator) ForUpgrade(op internal.UpgradeKymaOperation) (*internal.RuntimeVersionData, error) {
-	version, found, err := rvc.accountMapping.Get(op.GlobalAccountID, op.InstanceDetails.SubAccountID)
+	version, found, err := rvc.accountMapping.Get(op.GlobalAccountID, op.RuntimeOperation.SubAccountID)
 	if err != nil {
 		return nil, err
 	}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-419"
     kyma_environment_broker:
       dir:
-      version: "PR-428"
+      version: "PR-431"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-419"
     kyma_environment_broker:
       dir:
-      version: "PR-426"
+      version: "PR-428"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Fill orchestration DTO with runtime op attributes, as there are many legacy runtimes which doesn't have shoot and subaccount data properly sert/migrated in KEB DB
- add stack trace to kyma upgrade operation panic

