### PR TITLE
Fix converting orchestration ID in upgrade ops

### DIFF
--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -38,7 +38,7 @@ type Operation struct {
 	Description     string    `json:"description"`
 	CreatedAt       time.Time `json:"createdAt"`
 	OperationID     string    `json:"operationID"`
-	OrchestrationID *string   `json:"orchestrationID,omitempty"`
+	OrchestrationID string    `json:"orchestrationID,omitempty"`
 }
 
 type RuntimesPage struct {

--- a/components/kyma-environment-broker/internal/runtime/converter.go
+++ b/components/kyma-environment-broker/internal/runtime/converter.go
@@ -58,9 +58,7 @@ func (c *converter) applyOperation(source *internal.Operation, target *pkg.Opera
 		target.CreatedAt = source.CreatedAt
 		target.State = string(source.State)
 		target.Description = source.Description
-		if source.OrchestrationID != "" {
-			target.OrchestrationID = &source.OrchestrationID
-		}
+		target.OrchestrationID = source.OrchestrationID
 	}
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-440"
     kyma_environment_broker:
       dir:
-      version: "PR-436"
+      version: "PR-449"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
**Description**

Orchestration ID in runtime's upgradingKyma.data block is duplicated for all operations:

```
        "upgradingKyma": {
          "data": [
            {
              "state": "in progress",
              "description": "kyma upgrade in progress",
              "createdAt": "2021-01-14T09:57:59.070884Z",
              "operationID": "71c63c56-54c5-420d-8e9a-d0949982d52e",
              "orchestrationID": "1c887a00-42fd-44a4-ae59-0f4118a9251d"
            },
            {
              "state": "in progress",
              "description": "Operation created",
              "createdAt": "2021-01-13T10:35:36.471386Z",
              "operationID": "afd519b4-6947-4ade-a1f7-6d8e23afdcc7",
              "orchestrationID": "1c887a00-42fd-44a4-ae59-0f4118a9251d"
            }
```

It is caused by the local variable used in the for loop being reused, and pointer to the `source.OrchestrationID` being used.

