### PR TITLE
Ensure pre- and post- logic return valid data on Kyma upgrade

### DIFF
--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/evaluation_manager.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/evaluation_manager.go
@@ -56,14 +56,20 @@ func (em *EvaluationManager) RestoreStatus(operation internal.UpgradeKymaOperati
 
 	// do internal monitor status reset
 	if em.internalAssistant.IsValid(avsData) && em.internalAssistant.IsInMaintenance(avsData) {
-		op, _, err := em.delegator.ResetStatus(logger, operation, em.internalAssistant)
-		return op, delay, err
+		op, d, err := em.delegator.ResetStatus(logger, operation, em.internalAssistant)
+		if d == 0 {
+			d = delay
+		}
+		return op, d, err
 	}
 
 	// do external monitor status reset
 	if em.externalAssistant.IsValid(avsData) && em.externalAssistant.IsInMaintenance(avsData) {
-		op, _, err := em.delegator.ResetStatus(logger, operation, em.externalAssistant)
-		return op, delay, err
+		op, d, err := em.delegator.ResetStatus(logger, operation, em.externalAssistant)
+		if d == 0 {
+			d = delay
+		}
+		return op, d, err
 	}
 
 	return operation, delay, nil

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/evaluation_manager.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/evaluation_manager.go
@@ -27,52 +27,38 @@ func NewEvaluationManager(delegator *avs.Delegator, config avs.Config) *Evaluati
 // SetStatus updates evaluation monitors (internal and external) status.
 // Note that this operation should be called twice (reason behind the zero delay)
 // to configure both monitors.
-// Should never return zero delay as Upgrade Manager will pickup operation as completed.
-// See: Manager.Execute
 func (em *EvaluationManager) SetStatus(status string, operation internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
 	avsData := operation.Avs
-	delay := 1 * time.Second
 
 	// do internal monitor status update
 	if em.internalAssistant.IsValid(avsData) && !em.internalAssistant.IsInMaintenance(avsData) {
-		op, _, err := em.delegator.SetStatus(logger, operation, em.internalAssistant, status)
-		return op, delay, err
+		return em.delegator.SetStatus(logger, operation, em.internalAssistant, status)
 	}
 
 	// do external monitor status update
 	if em.externalAssistant.IsValid(avsData) && !em.externalAssistant.IsInMaintenance(avsData) {
-		op, _, err := em.delegator.SetStatus(logger, operation, em.externalAssistant, status)
-		return op, delay, err
+		return em.delegator.SetStatus(logger, operation, em.externalAssistant, status)
 	}
 
-	return operation, delay, nil
+	return operation, 0, nil
 }
 
 // RestoreStatus reverts previously set evaluation monitors status.
 // Similarly to SetStatus, this method should also be called twice.
 func (em *EvaluationManager) RestoreStatus(operation internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
 	avsData := operation.Avs
-	delay := 1 * time.Second
 
 	// do internal monitor status reset
 	if em.internalAssistant.IsValid(avsData) && em.internalAssistant.IsInMaintenance(avsData) {
-		op, d, err := em.delegator.ResetStatus(logger, operation, em.internalAssistant)
-		if d == 0 {
-			d = delay
-		}
-		return op, d, err
+		return em.delegator.ResetStatus(logger, operation, em.internalAssistant)
 	}
 
 	// do external monitor status reset
 	if em.externalAssistant.IsValid(avsData) && em.externalAssistant.IsInMaintenance(avsData) {
-		op, d, err := em.delegator.ResetStatus(logger, operation, em.externalAssistant)
-		if d == 0 {
-			d = delay
-		}
-		return op, d, err
+		return em.delegator.ResetStatus(logger, operation, em.externalAssistant)
 	}
 
-	return operation, delay, nil
+	return operation, 0, nil
 }
 
 func (em *EvaluationManager) SetMaintenanceStatus(operation internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/evaluation_manager.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/evaluation_manager.go
@@ -27,38 +27,46 @@ func NewEvaluationManager(delegator *avs.Delegator, config avs.Config) *Evaluati
 // SetStatus updates evaluation monitors (internal and external) status.
 // Note that this operation should be called twice (reason behind the zero delay)
 // to configure both monitors.
+// Should never return zero delay as Upgrade Manager will pickup operation as completed.
+// See: Manager.Execute
 func (em *EvaluationManager) SetStatus(status string, operation internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
 	avsData := operation.Avs
+	delay := 1 * time.Second
 
 	// do internal monitor status update
 	if em.internalAssistant.IsValid(avsData) && !em.internalAssistant.IsInMaintenance(avsData) {
-		return em.delegator.SetStatus(logger, operation, em.internalAssistant, status)
+		op, _, err := em.delegator.SetStatus(logger, operation, em.internalAssistant, status)
+		return op, delay, err
 	}
 
 	// do external monitor status update
 	if em.externalAssistant.IsValid(avsData) && !em.externalAssistant.IsInMaintenance(avsData) {
-		return em.delegator.SetStatus(logger, operation, em.externalAssistant, status)
+		op, _, err := em.delegator.SetStatus(logger, operation, em.externalAssistant, status)
+		return op, delay, err
 	}
 
-	return operation, 0, nil
+	return operation, delay, nil
 }
 
 // RestoreStatus reverts previously set evaluation monitors status.
 // Similarly to SetStatus, this method should also be called twice.
 func (em *EvaluationManager) RestoreStatus(operation internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
 	avsData := operation.Avs
+	delay := 1 * time.Second
 
 	// do internal monitor status reset
 	if em.internalAssistant.IsValid(avsData) && em.internalAssistant.IsInMaintenance(avsData) {
-		return em.delegator.ResetStatus(logger, operation, em.internalAssistant)
+		op, _, err := em.delegator.ResetStatus(logger, operation, em.internalAssistant)
+		return op, delay, err
 	}
 
 	// do external monitor status reset
 	if em.externalAssistant.IsValid(avsData) && em.externalAssistant.IsInMaintenance(avsData) {
-		return em.delegator.ResetStatus(logger, operation, em.externalAssistant)
+		op, _, err := em.delegator.ResetStatus(logger, operation, em.externalAssistant)
+		return op, delay, err
 	}
 
-	return operation, 0, nil
+	return operation, delay, nil
 }
 
 func (em *EvaluationManager) SetMaintenanceStatus(operation internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-440"
     kyma_environment_broker:
       dir:
-      version: "PR-434"
+      version: "PR-451"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As per Kyma upgrade Manager requirement, zero delay means the operation has finished. 
https://github.com/kyma-project/control-plane/blob/83bd1342cc40ef7b9fb3679f04b88985315fb0e0/components/kyma-environment-broker/internal/process/upgrade_kyma/manager.go#L96-L98

This means pre- and post- logic should always return non-zero delay to avoid data collisions.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
