### PR TITLE
Block unsuspension if the instance is being deprovisioned

### DIFF
--- a/components/kyma-environment-broker/internal/suspension/handler_test.go
+++ b/components/kyma-environment-broker/internal/suspension/handler_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
+
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -147,7 +149,7 @@ func TestUnsuspension(t *testing.T) {
 	assertQueue(t, deprovisioning)
 	assertQueue(t, provisioning, op.ID)
 
-	assert.Equal(t, domain.InProgress, op.State)
+	assert.Equal(t, domain.LastOperationState(orchestration.Pending), op.State)
 	assert.Equal(t, instance.InstanceID, op.InstanceID)
 	assert.Equal(t, "c-012345", op.ShootName)
 	assert.Equal(t, "c-012345.sap.com", op.ShootDomain)
@@ -204,7 +206,7 @@ func TestUnsuspensionWithoutShootname(t *testing.T) {
 	assertQueue(t, deprovisioning)
 	assertQueue(t, provisioning, op.ID)
 
-	assert.Equal(t, domain.InProgress, op.State)
+	assert.Equal(t, domain.LastOperationState(orchestration.Pending), op.State)
 	assert.Equal(t, instance.InstanceID, op.InstanceID)
 	assert.Equal(t, "c-7f1eb9e", op.ShootName)
 	assert.Equal(t, "c-7f1eb9e.kyma-dev.shoot.canary.k8s-hana.ondemand.com", op.ShootDomain)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-646"
     kyma_environment_broker:
       dir:
-      version: "PR-669"
+      version: "PR-666"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- do not start unsuspension if the instance is being deprovisioned (or the deprovisioning is failed)
- unsuspension starts Pending operation
- the provisioning initialisation process checks if there is ongoing deprovisioning - if not - then changes from pending to inprogress status

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
