### PR TITLE
AVS deprovisioning step fails the operation properly

### DIFF
--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -252,10 +252,6 @@ func (c *Client) execute(request *http.Request, allowNotFound bool, allowResetTo
 		return response, fmt.Errorf("avs server returned %d status code twice for %s (response body: %s)", http.StatusUnauthorized, request.URL.String(), responseBody(response))
 	}
 
-	if response.StatusCode >= http.StatusInternalServerError {
-		return response, kebError.NewTemporaryError("avs server returned %d status code", response.StatusCode)
-	}
-
 	return response, fmt.Errorf("unsupported status code: %d for %s (response body: %s)", response.StatusCode, request.URL.String(), responseBody(response))
 }
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
@@ -42,12 +42,12 @@ func (ars *AvsEvaluationRemovalStep) Run(deProvisioningOperation internal.Deprov
 
 	deProvisioningOperation, err := ars.delegator.DeleteAvsEvaluation(deProvisioningOperation, logger, ars.internalEvalAssistant)
 	if err != nil {
-		return ars.deProvisioningManager.RetryOperationWithoutFail(deProvisioningOperation, err.Error(), 10*time.Second, 10*time.Minute, logger)
+		return ars.deProvisioningManager.RetryOperation(deProvisioningOperation, err.Error(), 10*time.Second, 10*time.Minute, logger)
 	}
 
 	deProvisioningOperation, err = ars.delegator.DeleteAvsEvaluation(deProvisioningOperation, logger, ars.externalEvalAssistant)
 	if err != nil {
-		return ars.deProvisioningManager.RetryOperationWithoutFail(deProvisioningOperation, err.Error(), 10*time.Second, 10*time.Minute, logger)
+		return ars.deProvisioningManager.RetryOperation(deProvisioningOperation, err.Error(), 10*time.Second, 10*time.Minute, logger)
 	}
 	return deProvisioningOperation, 0, nil
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-524"
     kyma_environment_broker:
       dir:
-      version: "PR-553"
+      version: "PR-558"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-473"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- `RetryOperationWithoutFail` always updates the `UpdatedAt` field, making the deprovision operation timeout not to be reached.
- Removal of duplicated `if response.StatusCode >= http.StatusInternalServerError`... line

