### PR TITLE
Allow retriggering runtime suspension

### DIFF
--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -51,7 +51,7 @@ func (h *ContextUpdateHandler) Handle(instance *internal.Instance, newCtx intern
 		isActivated = *instance.Parameters.ErsContext.Active
 	}
 
-	if newCtx.Active == nil || isActivated == *newCtx.Active {
+	if newCtx.Active == nil || isActivated && *newCtx.Active {
 		logrus.Debugf("Context.Active flag was not changed, the current value: %v", newCtx.Active)
 		return nil
 	}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-435"
     kyma_environment_broker:
       dir:
-      version: "PR-477"
+      version: "PR-478"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-435"
     kyma_environment_broker:
       dir:
-      version: "PR-466"
+      version: "PR-477"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
**Description**

Only skip context update  during unsuspension, but allow retriggering suspension, as it is needed to reprocess failed deprovisionings.
