### PR TITLE
Check orchestration state in upgrade initialisation

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -606,8 +606,9 @@ func NewOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerStora
 	defaultRegion string, logs logrus.FieldLogger) (*process.Queue, error) {
 
 	upgradeKymaManager := upgrade_kyma.NewManager(db.Operations(), pub, logs.WithField("upgradeKyma", "manager"))
+	upgradeKymaInit := upgrade_kyma.NewInitialisationStep(db.Operations(), db.Orchestrations(), db.Instances(),
+		provisionerClient, inputFactory, icfg, runtimeVerConfigurator)
 
-	upgradeKymaInit := upgrade_kyma.NewInitialisationStep(db.Operations(), db.Instances(), provisionerClient, inputFactory, icfg, runtimeVerConfigurator)
 	upgradeKymaManager.InitStep(upgradeKymaInit)
 	upgradeKymaSteps := []struct {
 		disabled bool

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -169,6 +169,11 @@ func (o *Orchestration) IsFinished() bool {
 	return o.State == orchestration.Succeeded || o.State == orchestration.Failed || o.State == orchestration.Canceled
 }
 
+// IsCanceled returns true if orchestration's cancellation endpoint was ever triggered
+func (o *Orchestration) IsCanceled() bool {
+	return o.State == orchestration.Canceling || o.State == orchestration.Canceled
+}
+
 type InstanceWithOperation struct {
 	Instance
 

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
@@ -1,7 +1,6 @@
 package upgrade_kyma
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -38,11 +37,14 @@ func TestInitialisationStep_Run(t *testing.T) {
 		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
-		provisioningOperation := fixProvisioningOperation(t)
-		err := memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
+		err := memoryStorage.Orchestrations().Insert(internal.Orchestration{OrchestrationID: fixOrchestrationID, State: orchestration.InProgress})
 		require.NoError(t, err)
 
-		upgradeOperation := fixUpgradeKymaOperation(t)
+		provisioningOperation := fixProvisioningOperation()
+		err = memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
+		require.NoError(t, err)
+
+		upgradeOperation := fixUpgradeKymaOperation()
 		err = memoryStorage.Operations().InsertUpgradeKymaOperation(upgradeOperation)
 		require.NoError(t, err)
 
@@ -59,7 +61,7 @@ func TestInitialisationStep_Run(t *testing.T) {
 			RuntimeID: StringPtr(fixRuntimeID),
 		}, nil)
 
-		step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Instances(), provisionerClient, nil, nil, nil)
+		step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Orchestrations(), memoryStorage.Instances(), provisionerClient, nil, nil, nil)
 
 		// when
 		upgradeOperation, repeat, err := step.Run(upgradeOperation, log)
@@ -81,11 +83,14 @@ func TestInitialisationStep_Run(t *testing.T) {
 		memoryStorage := storage.NewMemoryStorage()
 		ver := &internal.RuntimeVersionData{}
 
-		provisioningOperation := fixProvisioningOperation(t)
-		err := memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
+		err := memoryStorage.Orchestrations().Insert(internal.Orchestration{OrchestrationID: fixOrchestrationID, State: orchestration.InProgress})
 		require.NoError(t, err)
 
-		upgradeOperation := fixUpgradeKymaOperation(t)
+		provisioningOperation := fixProvisioningOperation()
+		err = memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
+		require.NoError(t, err)
+
+		upgradeOperation := fixUpgradeKymaOperation()
 		upgradeOperation.ProvisionerOperationID = ""
 		err = memoryStorage.Operations().InsertUpgradeKymaOperation(upgradeOperation)
 		require.NoError(t, err)
@@ -105,7 +110,7 @@ func TestInitialisationStep_Run(t *testing.T) {
 		expectedOperation.State = orchestration.InProgress
 		rvc.On("ForUpgrade", expectedOperation).Return(ver, nil).Once()
 
-		step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Instances(), provisionerClient, inputBuilder, nil, rvc)
+		step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Orchestrations(), memoryStorage.Instances(), provisionerClient, inputBuilder, nil, rvc)
 
 		// when
 		op, repeat, err := step.Run(upgradeOperation, log)
@@ -121,38 +126,39 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	t.Run("should mark finish if operation was canceled", func(t *testing.T) {
+	t.Run("should mark finish if orchestration was canceled", func(t *testing.T) {
 		// given
 		log := logrus.New()
 		memoryStorage := storage.NewMemoryStorage()
 
-		upgradeOperation := fixUpgradeKymaOperation(t)
-		upgradeOperation.State = orchestration.Canceled
-		err := memoryStorage.Operations().InsertUpgradeKymaOperation(upgradeOperation)
+		err := memoryStorage.Orchestrations().Insert(internal.Orchestration{OrchestrationID: fixOrchestrationID, State: orchestration.Canceled})
 		require.NoError(t, err)
 
-		provisioningOperation := fixProvisioningOperation(t)
+		upgradeOperation := fixUpgradeKymaOperation()
+		err = memoryStorage.Operations().InsertUpgradeKymaOperation(upgradeOperation)
+		require.NoError(t, err)
+
+		provisioningOperation := fixProvisioningOperation()
 		err = memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
 		require.NoError(t, err)
 
-		step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Instances(), nil, nil, nil, nil)
+		step := NewInitialisationStep(memoryStorage.Operations(), memoryStorage.Orchestrations(), memoryStorage.Instances(), nil, nil, nil, nil)
 
 		// when
 		upgradeOperation, repeat, err := step.Run(upgradeOperation, log)
 
 		// then
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, time.Duration(0), repeat)
 		assert.Equal(t, orchestration.Canceled, string(upgradeOperation.State))
 
 		storedOp, err := memoryStorage.Operations().GetUpgradeKymaOperationByID(upgradeOperation.Operation.ID)
+		require.NoError(t, err)
 		assert.Equal(t, upgradeOperation, *storedOp)
-		assert.NoError(t, err)
-
 	})
 }
 
