### PR TITLE
Implement fake edp client for tests

### DIFF
--- a/components/kyma-environment-broker/internal/edp/client_fake.go
+++ b/components/kyma-environment-broker/internal/edp/client_fake.go
@@ -1,25 +1,79 @@
 package edp
 
+import "errors"
+
 // FakeClient implements the edp client interface but does not process data nor call real external system
-type FakeClient struct{}
+type FakeClient struct {
+	data map[string]interface{}
+}
 
 // NewFakeClient creates edp fake client
 func NewFakeClient() *FakeClient {
-	return &FakeClient{}
+	return &FakeClient{
+		data: make(map[string]interface{}),
+	}
 }
 
 func (f *FakeClient) CreateDataTenant(data DataTenantPayload) error {
+	err := checkDataTenantPayload(data)
+	if err != nil {
+		return err
+	}
+	f.data["DataTenant"] = struct {
+		Name        string
+		Environment string
+		Secret      string
+	}{
+		Name:        data.Name,
+		Environment: data.Environment,
+		Secret:      data.Secret,
+	}
 	return nil
 }
 
 func (f *FakeClient) CreateMetadataTenant(name, env string, data MetadataTenantPayload) error {
+	err := checkMetadataTenantPayload(data)
+	if err != nil {
+		return err
+	}
+	f.data["MetadataTenant"] = struct {
+		Key   string
+		Value string
+	}{
+		Key:   data.Key,
+		Value: data.Value,
+	}
 	return nil
 }
 
 func (f *FakeClient) DeleteDataTenant(name, env string) error {
+	_, found := f.data["DataTenant"]
+	if !found {
+		return errors.New("datatenant does not exist")
+	}
+	delete(f.data, "DataTenant")
 	return nil
 }
 
 func (f *FakeClient) DeleteMetadataTenant(name, env, key string) error {
+	_, found := f.data["MetadataTenant"]
+	if !found {
+		return errors.New("metadatatenant does not exist")
+	}
+	delete(f.data, "MetadataTenant")
+	return nil
+}
+
+func checkDataTenantPayload(data DataTenantPayload) error {
+	if data.Name == "" || data.Environment == "" || data.Secret == "" {
+		return errors.New("one of the fields in DataTenantPayload is missing")
+	}
+	return nil
+}
+
+func checkMetadataTenantPayload(data MetadataTenantPayload) error {
+	if data.Key == "" || data.Value == "" {
+		return errors.New("one of the fields in MetadataTenantPayload is missing")
+	}
 	return nil
 }

--- a/components/kyma-environment-broker/internal/edp/client_fake.go
+++ b/components/kyma-environment-broker/internal/edp/client_fake.go
@@ -1,66 +1,104 @@
 package edp
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+	"sync"
+)
+
+const (
+	dataTenantMapKey     = "%s-%s"
+	metadataTenantMapKey = "%s-%s-%s"
+)
 
 // FakeClient implements the edp client interface but does not process data nor call real external system
 type FakeClient struct {
-	data map[string]interface{}
+	mu                 sync.Mutex
+	dataTenantData     map[string]DataTenantItem
+	metadataTenantData map[string]MetadataItem
 }
 
 // NewFakeClient creates edp fake client
 func NewFakeClient() *FakeClient {
 	return &FakeClient{
-		data: make(map[string]interface{}),
+		dataTenantData:     make(map[string]DataTenantItem),
+		metadataTenantData: make(map[string]MetadataItem),
 	}
 }
 
 func (f *FakeClient) CreateDataTenant(data DataTenantPayload) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	err := checkDataTenantPayload(data)
 	if err != nil {
 		return err
 	}
-	f.data["DataTenant"] = struct {
-		Name        string
-		Environment string
-		Secret      string
-	}{
+
+	key := generateDataTenantMapKey(data.Name, data.Environment)
+
+	_, found := f.dataTenantData[key]
+	if found {
+		return errors.New("datatenant already exist")
+	}
+
+	f.dataTenantData[key] = DataTenantItem{
 		Name:        data.Name,
 		Environment: data.Environment,
-		Secret:      data.Secret,
 	}
 	return nil
 }
 
 func (f *FakeClient) CreateMetadataTenant(name, env string, data MetadataTenantPayload) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
 	err := checkMetadataTenantPayload(data)
 	if err != nil {
 		return err
 	}
