### PR TITLE
Fix suspension when last deprovisioning not exist

### DIFF
--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -69,6 +69,10 @@ func (h *ContextUpdateHandler) handleContextChange(newCtx internal.ERSContext, i
 			if err != nil && !dberr.IsNotFound(err) {
 				return err
 			}
+			if dberr.IsNotFound(err) || lastDeprovisioning == nil {
+				l.Info("Last deprovisioning operation not found, triggering suspension")
+				return h.suspend(instance, l)
+			}
 
 			if lastDeprovisioning.Temporary && lastDeprovisioning.State == domain.Failed {
 				l.Infof("Retriggering suspension for instance id %s", instance.InstanceID)

--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -69,7 +69,7 @@ func (h *ContextUpdateHandler) handleContextChange(newCtx internal.ERSContext, i
 			if err != nil && !dberr.IsNotFound(err) {
 				return err
 			}
-			if dberr.IsNotFound(err) || lastDeprovisioning == nil {
+			if lastDeprovisioning == nil {
 				l.Info("Last deprovisioning operation not found, triggering suspension")
 				return h.suspend(instance, l)
 			}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-435"
     kyma_environment_broker:
       dir:
-      version: "PR-490"
+      version: "PR-497"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-473"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When last deprovisioning operation does not exist we return `nil`, which can cause crash

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
