### PR TITLE
Allow changing trial limit per GA

### DIFF
--- a/components/kyma-environment-broker/internal/broker/broker.go
+++ b/components/kyma-environment-broker/internal/broker/broker.go
@@ -27,7 +27,8 @@ type KymaEnvironmentBroker struct {
 // Config represents configuration for broker
 type Config struct {
 	Service
-	EnablePlans EnablePlans `envconfig:"default=azure"`
+	EnablePlans          EnablePlans `envconfig:"default=azure"`
+	OnlySingleTrialPerGA bool        `envconfig:"default=true"`
 }
 
 type Service struct {

--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -40,6 +40,7 @@ type ProvisionEndpoint struct {
 	queue                Queue
 	builderFactory       PlanValidator
 	enabledPlanIDs       map[string]struct{}
+	onlySingleTrialPerGA bool
 	plansSchemaValidator PlansSchemaValidator
 	kymaVerOnDemand      bool
 
@@ -72,6 +73,7 @@ func NewProvision(cfg Config,
 		builderFactory:       builderFactory,
 		log:                  log.WithField("service", "ProvisionEndpoint"),
 		enabledPlanIDs:       enabledPlanIDs,
+		onlySingleTrialPerGA: cfg.OnlySingleTrialPerGA,
 		kymaVerOnDemand:      kvod,
 		shootDomain:          gardenerConfig.ShootDomain,
 		shootProject:         gardenerConfig.Project,
@@ -208,7 +210,7 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 		return ersContext, parameters, errors.Errorf("the plan ID not known, planID: %s", details.PlanID)
 	}
 
-	if IsTrialPlan(details.PlanID) {
+	if IsTrialPlan(details.PlanID) && b.onlySingleTrialPerGA {
 		count, err := b.instanceStorage.GetNumberOfInstancesForGlobalAccountID(ersContext.GlobalAccountID)
 		if err != nil {
 			return ersContext, parameters, errors.Wrap(err, "while checking if a trial Kyma instance exists for given global account")

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -50,6 +50,8 @@ spec:
               value: "{{ .Values.disableProcessOperationsInProgress }}"
             - name: APP_BROKER_ENABLE_PLANS
               value: "{{ .Values.enablePlans }}"
+            - name: APP_BROKER_ONLY_SINGLE_TRIAL_PER_GA
+              value: "{{ .Values.onlySingleTrialPerGA }}"
             - name: APP_OPERATION_TIMEOUT
               value: "{{ .Values.broker.operationTimeout }}"
             - name: APP_BROKER_SERVICE_DISPLAY_NAME

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -76,6 +76,7 @@ kymaVersionOnDemand: "false"
 
 disableProcessOperationsInProgress: "false"
 enablePlans: "azure,gcp,azure_lite,trial"
+onlySingleTrialPerGA: "true"
 
 osbUpdateProcessingEnabled: "false"
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, the limit for TRIAL SKR is one per global account. To improve the testing process, the flag indicating if KEB should allow more than one trial SKR per global account is introduced in this PR. This should be enabled on `dev` environment only.

Changes proposed in this pull request:

- Added a flag to KEB to allow more than one trial SKR per global account ID

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
