### PR TITLE
Remove xip-patch component from kyma installer for KCP installation

### DIFF
--- a/installation/resources/installer-cr-kyma-kcp-dependencies.yaml
+++ b/installation/resources/installer-cr-kyma-kcp-dependencies.yaml
@@ -1,0 +1,38 @@
+apiVersion: "installer.kyma-project.io/v1alpha1"
+kind: Installation
+metadata:
+  name: kyma-installation
+  namespace: default
+  labels:
+    action: install
+    kyma-project.io/installation: ""
+  finalizers:
+    - finalizer.installer.kyma-project.io
+spec:
+  version: "0.0.1"
+  url: ""
+  components:
+    - name: "cluster-essentials"
+      namespace: "kyma-system"
+    - name: "testing"
+      namespace: "kyma-system"
+    - name: "istio"
+      namespace: "istio-system"
+    - name: "istio-kyma-patch"
+      namespace: "istio-system"
+    - name: "dex"
+      namespace: "kyma-system"
+    - name: "ory"
+      namespace: "kyma-system"
+    - name: "api-gateway"
+      namespace: "kyma-system"
+    - name: "core"
+      namespace: "kyma-system"
+    - name: "monitoring"
+      namespace: "kyma-system"
+    - name: "logging"
+      namespace: "kyma-system"
+    - name: "tracing"
+      namespace: "kyma-system"
+    - name: "kiali"
+      namespace: "kyma-system"

--- a/installation/scripts/generate-installer-artifacts.sh
+++ b/installation/scripts/generate-installer-artifacts.sh
@@ -37,15 +37,24 @@ function copyKymaInstaller() {
     release=$(<"${RESOURCES_DIR}"/KYMA_VERSION)
     if [[ $release == *PR-* ]] || [[ $release == *master* ]]; then
         curl -L https://storage.googleapis.com/kyma-development-artifacts/${release}/kyma-installer-cluster.yaml -o kyma-installer.yaml
+        curl -L https://storage.googleapis.com/kyma-development-artifacts/${release}/kyma-installer-cluster.yaml -o kyma-kcp-installer.yaml
+
         curl -L https://storage.googleapis.com/kyma-development-artifacts/${release}/is-installed.sh -o ${ARTIFACTS_DIR}/is-kyma-installed.sh
     else
         curl -L https://storage.googleapis.com/kyma-prow-artifacts/${release}/kyma-installer-cluster.yaml -o kyma-installer.yaml
+        curl -L https://storage.googleapis.com/kyma-prow-artifacts/${release}/kyma-installer-cluster.yaml -o kyma-kcp-installer.yaml
+
         cp ${SCRIPTS_DIR}/is-kyma-installed.sh ${ARTIFACTS_DIR}/is-kyma-installed.sh
     fi
 
     sed -i '/action: install/d' kyma-installer.yaml
     cat ${RESOURCES_DIR}/installer-cr-kyma-dependencies.yaml >> kyma-installer.yaml
+
+    sed -i '/action: install/d' kyma-kcp-installer.yaml
+    cat ${RESOURCES_DIR}/installer-cr-kyma-kcp-dependencies.yaml >> kyma-kcp-installer.yaml
+
     mv kyma-installer.yaml ${ARTIFACTS_DIR}/kyma-installer.yaml
+    mv kyma-kcp-installer.yaml ${ARTIFACTS_DIR}/kyma-kcp-installer.yaml
 }
 
 function copyCompassInstaller() {


### PR DESCRIPTION
Changes proposed in this pull request:

- Add new `installer-cr-kyma-kcp-dependencies.yaml` only for installation on `mps` where  `xip-patch` component is removed