### PR TITLE
Using M5 machine types for AWS

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -166,7 +166,7 @@ func Plans(plans PlansConfig) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AWSSchema([]string{"m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "m4.16xlarge"}),
+			provisioningRawSchema: AWSSchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"}),
 		},
 		GCPPlanID: {
 			PlanDefinition: domain.ServicePlan{

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -21,7 +21,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:         "AWS schema is correct",
 			generator:    AWSSchema,
-			machineTypes: []string{"m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "m4.16xlarge"},
+			machineTypes: []string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
 			file:         "aws-schema.json",
 		},
 		{

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-schema.json
@@ -15,7 +15,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "m4.16xlarge"]
+      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -37,7 +37,7 @@ func (p *AWSInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m4.2xlarge",
+			MachineType:    "m5.2xlarge",
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",
@@ -97,7 +97,7 @@ func (p *AWSTrialInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m4.xlarge",
+			MachineType:    "m5.xlarge",
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -312,7 +312,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 kubernetesVersion: "1.15.11"
                 diskType: "gp2"
                 volumeSizeGB: 35
-                machineType: "m4.2xlarge"
+                machineType: "m5.2xlarge"
                 region: "eu-west-1"
                 provider: "aws"
                 purpose: "testing" # possible values: "development", "evaluation", "production", "testing"; default value: "evaluation"


### PR DESCRIPTION
**Description**

Changing from M4 to M5 machines for cost reduction and gaining higher performance.

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/1201
