### PR TITLE
Enable PERMISSIVE mTLS for provisioner for all endpoints

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/environments-cleanup-job.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/environments-cleanup-job.yaml
@@ -1,15 +1,4 @@
 {{if eq .Values.global.kyma_environment_broker.environmentsCleanup.enabled true}}
-apiVersion: networking.istio.io/v1alpha3
-kind: DestinationRule
-metadata:
-  name: "kcp-kyma-environments-cleanup"
-  namespace: {{ .Release.Namespace }}
-spec:
-  host: "{{ .Values.provisioner.Host }}"
-  trafficPolicy:
-    tls:
-      mode: DISABLE
----
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -41,7 +41,6 @@ resources: {}
   #   memory: 128Mi
 
 provisioner:
-  Host: "kcp-provisioner.kcp-system.svc.cluster.local"
   URL: "http://kcp-provisioner.kcp-system.svc.cluster.local:3000/graphql"
 
   # Defines how long should the Kyma Environment Broker checks the status of the provisioning in the Provisioner.

--- a/resources/kcp/charts/provisioner/templates/policy.yaml
+++ b/resources/kcp/charts/provisioner/templates/policy.yaml
@@ -1,12 +1,11 @@
 apiVersion: security.istio.io/v1beta1
 kind: PeerAuthentication
 metadata:
-  name: {{ template "fullname" . }}-metrics
+  name: {{ template "fullname" . }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
       app: {{ .Chart.Name }}
-  portLevelMtls:
-    {{ .Values.metrics.port }}:
-      mode: "PERMISSIVE"
+  mtls:
+    mode: PERMISSIVE


### PR DESCRIPTION
**Description**

#473 introduced a DestionationRule for provisioner to disable mTLS for downstream peers of provisioner. It results in an error for peers within the Istio mesh as provisioner's istio-proxy is configured with STRICT TLS settings (i.e. not allow clients with plain-text HTTP connection). 
To fix this issue while still allowing KEB environments-cleanup job to reach provisioner's GraphQL endpoint, provisioner's istio-proxy ios configured in PERMISSIVE mode which will allow both TLS and plain-text connections from within the cluster.

