### PR TITLE
Fix building components list for upgrade

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -240,7 +240,7 @@ func (f *InputBuilderFactory) initUpgradeRuntimeInput(version internal.RuntimeVe
 	return gqlschema.UpgradeRuntimeInput{
 		KymaConfig: &gqlschema.KymaConfigInput{
 			Version:    version.Version,
-			Components: components,
+			Components: components.DeepCopy(),
 		},
 	}, nil
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-390"
     kyma_environment_broker:
       dir:
-      version: "PR-431"
+      version: "PR-442"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

The `initUpgradeRuntimeInput()` function returns the original `InputBuilderFactory.fullComponentsList` slice to the operation. Later on at `RuntimeInput.disableComponentsForProvisionRuntime()` the slice backing array is edited in place with the notorious in-place filtering algorithm implemented in `NewGenericComponentDisabler`
