### PR TITLE
Fixes to a few minor upgrade issues

### DIFF
--- a/components/kyma-environment-broker/common/orchestration/strategies/parallel.go
+++ b/components/kyma-environment-broker/common/orchestration/strategies/parallel.go
@@ -79,10 +79,16 @@ func (p *ParallelOrchestrationStrategy) Wait(executionID string) {
 }
 
 func (p *ParallelOrchestrationStrategy) Cancel(executionID string) {
+	if executionID == "" {
+		return
+	}
+	p.log.Infof("Cancelling strategy execution %s", executionID)
 	p.mux.Lock()
 	defer p.mux.Unlock()
-	p.log.Infof("Cancelling strategy execution %s", executionID)
-	p.dq[executionID].ShutDown()
+	dq := p.dq[executionID]
+	if dq != nil {
+		dq.ShutDown()
+	}
 }
 
 func (p *ParallelOrchestrationStrategy) createWorker(execID string, ops chan orchestration.RuntimeOperation, strategy orchestration.StrategySpec) {

--- a/components/kyma-environment-broker/internal/avs/delegator_test.go
+++ b/components/kyma-environment-broker/internal/avs/delegator_test.go
@@ -178,7 +178,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		delegator, op := newDelOpsParams(params)
 
 		requested := params.internalMonitor.Status
-		_, original := setOpAvsStatus(&op, "", StatusMaintenance)
+		_, _ = setOpAvsStatus(&op, "", StatusMaintenance)
 
 		// When
 		err := delegator.SetStatus(logger, &op.Avs, internalEA, requested)
@@ -186,7 +186,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		// Then
 		assert.NoError(t, err)
 		assert.Equal(t, params.internalMonitor.Status, internalEA.GetEvalStatus(op.Avs))
-		assert.Equal(t, original, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, params.internalMonitor.Status, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	t.Run("set for empty fields", func(t *testing.T) {
@@ -281,7 +281,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 	t.Run("reset for empty fields", func(t *testing.T) {
 		delegator, op := newDelOpsParams(params)
 
-		_, original := setOpAvsStatus(&op, "", "")
+		_, _ = setOpAvsStatus(&op, "", "")
 
 		// When
 		err := delegator.ResetStatus(logger, &op.Avs, internalEA)
@@ -290,7 +290,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		assert.NoError(t, err)
 		// restores current status from default
 		assert.Equal(t, StatusActive, internalEA.GetEvalStatus(op.Avs))
-		assert.Equal(t, original, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, StatusActive, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	// Since logic is the same for both internal and external monitors,
@@ -298,7 +298,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 	t.Run("reset for partial fields (original empty)", func(t *testing.T) {
 		delegator, op := newDelOpsParams(params)
 
-		current, _ := setOpAvsStatus(&op, StatusMaintenance, "")
+		_, _ = setOpAvsStatus(&op, StatusMaintenance, "")
 
 		// When
 		err := delegator.ResetStatus(logger, &op.Avs, internalEA)
@@ -307,7 +307,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		assert.NoError(t, err)
 		// restores current status from default
 		assert.Equal(t, StatusActive, internalEA.GetEvalStatus(op.Avs))
-		assert.Equal(t, current, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, StatusActive, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	// Since logic is the same for both internal and external monitors,
@@ -333,7 +333,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 	t.Run("reset from invalid fields (original invalid)", func(t *testing.T) {
 		delegator, op := newDelOpsParams(params)
 
-		current, _ := setOpAvsStatus(&op, StatusInactive, "invalid")
+		_, _ = setOpAvsStatus(&op, StatusInactive, "invalid")
 
 		// When
 		err := delegator.ResetStatus(logger, &op.Avs, internalEA)
@@ -343,7 +343,7 @@ func TestDelegator_SetStatus(t *testing.T) {
 		// restores current status from default
 		assert.Equal(t, StatusActive, internalEA.GetEvalStatus(op.Avs))
 		// restores original status from current, which is restored from Avs
-		assert.Equal(t, current, internalEA.GetOriginalEvalStatus(op.Avs))
+		assert.Equal(t, StatusActive, internalEA.GetOriginalEvalStatus(op.Avs))
 	})
 
 	t.Run("reset from invalid fields (current invalid)", func(t *testing.T) {

--- a/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
@@ -69,12 +69,10 @@ func (eea *ExternalEvalAssistant) SetEvalId(lifecycleData *internal.AvsLifecycle
 
 func (eea *ExternalEvalAssistant) SetEvalStatus(lifecycleData *internal.AvsLifecycleData, status string) {
 	current := lifecycleData.AvsExternalEvaluationStatus.Current
-	if current != status {
-		if ValidStatus(current) {
-			lifecycleData.AvsExternalEvaluationStatus.Original = current
-		}
-		lifecycleData.AvsExternalEvaluationStatus.Current = status
+	if ValidStatus(current) {
+		lifecycleData.AvsExternalEvaluationStatus.Original = current
 	}
+	lifecycleData.AvsExternalEvaluationStatus.Current = status
 }
 
 func (eea *ExternalEvalAssistant) GetEvalStatus(lifecycleData internal.AvsLifecycleData) string {

--- a/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
@@ -104,12 +104,10 @@ func (iec *InternalEvalAssistant) SetEvalId(lifecycleData *internal.AvsLifecycle
 
 func (iec *InternalEvalAssistant) SetEvalStatus(lifecycleData *internal.AvsLifecycleData, status string) {
 	current := lifecycleData.AvsInternalEvaluationStatus.Current
-	if current != status {
-		if ValidStatus(current) {
-			lifecycleData.AvsInternalEvaluationStatus.Original = current
-		}
-		lifecycleData.AvsInternalEvaluationStatus.Current = status
+	if ValidStatus(current) {
+		lifecycleData.AvsInternalEvaluationStatus.Original = current
 	}
+	lifecycleData.AvsInternalEvaluationStatus.Current = status
 }
 
 func (iec *InternalEvalAssistant) GetEvalStatus(lifecycleData internal.AvsLifecycleData) string {

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/initialisation_test.go
@@ -592,8 +592,8 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, repeat)
 		assert.Equal(t, domain.InProgress, upgradeOperation.State)
-		assert.Equal(t, upgradeOperation.Avs.AvsInternalEvaluationStatus, internal.AvsEvaluationStatus{Current: internalStatus, Original: ""})
-		assert.Equal(t, upgradeOperation.Avs.AvsExternalEvaluationStatus, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""})
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: internalStatus, Original: internalStatus}, upgradeOperation.Avs.AvsInternalEvaluationStatus)
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""}, upgradeOperation.Avs.AvsExternalEvaluationStatus)
 	})
 
 	t.Run("should go through init and finish steps (both monitors)", func(t *testing.T) {
@@ -657,8 +657,8 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, repeat)
 		assert.Equal(t, domain.InProgress, upgradeOperation.State)
-		assert.Equal(t, upgradeOperation.Avs.AvsInternalEvaluationStatus, internal.AvsEvaluationStatus{Current: internalStatus, Original: ""})
-		assert.Equal(t, upgradeOperation.Avs.AvsExternalEvaluationStatus, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""})
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: internalStatus, Original: internalStatus}, upgradeOperation.Avs.AvsInternalEvaluationStatus)
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""}, upgradeOperation.Avs.AvsExternalEvaluationStatus)
 
 		// when valid client request and InProgress state from RuntimeOperationStatus, this should do init tasks
 		step.evaluationManager = evalManager

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
@@ -603,8 +603,8 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, repeat)
 		assert.Equal(t, domain.InProgress, upgradeOperation.State)
-		assert.Equal(t, upgradeOperation.Avs.AvsInternalEvaluationStatus, internal.AvsEvaluationStatus{Current: internalStatus, Original: ""})
-		assert.Equal(t, upgradeOperation.Avs.AvsExternalEvaluationStatus, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""})
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: internalStatus, Original: internalStatus}, upgradeOperation.Avs.AvsInternalEvaluationStatus)
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""}, upgradeOperation.Avs.AvsExternalEvaluationStatus)
 	})
 
 	t.Run("should go through init and finish steps (both monitors)", func(t *testing.T) {
@@ -669,8 +669,8 @@ func TestInitialisationStep_Run(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 10*time.Second, repeat)
 		assert.Equal(t, domain.InProgress, upgradeOperation.State)
-		assert.Equal(t, upgradeOperation.Avs.AvsInternalEvaluationStatus, internal.AvsEvaluationStatus{Current: internalStatus, Original: ""})
-		assert.Equal(t, upgradeOperation.Avs.AvsExternalEvaluationStatus, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""})
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: internalStatus, Original: internalStatus}, upgradeOperation.Avs.AvsInternalEvaluationStatus)
+		assert.Equal(t, internal.AvsEvaluationStatus{Current: externalStatus, Original: ""}, upgradeOperation.Avs.AvsExternalEvaluationStatus)
 
 		// when valid client request and InProgress state from RuntimeOperationStatus, this should do init tasks
 		step.evaluationManager = evalManager

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-608"
     kyma_environment_broker:
       dir:
-      version: "PR-568"
+      version: "PR-624"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-597"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix setting AVS evaluation status when the refreshed, current status is the same as the target status. This has caused problems when restoring the original status, as it was left empty.
- Fix checking input execution ID in `ParallelOrchestrationStrategy.Cancel()`

