### PR TITLE
Make orchestration resolver fully aware to suspension/unsuspension

### DIFF
--- a/components/kyma-environment-broker/common/orchestration/resolver_test.go
+++ b/components/kyma-environment-broker/common/orchestration/resolver_test.go
@@ -258,6 +258,7 @@ var (
 	shoot8  = fixShoot(8, globalAccountID1, region1)
 	shoot9  = fixShoot(9, globalAccountID1, region1)
 	shoot10 = fixShoot(10, globalAccountID1, region1)
+	shoot11 = fixShoot(11, globalAccountID1, region1)
 
 	runtime1  = fixRuntimeDTO(1, globalAccountID1, plan2, runtimeOpState{provision: string(brokerapi.Succeeded)})
 	runtime2  = fixRuntimeDTO(2, globalAccountID1, plan1, runtimeOpState{provision: string(brokerapi.Succeeded)})
@@ -269,6 +270,7 @@ var (
 	runtime8  = fixRuntimeDTO(8, globalAccountID1, plan1, runtimeOpState{provision: string(brokerapi.Succeeded), suspension: string(brokerapi.Succeeded)})
 	runtime9  = fixRuntimeDTO(9, globalAccountID1, plan1, runtimeOpState{provision: string(brokerapi.Succeeded), suspension: string(brokerapi.InProgress)})
 	runtime10 = fixRuntimeDTO(10, globalAccountID1, plan1, runtimeOpState{provision: string(brokerapi.Succeeded), suspension: string(brokerapi.Succeeded), unsuspension: string(brokerapi.Succeeded)})
+	runtime11 = fixRuntimeDTO(11, globalAccountID1, plan1, runtimeOpState{provision: string(brokerapi.Succeeded), suspension: string(brokerapi.Succeeded), unsuspension: string(brokerapi.Failed)})
 )
 
 func fixShoot(id int, globalAccountID, region string) gardenerapi.Shoot {

--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -78,7 +78,7 @@ type OperationType string
 const (
 	Provision    OperationType = "provision"
 	Deprovision  OperationType = "deprovision"
-	IpgradeKyma  OperationType = "kyma upgrade"
+	UpgradeKyma  OperationType = "kyma upgrade"
 	Suspension   OperationType = "suspension"
 	Unsuspension OperationType = "unsuspension"
 )
@@ -89,7 +89,7 @@ func FindLastOperation(rt RuntimeDTO) (Operation, OperationType) {
 	// Take the first upgrade operation, assuming that Data is sorted by CreatedAt DESC.
 	if rt.Status.UpgradingKyma.Count > 0 {
 		op = rt.Status.UpgradingKyma.Data[0]
-		opType = IpgradeKyma
+		opType = UpgradeKyma
 	}
 
 	// Take the first unsuspension operation, assuming that Data is sorted by CreatedAt DESC.

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-503"
     kyma_environment_broker:
       dir:
-      version: "PR-508"
+      version: "PR-511"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-473"


### PR DESCRIPTION
**Description**

Resolver skips SKRs which were suspended and then unsuspended successfully.