-func fixUpgradeKymaOperation(t *testing.T) internal.UpgradeKymaOperation {
+func fixUpgradeKymaOperation() internal.UpgradeKymaOperation {
 	n := time.Now()
 	windowEnd := n.Add(time.Minute)
 	return internal.UpgradeKymaOperation{
@@ -175,7 +181,7 @@ func fixUpgradeKymaOperation(t *testing.T) internal.UpgradeKymaOperation {
 	}
 }
 
-func fixProvisioningOperation(t *testing.T) internal.ProvisioningOperation {
+func fixProvisioningOperation() internal.ProvisioningOperation {
 	return internal.ProvisioningOperation{
 		Operation: internal.Operation{
 			ID:                     fixProvisioningOperationID,
@@ -199,15 +205,6 @@ func fixProvisioningParameters() internal.ProvisioningParameters {
 		},
 		Parameters: internal.ProvisioningParametersDTO{},
 	}
-}
-
-func fixRawProvisioningParameters(t *testing.T) string {
-	rawParameters, err := json.Marshal(fixProvisioningParameters())
-	if err != nil {
-		t.Errorf("cannot marshal provisioning parameters: %s", err)
-	}
-
-	return string(rawParameters)
 }
 
 func fixInstanceRuntimeStatus() internal.Instance {

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step_test.go
@@ -34,7 +34,7 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 	err := memoryStorage.Operations().InsertUpgradeKymaOperation(operation)
 	assert.NoError(t, err)
 
-	provisioningOperation := fixProvisioningOperation(t)
+	provisioningOperation := fixProvisioningOperation()
 	err = memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
 	assert.NoError(t, err)
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added check for orchestration state in upgrade initialisation

* we need that because of race condition which may happen between orchestration manager's waiting loop and the parallel strategy executor 