### PR TITLE
Fix deprovisioning of suspended trial runtimes

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
@@ -114,6 +114,10 @@ func (s *InitialisationStep) run(operation internal.DeprovisioningOperation, log
 	instance, err := s.instanceStorage.GetByID(operation.InstanceID)
 	switch {
 	case err == nil:
+		// If the instance is currently suspended, let this deprovision operation clean up the instance
+		if instance.Parameters.ErsContext.Active != nil && !*instance.Parameters.ErsContext.Active {
+			return s.operationManager.OperationSucceeded(operation, "instance has been suspended previously", log)
+		}
 		if operation.State == orchestration.Pending {
 			upgrades, err := s.operationStorage.ListUpgradeKymaOperationsByInstanceID(operation.InstanceID)
 			if err != nil {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-524"
     kyma_environment_broker:
       dir:
-      version: "PR-523"
+      version: "PR-590"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-473"


### PR DESCRIPTION
**Description**

If a deprovision is triggered after suspension (so without having the runtime unsuspended first), KEB doesn't clean up the instance from DB properly. As a consequence the subsequent provisioning requests always fail with `The Trial Kyma was created for the global account, but there is only one allowed` error message.

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/1301