### PR TITLE
Bump KEB go libraries

### DIFF
--- a/components/kyma-environment-broker/Gopkg.lock
+++ b/components/kyma-environment-broker/Gopkg.lock
@@ -387,15 +387,15 @@
   version = "v3.1.0"
 
 [[projects]]
-  digest = "1:a1b2a5e38f79688ee8250942d5fa960525fceb1024c855c7bc76fa77b0f3cca2"
+  digest = "1:6b6839a74a75dcb073a4bde536fed808f8e7060bfc89e9b5565ce2f66716c094"
   name = "github.com/gogo/protobuf"
   packages = [
     "proto",
     "sortkeys",
   ]
   pruneopts = "NUT"
-  revision = "ba06b47c162d49f2af050fb4c75bcbc86a159d5c"
-  version = "v1.2.1"
+  revision = "b03c65ea87cdc3521ede29f62fe3ce239267c1bc"
+  version = "v1.3.2"
 
 [[projects]]
   digest = "1:796f9c63c68774a89eade387a8476e45ec2b34f5649b0726983204202c3649d6"

--- a/components/kyma-environment-broker/Gopkg.toml
+++ b/components/kyma-environment-broker/Gopkg.toml
@@ -97,7 +97,11 @@
 
 [[override]]
   name = "golang.org/x/text"
-  version = "v0.3.3"
+  version = "v0.3.5"
+
+[[override]]
+  name = "github.com/gogo/protobuf"
+  version = "v1.3.2"
 
 [prune]
   go-tests = true

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-524"
     kyma_environment_broker:
       dir:
-      version: "PR-523"
+      version: "PR-591"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-473"


### PR DESCRIPTION
Changes proposed in this pull request:

- bump KEB `golang.org/x/text` library from `v0.3.3` to `v0.3.5`
- bump KEB `github.com/gogo/protobuf` library from `v1.2.1` to `v1.3.2`

due to vulnerability issue