### PR TITLE
Add retriggering runtime suspension

### DIFF
--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -46,14 +46,36 @@ func (h *ContextUpdateHandler) Handle(instance *internal.Instance, newCtx intern
 		return nil
 	}
 
+	return h.handleContextChange(newCtx, instance, l)
+}
+
+func (h *ContextUpdateHandler) handleContextChange(newCtx internal.ERSContext, instance *internal.Instance, l logrus.FieldLogger) error {
 	isActivated := true
 	if instance.Parameters.ErsContext.Active != nil {
 		isActivated = *instance.Parameters.ErsContext.Active
 	}
 
 	if newCtx.Active == nil || isActivated == *newCtx.Active {
-		logrus.Debugf("Context.Active flag was not changed, the current value: %v", newCtx.Active)
-		return nil
+		l.Debugf("Context.Active flag was not changed, the current value: %v", *newCtx.Active)
+		if isActivated {
+			// instance is marked as Active and incoming context update is unsuspension
+			// TODO: consider retriggering failed unsuspension here
+			return nil
+		}
+		if !isActivated {
+			// instance is inactive and incoming context update is suspension - verify if KEB should retrigger the operation
+			lastDeprovisioning, err := h.operations.GetDeprovisioningOperationByInstanceID(instance.InstanceID)
+			// there was an error - fail
+			if err != nil && !dberr.IsNotFound(err) {
+				return err
+			}
+
+			if lastDeprovisioning.Temporary && lastDeprovisioning.State == domain.Failed {
+				l.Infof("Retriggering suspension for instance id %s", instance.InstanceID)
+				return h.suspend(instance, l)
+			}
+			return nil
+		}
 	}
 
 	if *newCtx.Active {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-435"
     kyma_environment_broker:
       dir:
-      version: "PR-466"
+      version: "PR-479"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-416"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently updating context with the same `Active` value as the one in `instance.Parameters.ErsContext.Active` in database results in skipping the update. However, `instance.Parameters.ErsContext.Active` is always updated if there is no error here:

https://github.com/kyma-project/control-plane/blob/b5e8b6e1163a47c6e819895af45bb3204d11df3c/components/kyma-environment-broker/internal/broker/instance_update.go#L69

`Handle()` method does not check, if the deprovisioning operation created underneath succeeded or failed in the process, and afterwards the instance is updated anyways which prevents from retriggering the failed suspension call when user tries updating context again (instance state in DB is `Active: false` and incoming call also contains `Active: false` parameter)

Changes proposed in this pull request:

- Check if there is an existing temporary operation when `Context.Active` flag was not changed - if it exists and is in state `failed`, retrigger the deprovisioning process

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
