### PR TITLE
Re-add Kibana URL

### DIFF
--- a/components/kyma-environment-broker/internal/cls/client.go
+++ b/components/kyma-environment-broker/internal/cls/client.go
@@ -34,6 +34,7 @@ type OverrideParams struct {
 	FluentdEndPoint string `json:"Fluentd-endpoint"`
 	FluentdPassword string `json:"Fluentd-password"`
 	FluentdUsername string `json:"Fluentd-username"`
+	KibanaURL       string `json:"Kibana-endpoint"`
 }
 
 type BindingRequest struct {
@@ -105,6 +106,7 @@ func (c *Client) CreateBinding(smClient servicemanager.Client, request *BindingR
 		FluentdUsername: resp.Credentials["Fluentd-username"].(string),
 		FluentdPassword: resp.Credentials["Fluentd-password"].(string),
 		FluentdEndPoint: resp.Credentials["Fluentd-endpoint"].(string),
+		KibanaURL:       resp.Credentials["Kibana-endpoint"].(string),
 	}, nil
 }
 

--- a/components/kyma-environment-broker/internal/cls/client_test.go
+++ b/components/kyma-environment-broker/internal/cls/client_test.go
@@ -138,6 +138,7 @@ func TestCreateBinding(t *testing.T) {
 	creds["Fluentd-username"] = "fbUser"
 	creds["Fluentd-password"] = "fbPass"
 	creds["Fluentd-endpoint"] = "fbEndpoint"
+	creds["Kibana-endpoint"] = "kibUrl"
 	resB := servicemanager.BindingResponse{
 		Binding:      servicemanager.Binding{Credentials: creds},
 		HTTPResponse: servicemanager.HTTPResponse{StatusCode: 200},
@@ -153,6 +154,7 @@ func TestCreateBinding(t *testing.T) {
 		FluentdEndPoint: "fbEndpoint",
 		FluentdPassword: "fbPass",
 		FluentdUsername: "fbUser",
+		KibanaURL:       "kibUrl",
 	}
 	res, err := sut.CreateBinding(smClientMock, &br)
 	require.NoError(t, err)

--- a/components/kyma-environment-broker/internal/cls/overrides_test.go
+++ b/components/kyma-environment-broker/internal/cls/overrides_test.go
@@ -13,6 +13,7 @@ func TestClsEncryptDecrypt(t *testing.T) {
 		FluentdEndPoint: "foo.bar",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}
 
 	// when

--- a/components/kyma-environment-broker/internal/process/provisioning/cls_audit_log_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/cls_audit_log_step_test.go
@@ -62,6 +62,7 @@ return "fooBar"
 		FluentdEndPoint: "foo.bar",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}
 	secretKey := "1234567890123456"
 	encrypted, err := cls.EncryptOverrides(secretKey, &overridesIn)
@@ -266,6 +267,7 @@ return "fooBar"
 		FluentdEndPoint: "foo.bar",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}
 	secretKey := "1234567890123456"
 

--- a/components/kyma-environment-broker/internal/process/provisioning/cls_binding_step_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/cls_binding_step_test.go
@@ -109,6 +109,7 @@ func TestClsBindingStep_Run(t *testing.T) {
 		FluentdEndPoint: "fooEndPoint",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}, nil)
 
 	bindingStep := NewClsBindStep(config, clsBindingProvider, repo, "1234567890123456")

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/cls_audit_log_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/cls_audit_log_test.go
@@ -63,6 +63,7 @@ return "fooBar"
 		FluentdEndPoint: "foo.bar",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}
 	secretKey := "1234567890123456"
 	encrypted, err := cls.EncryptOverrides(secretKey, &overridesIn)
@@ -266,6 +267,7 @@ return "fooBar"
 		FluentdEndPoint: "foo.bar",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}
 	secretKey := "1234567890123456"
 

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/cls_binding_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/cls_binding_test.go
@@ -107,6 +107,7 @@ func TestClsBindingStep_Run(t *testing.T) {
 		FluentdEndPoint: "fooEndPoint",
 		FluentdPassword: "fooPass",
 		FluentdUsername: "fooUser",
+		KibanaURL:       "kibana.url",
 	}, nil)
 
 	bindingStep := NewClsUpgradeBindStep(config, clsBindingProvider, repo, "1234567890123456")


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Adds CLS Kibana URL to the overrides since SREs rely on it. Basically, it reverts the following commit: https://github.com/kyma-project/control-plane/pull/563/commits/0e36826e3993c43002bdbe7ec6dbf9a530607d1e
 
**Related issue(s)**
See also #563
