### PR TITLE
Disable testing Azure Event Hubs in e2e provisioning test

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -81,7 +81,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]
@@ -166,7 +166,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-gcp.yaml
@@ -81,7 +81,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]
@@ -165,7 +165,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-skr.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-skr.yaml
@@ -81,7 +81,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]
@@ -166,7 +166,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-suspension.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-suspension.yaml
@@ -77,7 +77,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "false"
           command: ["/bin/sh"]

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-upgrade-azure.yaml
@@ -81,7 +81,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "true"
             - name: APP_UPGRADE_TIMEOUT
@@ -168,7 +168,7 @@ spec:
             - name: APP_GARDENER_KUBECONFIG_PATH
               value: {{ .Values.gardener.kubeconfigPath }}
             - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
-              value: "true"
+              value: "false"
             - name: APP_UPGRADE_TEST
               value: "true"
             - name: APP_UPGRADE_TIMEOUT


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In Kyma version `>1.21`, Azure Event Hubs are not provisioned anymore and testing this integration in `e2e_provisioning_test` does not work.

Changes proposed in this pull request:

- Set `APP_TEST_AZURE_EVENT_HUBS_ENABLED` to `false` for all e2e `TestDefinitions`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
