### PR TITLE
Add overrides with userID

### DIFF
--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -251,6 +251,9 @@ func (b *ProvisionEndpoint) extractERSContext(details domain.ProvisionDetails) (
 	if ersContext.SubAccountID == "" {
 		return ersContext, errors.New("subAccountID parameter cannot be empty")
 	}
+	if ersContext.UserID == "" {
+		return ersContext, errors.New("UserID parameter cannot be empty")
+	}
 
 	return ersContext, nil
 }

--- a/components/kyma-environment-broker/internal/broker/instance_create_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create_test.go
@@ -400,7 +400,7 @@ func TestProvision_Provision(t *testing.T) {
 		factoryBuilder := &automock.PlanValidator{}
 		factoryBuilder.On("IsPlanSupport", planID).Return(true)
 
-		fixValidator, err := broker.NewPlansSchemaValidator()
+		fixValidator, err := broker.NewPlansSchemaValidator(broker.PlansConfig{})
 		require.NoError(t, err)
 
 		provisionEndpoint := broker.NewProvision(
@@ -411,6 +411,7 @@ func TestProvision_Provision(t *testing.T) {
 			nil,
 			factoryBuilder,
 			fixValidator,
+			broker.PlansConfig{},
 			true,
 			logrus.StandardLogger(),
 		)

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
@@ -23,6 +23,9 @@ const (
 
 	brokerKeyPrefix = "broker_"
 	globalKeyPrefix = "global_"
+
+	adminAccessComponent = "cluster-users"
+	adminAccessKey       = "users.adminName"
 )
 
 type CreateRuntimeStep struct {
@@ -131,6 +134,14 @@ func (s *CreateRuntimeStep) updateInstance(id, runtimeID, region string) error {
 }
 
 func (s *CreateRuntimeStep) createProvisionInput(operation internal.ProvisioningOperation) (gqlschema.ProvisionRuntimeInput, error) {
+	var request gqlschema.ProvisionRuntimeInput
+
+	operation.InputCreator.AppendOverrides(adminAccessComponent, []*gqlschema.ConfigEntryInput{
+		{
+			Key:   adminAccessKey,
+			Value: operation.ProvisioningParameters.ErsContext.UserID,
+		},
+	})
 	operation.InputCreator.SetProvisioningParameters(operation.ProvisioningParameters)
 	operation.InputCreator.SetShootName(operation.ShootName)
 	operation.InputCreator.SetLabel(brokerKeyPrefix+"instance_id", operation.InstanceID)

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -36,6 +36,8 @@ const (
 	serviceManagerURL      = "http://sm.com"
 	serviceManagerUser     = "admin"
 	serviceManagerPassword = "admin123"
+
+	adminUserName = "admin@example.com"
 )
 
 var (
@@ -99,6 +101,16 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 					Component:     "keb",
 					Namespace:     "kyma-system",
 					Configuration: nil,
+				},
+				{
+					Component: "cluster-users",
+					Namespace: "kyma-system",
+					Configuration: []*gqlschema.ConfigEntryInput{
+						{
+							Key:   "users.adminName",
+							Value: adminUserName,
+						},
+					},
 				},
 			},
 			Configuration:    []*gqlschema.ConfigEntryInput{},
@@ -202,6 +214,7 @@ func fixProvisioningParametersWithPlanID(planID, region string) internal.Provisi
 				},
 				URL: serviceManagerURL,
 			},
+			UserID: adminUserName,
 		},
 		Parameters: internal.ProvisioningParametersDTO{
 			Region: ptr.String(region),
@@ -226,9 +239,19 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 			Namespace:     "kyma-system",
 			Configuration: nil,
 		},
+		{
+			Component:     "cluster-users",
+			Namespace:     "kyma-system",
+			Configuration: nil,
+		},
 	}).Return(internal.ComponentConfigurationInputList{
 		{
 			Component:     "keb",
+			Namespace:     "kyma-system",
+			Configuration: nil,
+		},
+		{
+			Component:     "cluster-users",
 			Namespace:     "kyma-system",
 			Configuration: nil,
 		},
@@ -241,6 +264,10 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 		},
 		{
 			Name:      "keb",
+			Namespace: "kyma-system",
+		},
+		{
+			Name:      "cluster-users",
 			Namespace: "kyma-system",
 		},
 	}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-730"
     kyma_environment_broker:
       dir:
-      version: "PR-739"
+      version: "PR-522"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
Changes proposed in this pull request:

- Add overrides with userID (to the `create-runtime` step). UserID (which is a user email sent from CIS in ERSContext block) is passed to override to the `cluster-users` Kyma component. UserID will be assigned to super admin ClusterRole.