### PR TITLE
Align schemas in KEB swagger

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/files/swagger.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/files/swagger.yaml
@@ -272,14 +272,14 @@ components:
               type: string
               example: parallel
               enum: [
-                "parallel"
+                  "parallel"
               ]
               description: "Specifies the type of the orchestration"
             schedule:
               type: string
               enum: [
-                "immediate",
-                "maintenanceWindow"
+                  "immediate",
+                  "maintenanceWindow"
               ]
               example: immediate
               description: "Specifies the schedule type for an orchestration"
@@ -312,7 +312,7 @@ components:
         target:
           type: string
           enum: [
-            "all"
+              "all"
           ]
           example: all
           description: "Selects Runtimes in a specified way"
@@ -399,9 +399,9 @@ components:
           type: string
           example: in progress
           enum: [
-            "suceeded",
-            "failed",
-            "in progress"
+              "suceeded",
+              "failed",
+              "in progress"
           ]
         description:
           type: string
@@ -458,9 +458,9 @@ components:
         state:
           type: string
           enum: [
-            "suceeded",
-            "failed",
-            "in progress"
+              "suceeded",
+              "failed",
+              "in progress"
           ]
           example: in progress
         description:
@@ -587,7 +587,7 @@ components:
         deprovisioning:
           $ref: '#/components/schemas/OperationStateDTO'
         upgradingKyma:
-          $ref: '#/components/schemas/OperationStateDTO'
+          $ref: '#/components/schemas/OperationsDataDTO'
 
     OperationStateDTO:
       type: object
@@ -596,13 +596,31 @@ components:
           type: string
           example: in progress
           enum: [
-            "suceeded",
-            "failed",
-            "in progress"
+              "suceeded",
+              "failed",
+              "in progress"
           ]
         description:
           type: string
           example: Operation scheduled
+        createdAt:
+          type: string
+          format: timestamp
+        operationID:
+          type: string
+          format: uuid
+
+    OperationsDataDTO:
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/OperationStateDTO'
+        count:
+          type: integer
+        totalCount:
+          type: integer
 
     errObj:
       type: object


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Schemas in KEB Swagger for `/runtimes` endpoint was not up to date - operation was missing `createdAt` and `operationID` fields and currently `upgradingKyma` section of RuntimeStatus is an array (limited to last 2 upgradeKymaOperations)

Changes proposed in this pull request:

- Aligned schemas in KEB Swagger

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
