### PR TITLE
Enable kcp cli -o custom-columns output format

### DIFF
--- a/docs/cli/commands/kcp_orchestrations.md
+++ b/docs/cli/commands/kcp_orchestrations.md
@@ -20,6 +20,8 @@ kcp orchestrations [id] [ops|operations] [cancel] [flags]
 
 ```
   kcp orchestrations --state inprogress                                   Display all orchestrations which are in progress.
+  kcp orchestration -o custom="Orchestration ID:{.OrchestrationID},STATE:{.State},CREATED AT:{.createdAt}"
+                                                                          Display all orchestations with specific custom fields.
   kcp orchestration 0c4357f5-83e0-4b72-9472-49b5cd417c00                  Display details about a specific orchestration.
   kcp orchestration 0c4357f5-83e0-4b72-9472-49b5cd417c00 --operation OID  Display details of the specified Runtime operation within the orchestration.
   kcp orchestration 0c4357f5-83e0-4b72-9472-49b5cd417c00 operations       Display the operations of the given orchestration.
@@ -30,7 +32,7 @@ kcp orchestrations [id] [ops|operations] [cancel] [flags]
 
 ```
       --operation string   Option that displays details of the specified Runtime operation when a given orchestration is selected.
-  -o, --output string      Output type of displayed Runtime(s). The possible values are: table, json, custom-columns. (default "table")
+  -o, --output string      Output type of displayed Runtime(s). The possible values are: table, json, custom(e.g. custom=<header>:<jsonpath-field-spec>. (default "table")
   -s, --state strings      Filter output by state. You can provide multiple values, either separated by a comma (e.g. failed,inprogress), or by specifying the option multiple times. The possible values are: canceled, canceling, failed, inprogress, pending, succeeded.
 ```
 

--- a/docs/cli/commands/kcp_orchestrations.md
+++ b/docs/cli/commands/kcp_orchestrations.md
@@ -30,7 +30,7 @@ kcp orchestrations [id] [ops|operations] [cancel] [flags]
 
 ```
       --operation string   Option that displays details of the specified Runtime operation when a given orchestration is selected.
-  -o, --output string      Output type of displayed Runtime(s). The possible values are: table, json. (default "table")
+  -o, --output string      Output type of displayed Runtime(s). The possible values are: table, json, custom-columns. (default "table")
   -s, --state strings      Filter output by state. You can provide multiple values, either separated by a comma (e.g. failed,inprogress), or by specifying the option multiple times. The possible values are: canceled, canceling, failed, inprogress, pending, succeeded.
 ```
 

--- a/docs/cli/commands/kcp_runtimes.md
+++ b/docs/cli/commands/kcp_runtimes.md
@@ -17,13 +17,17 @@ kcp runtimes [flags]
   kcp runtimes                                           Display table overview about all Runtimes.
   kcp rt -c c-178e034 -o json                            Display all details about one Runtime identified by a Shoot name in the JSON format.
   kcp runtimes --account CA4836781TID000000000123456789  Display all Runtimes of a given global account.
+  kcp runtimes -c bbc3ee7 -o custom="INSTANCE ID:instanceID,SHOOTNAME:shootName"
+                                                         Display the custom fields about one Runtime identified by a Shoot name.
+  kcp runtimes -o custom="INSTANCE ID:instanceID,SHOOTNAME:shootName,runtimeID:runtimeID,STATUS:{status.provisioning}"
+                                                         Display all Runtimes with specific custom fields.
 ```
 
 ## Options
 
 ```
   -g, --account strings      Filter by global account ID. You can provide multiple values, either separated by a comma (e.g. GAID1,GAID2), or by specifying the option multiple times.
-  -o, --output string        Output type of displayed Runtime(s). The possible values are: table, json, custom-columns. (default "table")
+  -o, --output string        Output type of displayed Runtime(s). The possible values are: table, json, custom(e.g. custom=<header>:<jsonpath-field-spec>. (default "table")
   -p, --plan strings         Filter by service plan name. You can provide multiple values, either separated by a comma (e.g. azure,trial), or by specifying the option multiple times.
   -r, --region strings       Filter by provider region. You can provide multiple values, either separated by a comma (e.g. westeurope,northeurope), or by specifying the option multiple times.
   -i, --runtime-id strings   Filter by Runtime ID. You can provide multiple values, either separated by a comma (e.g. ID1,ID2), or by specifying the option multiple times.

--- a/docs/cli/commands/kcp_runtimes.md
+++ b/docs/cli/commands/kcp_runtimes.md
@@ -23,7 +23,7 @@ kcp runtimes [flags]
 
 ```
   -g, --account strings      Filter by global account ID. You can provide multiple values, either separated by a comma (e.g. GAID1,GAID2), or by specifying the option multiple times.
-  -o, --output string        Output type of displayed Runtime(s). The possible values are: table, json. (default "table")
+  -o, --output string        Output type of displayed Runtime(s). The possible values are: table, json, custom-columns. (default "table")
   -p, --plan strings         Filter by service plan name. You can provide multiple values, either separated by a comma (e.g. azure,trial), or by specifying the option multiple times.
   -r, --region strings       Filter by provider region. You can provide multiple values, either separated by a comma (e.g. westeurope,northeurope), or by specifying the option multiple times.
   -i, --runtime-id strings   Filter by Runtime ID. You can provide multiple values, either separated by a comma (e.g. ID1,ID2), or by specifying the option multiple times.

--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -20,7 +20,7 @@ const (
 const (
 	tableOutput        string = "table"
 	jsonOutput         string = "json"
-	customcolumnOutput string = "custom-columns"
+	customOutput string = "custom"
 )
 
 const (
@@ -138,7 +138,7 @@ func (keys *GlobalOptionsKey) GardenerNamespace() string {
 
 // SetOutputOpt configures the optput type option on the given command
 func SetOutputOpt(cmd *cobra.Command, opt *string) {
-	cmd.Flags().StringVarP(opt, "output", "o", tableOutput, fmt.Sprintf("Output type of displayed Runtime(s). The possible values are: %s, %s, %s.", tableOutput, jsonOutput, customcolumnOutput))
+	cmd.Flags().StringVarP(opt, "output", "o", tableOutput, fmt.Sprintf("Output type of displayed Runtime(s). The possible values are: %s, %s, %s(e.g. custom=<header>:<jsonpath-field-spec>.", tableOutput, jsonOutput, customOutput))
 }
 
 // ValidateOutputOpt checks whether the given optput type is one of the valid values
@@ -146,7 +146,7 @@ func ValidateOutputOpt(opt string) error {
 	switch {
 	case opt == tableOutput, opt == jsonOutput:
 		return nil
-	case strings.HasPrefix(opt, customcolumnOutput):
+	case strings.HasPrefix(opt, customOutput):
 		return nil
 	}
 	return fmt.Errorf("invalid value for output: %s", opt)

--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -18,8 +18,8 @@ const (
 )
 
 const (
-	tableOutput        string = "table"
-	jsonOutput         string = "json"
+	tableOutput  string = "table"
+	jsonOutput   string = "json"
 	customOutput string = "custom"
 )
 

--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -18,8 +18,9 @@ const (
 )
 
 const (
-	tableOutput string = "table"
-	jsonOutput  string = "json"
+	tableOutput        string = "table"
+	jsonOutput         string = "json"
+	customcolumnOutput string = "custom-columns"
 )
 
 const (
@@ -137,13 +138,15 @@ func (keys *GlobalOptionsKey) GardenerNamespace() string {
 
 // SetOutputOpt configures the optput type option on the given command
 func SetOutputOpt(cmd *cobra.Command, opt *string) {
-	cmd.Flags().StringVarP(opt, "output", "o", tableOutput, fmt.Sprintf("Output type of displayed Runtime(s). The possible values are: %s, %s.", tableOutput, jsonOutput))
+	cmd.Flags().StringVarP(opt, "output", "o", tableOutput, fmt.Sprintf("Output type of displayed Runtime(s). The possible values are: %s, %s, %s.", tableOutput, jsonOutput, customcolumnOutput))
 }
 
 // ValidateOutputOpt checks whether the given optput type is one of the valid values
 func ValidateOutputOpt(opt string) error {
-	switch opt {
-	case tableOutput, jsonOutput:
+	switch {
+	case opt == tableOutput, opt == jsonOutput:
+		return nil
+	case strings.HasPrefix(opt, customcolumnOutput):
 		return nil
 	}
 	return fmt.Errorf("invalid value for output: %s", opt)

--- a/tools/cli/pkg/command/orchestration.go
+++ b/tools/cli/pkg/command/orchestration.go
@@ -261,18 +261,29 @@ func (cmd *OrchestrationCommand) showOrchestrations() error {
 		return errors.Wrap(err, "while listing orchestrations")
 	}
 
-	switch cmd.output {
-	case tableOutput:
+	switch {
+	case cmd.output == tableOutput:
 		tp, err := printer.NewTablePrinter(orchestrationColumns, false)
 		if err != nil {
 			return err
 		}
 		return tp.PrintObj(srl.Data)
-	case jsonOutput:
+	case cmd.output == jsonOutput:
 		jp := printer.NewJSONPrinter("  ")
 		jp.PrintObj(srl)
-	}
+	case strings.HasPrefix(cmd.output, customcolumnOutput):
+		_, templateFile := printer.ParseOutputToTemplateTypeAndElement(cmd.output)
+		column, err := printer.ParseColumnToHeaderAndFieldSpec(templateFile)
+		if err != nil {
+			return err
+		}
 
+		ccp, err := printer.NewTablePrinter(column, false)
+		if err != nil {
+			return err
+		}
+		return ccp.PrintObj(srl.Data)
+	}
 	return nil
 }
 

--- a/tools/cli/pkg/command/orchestration.go
+++ b/tools/cli/pkg/command/orchestration.go
@@ -148,6 +148,8 @@ The command has the following modes:
   - When specifying an orchestration ID and ` + "`operations` or `ops`" + ` as arguments. In this mode, the command displays the Runtime operations for the given orchestration.
   - When specifying an orchestration ID and ` + "`cancel`" + ` as arguments. In this mode, the command cancels the orchestration and all pending Runtime operations.`,
 		Example: `  kcp orchestrations --state inprogress                                   Display all orchestrations which are in progress.
+  kcp orchestration -o custom="Orchestration ID:{.OrchestrationID},STATE:{.State},CREATED AT:{.createdAt}"
+                                                                          Display all orchestations with specific custom fields.
   kcp orchestration 0c4357f5-83e0-4b72-9472-49b5cd417c00                  Display details about a specific orchestration.
   kcp orchestration 0c4357f5-83e0-4b72-9472-49b5cd417c00 --operation OID  Display details of the specified Runtime operation within the orchestration.
   kcp orchestration 0c4357f5-83e0-4b72-9472-49b5cd417c00 operations       Display the operations of the given orchestration.
@@ -271,7 +273,7 @@ func (cmd *OrchestrationCommand) showOrchestrations() error {
 	case cmd.output == jsonOutput:
 		jp := printer.NewJSONPrinter("  ")
 		jp.PrintObj(srl)
-	case strings.HasPrefix(cmd.output, customcolumnOutput):
+	case strings.HasPrefix(cmd.output, customOutput):
 		_, templateFile := printer.ParseOutputToTemplateTypeAndElement(cmd.output)
 		column, err := printer.ParseColumnToHeaderAndFieldSpec(templateFile)
 		if err != nil {

--- a/tools/cli/pkg/command/runtime.go
+++ b/tools/cli/pkg/command/runtime.go
@@ -77,7 +77,11 @@ func NewRuntimeCmd() *cobra.Command {
 The command supports filtering Runtimes based on various attributes. See the list of options for more details.`,
 		Example: `  kcp runtimes                                           Display table overview about all Runtimes.
   kcp rt -c c-178e034 -o json                            Display all details about one Runtime identified by a Shoot name in the JSON format.
-  kcp runtimes --account CA4836781TID000000000123456789  Display all Runtimes of a given global account.`,
+  kcp runtimes --account CA4836781TID000000000123456789  Display all Runtimes of a given global account.
+  kcp runtimes -c bbc3ee7 -o custom="INSTANCE ID:instanceID,SHOOTNAME:shootName"
+                                                         Display the custom fields about one Runtime identified by a Shoot name.
+  kcp runtimes -o custom="INSTANCE ID:instanceID,SHOOTNAME:shootName,runtimeID:runtimeID,STATUS:{status.provisioning}"
+                                                         Display all Runtimes with specific custom fields.`,
 		PreRunE: func(_ *cobra.Command, _ []string) error { return cmd.Validate() },
 		RunE:    func(_ *cobra.Command, _ []string) error { return cmd.Run() },
 	}
@@ -131,7 +135,7 @@ func (cmd *RuntimeCommand) printRuntimes(runtimes runtime.RuntimesPage) error {
 	case cmd.output == jsonOutput:
 		jp := printer.NewJSONPrinter("  ")
 		jp.PrintObj(runtimes)
-	case strings.HasPrefix(cmd.output, customcolumnOutput):
+	case strings.HasPrefix(cmd.output, customOutput):
 		_, templateFile := printer.ParseOutputToTemplateTypeAndElement(cmd.output)
 		column, err := printer.ParseColumnToHeaderAndFieldSpec(templateFile)
 		if err != nil {

--- a/tools/cli/pkg/printer/custom.go
+++ b/tools/cli/pkg/printer/custom.go
@@ -7,7 +7,7 @@ import (
 )
 
 var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
-var templateFormat = []string{"custom-columns="}
+var templateFormat = []string{"custom="}
 
 // RelaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
 //   * metadata.name (no leading '.' or curly braces '{...}'
@@ -37,8 +37,8 @@ func RelaxedJSONPathExpression(pathExpression string) (string, error) {
 }
 
 //ParseOutputToTemplateTypeAndElement parses the output into templateType and templateElement
-//e.g. kcp runtimes  -o custom-columns="INSTANCE ID:instanceID,SHOOTNAME:shootName"
-//After parsing, the templateType = "custom-columns" and  templateElement = "INSTANCE ID:instanceID,SHOOTNAME:shootName"
+//e.g. kcp runtimes  -o custom="INSTANCE ID:instanceID,SHOOTNAME:shootName"
+//After parsing, the templateType = "custom" and  templateElement = "INSTANCE ID:instanceID,SHOOTNAME:shootName"
 func ParseOutputToTemplateTypeAndElement(output string) (string, string) {
 	var templateType, templateElement string
 	for _, format := range templateFormat {
@@ -56,14 +56,14 @@ func ParseOutputToTemplateTypeAndElement(output string) (string, string) {
 // columnsOut[1].Header = "SHOOTNAME"   and  columnsOut[1].FieldSpec = "{.shootName}"
 func ParseColumnToHeaderAndFieldSpec(spec string) ([]Column, error) {
 	if len(spec) == 0 {
-		return nil, fmt.Errorf("custom-columns format specified but no custom columns given")
+		return nil, fmt.Errorf("custom format specified but no custom columns given")
 	}
 	parts := strings.Split(spec, ",")
 	columnsOut := make([]Column, len(parts))
 	for ix := range parts {
 		colSpec := strings.SplitN(parts[ix], ":", 2)
 		if len(colSpec) != 2 {
-			return nil, fmt.Errorf("unexpected custom-columns spec: %s, expected <header>:<json-path-expr>", parts[ix])
+			return nil, fmt.Errorf("unexpected custom spec: %s, expected <header>:<json-path-expr>", parts[ix])
 		}
 		spec, err := RelaxedJSONPathExpression(colSpec[1])
 		if err != nil {

--- a/tools/cli/pkg/printer/customcolumn.go
+++ b/tools/cli/pkg/printer/customcolumn.go
@@ -1,0 +1,75 @@
+package printer
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+var jsonRegexp = regexp.MustCompile(`^\{\.?([^{}]+)\}$|^\.?([^{}]+)$`)
+var templateFormat = []string{"custom-columns="}
+
+// RelaxedJSONPathExpression attempts to be flexible with JSONPath expressions, it accepts:
+//   * metadata.name (no leading '.' or curly braces '{...}'
+//   * {metadata.name} (no leading '.')
+//   * .metadata.name (no curly braces '{...}')
+//   * {.metadata.name} (complete expression)
+// And transforms them all into a valid jsonpath expression:
+//   {.metadata.name}
+func RelaxedJSONPathExpression(pathExpression string) (string, error) {
+	if len(pathExpression) == 0 {
+		return pathExpression, nil
+	}
+	submatches := jsonRegexp.FindStringSubmatch(pathExpression)
+	if submatches == nil {
+		return "", fmt.Errorf("unexpected path string, expected a 'name1.name2' or '.name1.name2' or '{name1.name2}' or '{.name1.name2}'")
+	}
+	if len(submatches) != 3 {
+		return "", fmt.Errorf("unexpected submatch list: %v", submatches)
+	}
+	var fieldSpec string
+	if len(submatches[1]) != 0 {
+		fieldSpec = submatches[1]
+	} else {
+		fieldSpec = submatches[2]
+	}
+	return fmt.Sprintf("{.%s}", fieldSpec), nil
+}
+
+//ParseOutputToTemplateTypeAndElement parses the output into templateType and templateElement
+//e.g. kcp runtimes  -o custom-columns="INSTANCE ID:instanceID,SHOOTNAME:shootName"
+//After parsing, the templateType = "custom-columns" and  templateElement = "INSTANCE ID:instanceID,SHOOTNAME:shootName"
+func ParseOutputToTemplateTypeAndElement(output string) (string, string) {
+	var templateType, templateElement string
+	for _, format := range templateFormat {
+		if strings.HasPrefix(output, format) {
+			templateElement = output[len(format):]
+			templateType = format[:len(format)-1]
+		}
+	}
+	return templateType, templateElement
+}
+
+// ParseColumnToHeaderAndFieldSpec parses a custom columns contents to a list of Column <header>:<jsonpath-field-spec> pairs.
+// e.g. spec is INSTANCE ID:instanceID,SHOOTNAME:shootName
+// columnsOut[0].Header = "INSTANCE ID" and  columnsOut[0].FieldSpec = "{.instanceID}"
+// columnsOut[1].Header = "SHOOTNAME"   and  columnsOut[1].FieldSpec = "{.shootName}"
+func ParseColumnToHeaderAndFieldSpec(spec string) ([]Column, error) {
+	if len(spec) == 0 {
+		return nil, fmt.Errorf("custom-columns format specified but no custom columns given")
+	}
+	parts := strings.Split(spec, ",")
+	columnsOut := make([]Column, len(parts))
+	for ix := range parts {
+		colSpec := strings.SplitN(parts[ix], ":", 2)
+		if len(colSpec) != 2 {
+			return nil, fmt.Errorf("unexpected custom-columns spec: %s, expected <header>:<json-path-expr>", parts[ix])
+		}
+		spec, err := RelaxedJSONPathExpression(colSpec[1])
+		if err != nil {
+			return nil, err
+		}
+		columnsOut[ix] = Column{Header: colSpec[0], FieldSpec: spec}
+	}
+	return columnsOut, nil
+}


### PR DESCRIPTION
Implement task [`KCP CLI: custom-columns output format`  ](https://github.tools.sap/kyma/backlog/issues/935)

```
$ go run main.go runtimes  -o custom-columns="INSTANCE ID:instanceID,SHOOTNAME:shootName,runtimeID:runtimeID,REGION:region" INSTANCE ID                            SHOOTNAME   runtimeID                              REGION          
8213F8C9-5268-478A-A910-3B61518251C2   c-57e10b5   2538930c-2dff-4e6e-b7ef-370659b33c46   westeurope      
371B2BDA-D094-4E18-A584-C3B050B226BD   df2b91e     b470f00e-9374-4fba-a95e-07a3d8daed40   centralus       
5C429A13-6F93-418C-8528-F4EAF95AD044   ed72781     3efcfbf0-d2fe-4aa1-8617-1e0d4b9cdbae   northeurope     
EDCBAC01-5300-4CE8-8CF8-13A060CE5C5E   ba5dbac     3bab8f22-1084-4844-821f-1c7530b3f661   centralus       
A62763FC-38B0-4B12-AA1B-629741A79FB1   ab78e35     f12a722d-0e49-4203-9d47-0d7355524c4e   centralus 

```