-	f.data["MetadataTenant"] = struct {
-		Key   string
-		Value string
-	}{
-		Key:   data.Key,
-		Value: data.Value,
+
+	dataMapKey := generateDataTenantMapKey(name, env)
+	metadataMapKey := generateMetadataTenantMapKey(name, env, data.Key)
+
+	_, found := f.metadataTenantData[metadataMapKey]
+	if found {
+		return errors.New("metadatatenant already exist")
+	}
+
+	f.metadataTenantData[metadataMapKey] = MetadataItem{
+		DataTenant: f.dataTenantData[dataMapKey],
+		Key:        data.Key,
+		Value:      data.Value,
 	}
 	return nil
 }
 
 func (f *FakeClient) DeleteDataTenant(name, env string) error {
-	_, found := f.data["DataTenant"]
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	key := generateDataTenantMapKey(name, env)
+
+	_, found := f.dataTenantData[key]
 	if !found {
 		return errors.New("datatenant does not exist")
 	}
-	delete(f.data, "DataTenant")
+	delete(f.dataTenantData, key)
 	return nil
 }
 
 func (f *FakeClient) DeleteMetadataTenant(name, env, key string) error {
-	_, found := f.data["MetadataTenant"]
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	mapKey := generateMetadataTenantMapKey(name, env, key)
+
+	_, found := f.metadataTenantData[mapKey]
 	if !found {
 		return errors.New("metadatatenant does not exist")
 	}
-	delete(f.data, "MetadataTenant")
+	delete(f.metadataTenantData, mapKey)
 	return nil
 }
 
@@ -76,4 +114,25 @@ func checkMetadataTenantPayload(data MetadataTenantPayload) error {
 		return errors.New("one of the fields in MetadataTenantPayload is missing")
 	}
 	return nil
+}
+
+func generateDataTenantMapKey(name, env string) string {
+	return fmt.Sprintf(dataTenantMapKey, name, env)
+}
+
+func generateMetadataTenantMapKey(name, env, key string) string {
+	return fmt.Sprintf(metadataTenantMapKey, name, env, key)
+}
+
+// assert methods
+func (f *FakeClient) GetDataTenantItem(name, env string) (item DataTenantItem, exists bool) {
+	key := generateDataTenantMapKey(name, env)
+	item, exists = f.dataTenantData[key]
+	return item, exists
+}
+
+func (f *FakeClient) GetMetadataItem(name, env, key string) (item MetadataItem, exists bool) {
+	mapKey := generateMetadataTenantMapKey(name, env, key)
+	item, exists = f.metadataTenantData[mapKey]
+	return item, exists
 }

