### PR TITLE
Fix kcp runtimes suspended status

### DIFF
--- a/tools/cli/pkg/command/runtime.go
+++ b/tools/cli/pkg/command/runtime.go
@@ -172,6 +172,12 @@ func findLastOperation(rt runtime.RuntimeDTO) (runtime.Operation, operationType)
 func operationStatusToString(op runtime.Operation, t operationType) string {
 	switch op.State {
 	case succeeded:
+		switch t {
+		case deprovision:
+			return "deprovisioned"
+		case suspension:
+			return "suspended"
+		}
 		return "succeeded"
 	case failed:
 		return fmt.Sprintf("%s (%s)", "failed", t)


### PR DESCRIPTION
**Description**

Deprovisioned and suspended SKRs should not be displayed as succeeded.
