### PR TITLE
add garadener-metrics dashboard

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/files/gardener-dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/gardener-dashboard.json
@@ -1,0 +1,177 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "panels": [],
+      "title": "Gardener Usage Exporter Metrics",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 23,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "sum by (resourceName) (gardener_quota_used/gardener_quota_limit) * 100 ",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gardener Quota Usage",
+      "type": "bargauge"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "decimals": 2,
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "",
+              "to": "",
+              "type": 1
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 23,
+        "x": 0,
+        "y": 8
+      },
+      "id": 6,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "pluginVersion": "7.3.3",
+      "targets": [
+        {
+          "expr": "sum by (__name__, service) (gardener_secrets_azure_used / gardener_secrets_azure_total) * 100",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Gardener Azure Secret Usage",
+      "type": "bargauge"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [
+    "gardener metrics"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Gardener Metrics",
+  "uid": "mnpIkYUGk",
+  "version": 2
+}

--- a/resources/kcp/charts/kyma-environment-broker/files/gardener-dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/gardener-dashboard.json
@@ -35,7 +35,10 @@
       "datasource": null,
       "fieldConfig": {
         "defaults": {
-          "custom": {},
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
           "decimals": 2,
           "mappings": [],
           "thresholds": {
@@ -51,42 +54,119 @@
               }
             ]
           },
-          "unit": "percent"
+          "unit": "short"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Usage percent %"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "decimals",
+                "value": 3
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 7,
-        "w": 23,
+        "h": 8,
+        "w": 11,
         "x": 0,
         "y": 1
       },
       "id": 4,
       "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
+        "showHeader": true
       },
       "pluginVersion": "7.3.3",
       "targets": [
         {
-          "expr": "sum by (resourceName) (gardener_quota_used/gardener_quota_limit) * 100 ",
+          "expr": " sum by (__name__, service)(gardener_secrets_azure_used)",
+          "format": "table",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "expr": " sum by (__name__, service)(gardener_secrets_azure_total)",
+          "format": "table",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": " sum by (__name__, service)(gardener_secrets_azure_used/gardener_secrets_azure_total)*100",
+          "format": "table",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Gardener Quota Usage",
-      "type": "bargauge"
+      "title": "Gardener Secret Usage",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "service",
+                "Value #A",
+                "Value #B",
+                "Value #C"
+              ]
+            }
+          }
+        },
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "service"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Used",
+              "Value #B": "Limited",
+              "Value #C": "Usage percent %",
+              "service": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
     },
     {
       "datasource": null,
@@ -96,16 +176,7 @@
             "align": null,
             "filterable": false
           },
-          "decimals": 2,
-          "mappings": [
-            {
-              "from": "",
-              "id": 1,
-              "text": "",
-              "to": "",
-              "type": 1
-            }
-          ],
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -118,43 +189,120 @@
                 "value": 80
               }
             ]
-          },
-          "unit": "percent"
+          }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "Usage Percent %"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    },
+                    {
+                      "color": "red",
+                      "value": 80
+                    }
+                  ]
+                }
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "decimals",
+                "value": 2
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
-        "h": 2,
-        "w": 23,
-        "x": 0,
-        "y": 8
+        "h": 8,
+        "w": 12,
+        "x": 11,
+        "y": 1
       },
-      "id": 6,
+      "id": 8,
       "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
+        "frameIndex": 2,
+        "showHeader": true
       },
       "pluginVersion": "7.3.3",
       "targets": [
         {
-          "expr": "sum by (__name__, service) (gardener_secrets_azure_used / gardener_secrets_azure_total) * 100",
+          "expr": "sum by (instance, resourceName) (gardener_quota_used)",
+          "format": "table",
           "interval": "",
           "legendFormat": "",
           "refId": "A"
+        },
+        {
+          "expr": "sum by (instance, resourceName) (gardener_quota_limit)",
+          "format": "table",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        },
+        {
+          "expr": "sum by (instance, resourceName) (gardener_quota_used/gardener_quota_limit) * 100",
+          "format": "table",
+          "interval": "",
+          "legendFormat": "",
+          "refId": "C"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Gardener Azure Secret Usage",
-      "type": "bargauge"
+      "title": "Gardener Quota Usage",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "resourceName",
+                "Value #C",
+                "Value #B",
+                "Value #A"
+              ]
+            }
+          }
+        },
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "resourceName"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Value #A": "Used",
+              "Value #B": "Limited",
+              "Value #C": "Usage Percent %",
+              "resourceName": "Service"
+            }
+          }
+        }
+      ],
+      "type": "table"
     }
   ],
   "schemaVersion": 26,
@@ -173,5 +321,5 @@
   "timezone": "",
   "title": "Gardener Metrics",
   "uid": "mnpIkYUGk",
-  "version": 2
+  "version": 1
 }

--- a/resources/kcp/charts/kyma-environment-broker/templates/gardener-dashboard.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/gardener-dashboard.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardener-metrics-dashboard
+  namespace: kyma-system
+  labels:
+    grafana_dashboard: "1"
+    app: monitoring-grafana
+data:
+  gardener-metrics-dashboard.json: |-
+{{ .Files.Get "files/gardener-dashboard.json" | indent 4 }}


### PR DESCRIPTION
Implement the task of [Grafana Dashboard for Gardener Usage Exporter](https://github.tools.sap/kyma/backlog/issues/1281) by adding new dashboard (see [example](https://grafana.cp.dev.kyma.cloud.sap/d/mnpIkYUGk/gardener-metrics-test?orgId=1) )