### PR TITLE
Change overrides labels to lowercase

### DIFF
--- a/components/kyma-environment-broker/internal/runtimeoverrides/runtimeoverrides.go
+++ b/components/kyma-environment-broker/internal/runtimeoverrides/runtimeoverrides.go
@@ -3,6 +3,7 @@ package runtimeoverrides
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -143,7 +144,7 @@ func secretListOptions() []client.ListOption {
 
 func configMapListOptions(plan string, version string) []client.ListOption {
 	planLabel := overridesPlanLabelPrefix + plan
-	versionLabel := overridesVersionLabelPrefix + version
+	versionLabel := overridesVersionLabelPrefix + strings.ToLower(version)
 
 	label := map[string]string{
 		planLabel:    "true",

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-524"
     kyma_environment_broker:
       dir:
-      version: "PR-546"
+      version: "PR-553"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-473"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/master/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
When using `PR-123` custom version for Subaccount mapping, there is an error while applying overrides:
```
{"instanceID":"1CD31DBA-57EF-4E4A-9F81-1DD176DA05E7","level":"info","msg":"Retry Operation was triggered with message: error when appending overrides for operation a38d718b-e286-440b-9988-98aa39455072: no global overrides for plan 'azure' and Kyma version 'PR-10674'","operation":"a38d718b-e286-440b-9988-98aa39455072","planID":"4deee563-e5ec-4731-b9b1-53b42d855f0c","provisioning":"manager","step":"Overrides_From_Secrets_And_Config_Step","time":"2021-02-26T02:45:44Z"}
```

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
