### PR TITLE
Bump alpine version and migrator tool version for schema-migrator job

### DIFF
--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:3.12.3
+FROM alpine:3.13.2
 LABEL source=git@github.com:kyma-project/control-plane.git
 
-ARG MIGRATE_VER=4.5.0
+ARG MIGRATE_VER=4.14.1
 
 WORKDIR /migrate
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -6,7 +6,7 @@ global:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:
       dir:
-      version: "PR-569"
+      version: "PR-589"
     provisioner:
       dir:
       version: "PR-524"


### PR DESCRIPTION
Changes proposed in this pull request:

- bump alpine version from `3.12.3` to `3.13.2`
- bump [migrator tool](https://github.com/golang-migrate/migrate) version from `4.5.0` to `4.14.1`

due to vulnerability issue