### PR TITLE
declaring the AVS api key as sensitive data

### DIFF
--- a/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 )
 
@@ -42,8 +43,9 @@ func (iec *InternalEvalAssistant) AppendOverrides(inputCreator internal.Provisio
 			Value: strconv.FormatInt(evaluationId, 10),
 		},
 		{
-			Key:   AvsBridgeAPIKey,
-			Value: apiKey,
+			Key:    AvsBridgeAPIKey,
+			Value:  apiKey,
+			Secret: ptr.Bool(true),
 		},
 	})
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/internal_eval_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 
 	"github.com/gorilla/mux"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
@@ -71,7 +72,7 @@ func TestInternalEvaluationStep_Run(t *testing.T) {
 	inputCreator.AssertOverride(t, avs.ComponentName, gqlschema.ConfigEntryInput{
 		Key: avs.EvaluationIdKey, Value: strconv.FormatInt(mockAvsSvc.evals[inDB.Avs.AvsEvaluationInternalId].Id, 10)})
 	inputCreator.AssertOverride(t, avs.ComponentName, gqlschema.ConfigEntryInput{
-		Key: avs.AvsBridgeAPIKey, Value: dummyStrAvsTest})
+		Key: avs.AvsBridgeAPIKey, Value: dummyStrAvsTest, Secret: ptr.Bool(true)})
 }
 
 func TestInternalEvaluationStep_WhenOperationIsRepeatedWithIdPresent(t *testing.T) {
@@ -115,7 +116,7 @@ func TestInternalEvaluationStep_WhenOperationIsRepeatedWithIdPresent(t *testing.
 	inputCreator.AssertOverride(t, avs.ComponentName, gqlschema.ConfigEntryInput{
 		Key: avs.EvaluationIdKey, Value: strconv.FormatInt(id, 10)})
 	inputCreator.AssertOverride(t, avs.ComponentName, gqlschema.ConfigEntryInput{
-		Key: avs.AvsBridgeAPIKey, Value: dummyStrAvsTest})
+		Key: avs.AvsBridgeAPIKey, Value: dummyStrAvsTest, Secret: ptr.Bool(true)})
 }
 
 func newMockAvsOauthServer() *httptest.Server {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-440"
     kyma_environment_broker:
       dir:
-      version: "PR-437"
+      version: "PR-454"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- declared the avs apikey overwrite as sensitive to get it stored in a secret on the cluster rather than a configmap
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
