### PR TITLE
Shorten the names of the e2e testing pods

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -2,7 +2,7 @@
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: e2e-provisioning-azure
+  name: e2e-azure
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
@@ -91,7 +91,7 @@ spec:
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: e2e-provisioning-azure-cleanup
+  name: e2e-azure-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -2,7 +2,7 @@
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: e2e-provisioning
+  name: e2e-gcp
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
@@ -90,7 +90,7 @@ spec:
 apiVersion: "testing.kyma-project.io/v1alpha1"
 kind: TestDefinition
 metadata:
-  name: e2e-provisioning-cleanup
+  name: e2e-gcp-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

After the kyma upgrade to 1.16.0-rc3, e2e-provisionining-azure-cleanup pod fails to be created due to the following error:

```
{"level":"error","ts":1612264845.4608088,"logger":"controller-runtime.controller","msg":"Reconciler error","controller":"testsuite-controller","request":"/testsuite-e2e-azure-cleanup","error":"while scheduling next testing pod for suite [testsuite-e2e-azure-cleanup]: while creating testing pod for suite [testsuite-e2e-azure-cleanup] and test definition [name: e2e-provisioning-azure-cleanup, namespace: kcp-system]: Pod \"oct-tp-testsuite-e2e-azure-cleanup-e2e-provisioning-azure-cleanup-0\" is invalid: metadata.labels: Invalid value: \"oct-tp-testsuite-e2e-azure-cleanup-e2e-provisioning-azure-cleanup-0\": must be no more than 63 characters" ...
```

