### PR TITLE
Add conflict strategy parameter to ProvisionRuntimeInput

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -89,7 +89,7 @@ func (r *RuntimeInput) AppendOverrides(component string, overrides []*gqlschema.
 	return r
 }
 
-// AppendAppendGlobalOverrides appends overrides, the existing overrides are preserved.
+// AppendGlobalOverrides appends overrides, the existing overrides are preserved.
 func (r *RuntimeInput) AppendGlobalOverrides(overrides []*gqlschema.ConfigEntryInput) internal.ProvisionerInputCreator {
 	r.mutex.Lock("AppendGlobalOverrides")
 	defer r.mutex.Unlock("AppendGlobalOverrides")
@@ -136,6 +136,10 @@ func (r *RuntimeInput) CreateProvisionRuntimeInput() (gqlschema.ProvisionRuntime
 			execute: r.applyGlobalOverridesForProvisionRuntime,
 		},
 		{
+			name:    "applying global configuration",
+			execute: r.applyGlobalConfigurationForProvisionRuntime,
+		},
+		{
 			name:    "removing forbidden chars and adding random string to runtime name",
 			execute: r.adjustRuntimeName,
 		},
@@ -172,6 +176,10 @@ func (r *RuntimeInput) CreateUpgradeRuntimeInput() (gqlschema.UpgradeRuntimeInpu
 		{
 			name:    "applying global overrides",
 			execute: r.applyGlobalOverridesForUpgradeRuntime,
+		},
+		{
+			name:    "applying global configuration",
+			execute: r.applyGlobalConfigurationForUpgradeRuntime,
 		},
 		{
 			name:    "set number of nodes from configuration",
@@ -327,6 +335,18 @@ func (r *RuntimeInput) applyGlobalOverridesForProvisionRuntime() error {
 
 func (r *RuntimeInput) applyGlobalOverridesForUpgradeRuntime() error {
 	r.upgradeRuntimeInput.KymaConfig.Configuration = r.globalOverrides
+	return nil
+}
+
+func (r *RuntimeInput) applyGlobalConfigurationForProvisionRuntime() error {
+	strategy := gqlschema.ConflictStrategyReplace
+	r.provisionRuntimeInput.KymaConfig.ConflictStrategy = &strategy
+	return nil
+}
+
+func (r *RuntimeInput) applyGlobalConfigurationForUpgradeRuntime() error {
+	strategy := gqlschema.ConflictStrategyReplace
+	r.upgradeRuntimeInput.KymaConfig.ConflictStrategy = &strategy
 	return nil
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -56,6 +56,7 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 	assert.NoError(t, err)
 
 	profile := gqlschema.KymaProfileProduction
+	strategy := gqlschema.ConflictStrategyReplace
 	provisionerInput := gqlschema.ProvisionRuntimeInput{
 		RuntimeInput: &gqlschema.RuntimeInput{
 			Name:        "dummy",
@@ -99,8 +100,9 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 					Configuration: nil,
 				},
 			},
-			Configuration: []*gqlschema.ConfigEntryInput{},
-			Profile:       &profile,
+			Configuration:    []*gqlschema.ConfigEntryInput{},
+			Profile:          &profile,
+			ConflictStrategy: &strategy,
 		},
 	}
 

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step_test.go
@@ -38,11 +38,13 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 	err = memoryStorage.Operations().InsertProvisioningOperation(provisioningOperation)
 	assert.NoError(t, err)
 	profile := gqlschema.KymaProfileProduction
+	strategy := gqlschema.ConflictStrategyReplace
 	provisionerClient := &provisionerAutomock.Client{}
 	provisionerClient.On("UpgradeRuntime", fixGlobalAccountID, fixRuntimeID, gqlschema.UpgradeRuntimeInput{
 		KymaConfig: &gqlschema.KymaConfigInput{
-			Version: kymaVersion,
-			Profile: &profile,
+			Version:          kymaVersion,
+			Profile:          &profile,
+			ConflictStrategy: &strategy,
 			Components: []*gqlschema.ComponentConfigurationInput{
 				{
 					Component:     "keb",

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
@@ -147,6 +147,9 @@ func (g *Graphqlizer) KymaConfigToGraphQL(in gqlschema.KymaConfigInput) (string,
 		{{- if .Profile }}
 		profile: {{ .Profile }},
 		{{- end }}
+		{{- if .ConflictStrategy }}
+		conflictStrategy: {{ .ConflictStrategy }},
+		{{- end }}
 		{{- with .Components }}
         components: [
 		  {{- range . }}
@@ -156,6 +159,9 @@ func (g *Graphqlizer) KymaConfigToGraphQL(in gqlschema.KymaConfigInput) (string,
             {{- if .SourceURL }}
             sourceURL: "{{ .SourceURL }}",
             {{- end }}
+			{{- if .ConflictStrategy }}
+			conflictStrategy: {{ .ConflictStrategy }},
+			{{- end }}
       	    {{- with .Configuration }}
             configuration: [
 			  {{- range . }}

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
@@ -12,18 +12,21 @@ import (
 func TestKymaConfigToGraphQLAllParametersProvided(t *testing.T) {
 	// given
 	profile := gqlschema.KymaProfileProduction
+	strategy := gqlschema.ConflictStrategyReplace
 	fixInput := gqlschema.KymaConfigInput{
-		Version: "966",
-		Profile: &profile,
+		Version:          "966",
+		Profile:          &profile,
+		ConflictStrategy: &strategy,
 		Components: []*gqlschema.ComponentConfigurationInput{
 			{
 				Component: "pico",
 				Namespace: "bello",
 			},
 			{
-				Component: "custom-component",
-				Namespace: "bello",
-				SourceURL: ptr.String("github.com/kyma-incubator/custom-component"),
+				Component:        "custom-component",
+				Namespace:        "bello",
+				ConflictStrategy: &strategy,
+				SourceURL:        ptr.String("github.com/kyma-incubator/custom-component"),
 			},
 			{
 				Component: "hakuna",
@@ -56,6 +59,7 @@ func TestKymaConfigToGraphQLAllParametersProvided(t *testing.T) {
 	expRender := `{
 		version: "966",
 		profile: Production,
+		conflictStrategy: Replace,
         components: [
           {
             component: "pico",
@@ -65,6 +69,7 @@ func TestKymaConfigToGraphQLAllParametersProvided(t *testing.T) {
             component: "custom-component",
             namespace: "bello",
             sourceURL: "github.com/kyma-incubator/custom-component",
+			conflictStrategy: Replace,
           }
           {
             component: "hakuna",

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-646"
     kyma_environment_broker:
       dir:
-      version: "PR-662"
+      version: "PR-657"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
Changes proposed in this pull request:

- Add conflict strategy parameter to ProvisionRuntimeInput
- Set global value for conflict strategy parameter as "Replace"
- Add posibility to set conflict strategy parameter per component