--- a/components/kyma-environment-broker/internal/edp/client_fake.go
+++ b/components/kyma-environment-broker/internal/edp/client_fake.go
@@ -5,7 +5,7 @@ type FakeClient struct{}
 
 // NewFakeClient creates edp fake client
 func NewFakeClient() *FakeClient {
-	return &FakeClient {}
+	return &FakeClient{}
 }
 
 func (f *FakeClient) CreateDataTenant(data DataTenantPayload) error {

--- a/components/kyma-environment-broker/internal/edp/client_fake.go
+++ b/components/kyma-environment-broker/internal/edp/client_fake.go
@@ -1,0 +1,25 @@
+package edp
+
+// FakeClient implements the edp client interface but does not process data nor call real external system
+type FakeClient struct{}
+
+// NewFakeClient creates edp fake client
+func NewFakeClient() *FakeClient {
+	return &FakeClient {}
+}
+
+func (f *FakeClient) CreateDataTenant(data DataTenantPayload) error {
+	return nil
+}
+
+func (f *FakeClient) CreateMetadataTenant(name, env string, data MetadataTenantPayload) error {
+	return nil
+}
+
+func (f *FakeClient) DeleteDataTenant(name, env string) error {
+	return nil
+}
+
+func (f *FakeClient) DeleteMetadataTenant(name, env, key string) error {
+	return nil
+}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/edp"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/deprovisioning/automock"
-
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
@@ -19,16 +17,7 @@ const (
 
 func TestEDPDeregistration_Run(t *testing.T) {
 	// given
-	client := &automock.EDPClient{}
-	client.On("DeleteMetadataTenant", edpName, edpEnvironment, edp.MaasConsumerSubAccountKey).
-		Return(nil).Once()
-	client.On("DeleteMetadataTenant", edpName, edpEnvironment, edp.MaasConsumerRegionKey).
-		Return(nil).Once()
-	client.On("DeleteMetadataTenant", edpName, edpEnvironment, edp.MaasConsumerEnvironmentKey).
-		Return(nil).Once()
-	client.On("DeleteDataTenant", edpName, edpEnvironment).
-		Return(nil).Once()
-	defer client.AssertExpectations(t)
+	client := edp.NewFakeClient()
 
 	step := NewEDPDeregistrationStep(client, edp.Config{
 		Environment: edpEnvironment,

--- a/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration_test.go
@@ -1,6 +1,8 @@
 package deprovisioning
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
 	"time"
 
@@ -18,6 +20,24 @@ const (
 func TestEDPDeregistration_Run(t *testing.T) {
 	// given
 	client := edp.NewFakeClient()
+	client.CreateDataTenant(edp.DataTenantPayload{
+		Name:        edpName,
+		Environment: edpEnvironment,
+		Secret:      base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s%s", edpName, edpEnvironment))),
+	})
+
+	metadataTenantKeys := []string{
+		edp.MaasConsumerEnvironmentKey,
+		edp.MaasConsumerRegionKey,
+		edp.MaasConsumerSubAccountKey,
+	}
+
+	for _, key := range metadataTenantKeys {
+		client.CreateMetadataTenant(edpName, edpEnvironment, edp.MetadataTenantPayload{
+			Key:   key,
+			Value: "-",
+		})
+	}
 
 	step := NewEDPDeregistrationStep(client, edp.Config{
 		Environment: edpEnvironment,
@@ -34,4 +54,14 @@ func TestEDPDeregistration_Run(t *testing.T) {
 	// then
 	assert.Equal(t, 0*time.Second, repeat)
 	assert.NoError(t, err)
+
+	for _, key := range metadataTenantKeys {
+		metadataTenant, metadataTenantExists := client.GetMetadataItem(edpName, edpEnvironment, key)
+		assert.False(t, metadataTenantExists)
+		assert.Equal(t, edp.MetadataItem{}, metadataTenant)
+	}
+
+	dataTenant, dataTenantExists := client.GetDataTenantItem(edpName, edpEnvironment)
+	assert.False(t, dataTenantExists)
+	assert.Equal(t, edp.DataTenantItem{}, dataTenant)
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/edp_registration_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/edp_registration_test.go
@@ -43,6 +43,31 @@ func TestEDPRegistration_Run(t *testing.T) {
 	// then
 	assert.Equal(t, 0*time.Second, repeat)
 	assert.NoError(t, err)
+
+	dataTenant, dataTenantExists := client.GetDataTenantItem(edpName, edpEnvironment)
+	assert.True(t, dataTenantExists)
+	assert.Equal(t, edp.DataTenantItem{
+		Name:        edpName,
+		Environment: edpEnvironment,
+	}, dataTenant)
+
+	for key, value := range map[string]string{
+		edp.MaasConsumerEnvironmentKey: step.selectEnvironmentKey(edpRegion, logger.NewLogDummy()),
+		edp.MaasConsumerRegionKey:      edpRegion,
+		edp.MaasConsumerSubAccountKey:  edpName,
+	} {
+		metadataTenant, metadataTenantExists := client.GetMetadataItem(edpName, edpEnvironment, key)
+		assert.True(t, metadataTenantExists)
+		assert.Equal(t, edp.MetadataItem{
+			DataTenant: edp.DataTenantItem{
+				Name:        edpName,
+				Environment: edpEnvironment,
+			},
+			Key:   key,
+			Value: value,
+		}, metadataTenant)
+	}
+
 }
 
 func TestEDPRegistrationStep_selectEnvironmentKey(t *testing.T) {

--- a/components/kyma-environment-broker/internal/process/provisioning/edp_registration_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/edp_registration_test.go
@@ -1,15 +1,12 @@
 package provisioning
 
 import (
-	"encoding/base64"
-	"fmt"
 	"testing"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/edp"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/logger"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning/automock"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 
 	"github.com/stretchr/testify/assert"
@@ -24,26 +21,7 @@ const (
 func TestEDPRegistration_Run(t *testing.T) {
 	// given
 	memoryStorage := storage.NewMemoryStorage()
-	client := &automock.EDPClient{}
-	client.On("CreateDataTenant", edp.DataTenantPayload{
-		Name:        edpName,
-		Environment: edpEnvironment,
-		// it is copy of body `generateSecret` method in `EDPRegistrationStep` step
-		Secret: base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s%s", edpName, edpEnvironment))),
-	}).Return(nil).Once()
-	client.On("CreateMetadataTenant", edpName, edpEnvironment, edp.MetadataTenantPayload{
-		Key:   edp.MaasConsumerEnvironmentKey,
-		Value: "CF",
-	}).Return(nil).Once()
-	client.On("CreateMetadataTenant", edpName, edpEnvironment, edp.MetadataTenantPayload{
-		Key:   edp.MaasConsumerRegionKey,
-		Value: edpRegion,
-	}).Return(nil).Once()
-	client.On("CreateMetadataTenant", edpName, edpEnvironment, edp.MetadataTenantPayload{
-		Key:   edp.MaasConsumerSubAccountKey,
-		Value: edpName,
-	}).Return(nil).Once()
-	defer client.AssertExpectations(t)
+	client := edp.NewFakeClient()
 
 	step := NewEDPRegistrationStep(memoryStorage.Operations(), client, edp.Config{
 		Environment: edpEnvironment,

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-435"
     kyma_environment_broker:
       dir:
-      version: "PR-479"
+      version: "PR-463"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
**Description**

EDP fake client has been introduced to replace EDPClient mocks in tests.

Changes proposed in this pull request:

- New source file: client_fake.go, which contains fake EDP client implementation
- Mock replaced with fake client in: edp_deregistration_test.go
- Mock replaced with fake client in: edp_registration_test.go