### PR TITLE
Add Azure HA plan

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -39,34 +39,52 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 	for tn, tc := range map[string]struct {
 		planID string
 
-		expectedProfile            gqlschema.KymaProfile
-		expectedProvider           string
-		expectedNumberOfNodes      int
-		expectedSharedSubscription bool
+		expectedProfile              gqlschema.KymaProfile
+		expectedProvider             string
+		expectedMinimalNumberOfNodes int
+		expectedMaximumNumberOfNodes int
+		expectedMachineType          string
+		expectedSharedSubscription   bool
 	}{
 		"Regular trial": {
 			planID: broker.TrialPlanID,
 
-			expectedNumberOfNodes:      1,
-			expectedProfile:            gqlschema.KymaProfileEvaluation,
-			expectedProvider:           "azure",
-			expectedSharedSubscription: true,
+			expectedMinimalNumberOfNodes: 1,
+			expectedMaximumNumberOfNodes: 1,
+			expectedMachineType:          "Standard_D4_v3",
+			expectedProfile:              gqlschema.KymaProfileEvaluation,
+			expectedProvider:             "azure",
+			expectedSharedSubscription:   true,
 		},
 		"Production Azure": {
 			planID: broker.AzurePlanID,
 
-			expectedNumberOfNodes:      2,
-			expectedProfile:            gqlschema.KymaProfileProduction,
-			expectedProvider:           "azure",
-			expectedSharedSubscription: false,
+			expectedMinimalNumberOfNodes: 2,
+			expectedMaximumNumberOfNodes: 10,
+			expectedMachineType:          "Standard_D8_v3",
+			expectedProfile:              gqlschema.KymaProfileProduction,
+			expectedProvider:             "azure",
+			expectedSharedSubscription:   false,
+		},
+		"HA Azure": {
+			planID: broker.AzureHAPlanID,
+
+			expectedMinimalNumberOfNodes: 4,
+			expectedMaximumNumberOfNodes: 10,
+			expectedMachineType:          "Standard_D4_v3",
+			expectedProfile:              gqlschema.KymaProfileProduction,
+			expectedProvider:             "azure",
+			expectedSharedSubscription:   false,
 		},
 		"Production AWS": {
 			planID: broker.AWSPlanID,
 
-			expectedNumberOfNodes:      2,
-			expectedProfile:            gqlschema.KymaProfileProduction,
-			expectedProvider:           "aws",
-			expectedSharedSubscription: false,
+			expectedMinimalNumberOfNodes: 2,
+			expectedMaximumNumberOfNodes: 10,
+			expectedMachineType:          "m5.2xlarge",
+			expectedProfile:              gqlschema.KymaProfileProduction,
+			expectedProvider:             "aws",
+			expectedSharedSubscription:   false,
 		},
 	} {
 		t.Run(tn, func(t *testing.T) {
@@ -91,7 +109,9 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			suite.AssertKymaProfile(tc.expectedProfile)
 			suite.AssertProvider(tc.expectedProvider)
-			suite.AssertMinimalNumberOfNodes(tc.expectedNumberOfNodes)
+			suite.AssertMinimalNumberOfNodes(tc.expectedMinimalNumberOfNodes)
+			suite.AssertMaximumNumberOfNodes(tc.expectedMaximumNumberOfNodes)
+			suite.AssertMachineType(tc.expectedMachineType)
 			suite.AssertSharedSubscription(tc.expectedSharedSubscription)
 		})
 

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/upgrade_cluster"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/upgrade_kyma"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provider"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provisioner"
 	kebRuntime "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/runtime"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/runtimeoverrides"
@@ -180,6 +181,7 @@ type RuntimeOptions struct {
 	PlatformRegion  string
 	Region          string
 	PlanID          string
+	ZonesCount      *int
 }
 
 func (o *RuntimeOptions) ProvideRegion() *string {
@@ -221,6 +223,10 @@ func (o *RuntimeOptions) ProvidePlanID() string {
 	} else {
 		return o.PlanID
 	}
+}
+
+func (o *RuntimeOptions) ProvideZonesCount() *int {
+	return o.ZonesCount
 }
 
 func (s *OrchestrationSuite) CreateProvisionedRuntime(options RuntimeOptions) string {
@@ -512,7 +518,8 @@ func (s *ProvisioningSuite) CreateProvisioning(options RuntimeOptions) string {
 		},
 		PlatformRegion: options.ProvidePlatformRegion(),
 		Parameters: internal.ProvisioningParametersDTO{
-			Region: options.ProvideRegion(),
+			Region:     options.ProvideRegion(),
+			ZonesCount: options.ProvideZonesCount(),
 		},
 	}
 
@@ -712,6 +719,22 @@ func (s *ProvisioningSuite) AssertMachineType(machineType string) {
 	input := s.fetchProvisionInput()
 
 	assert.Equal(s.t, machineType, input.ClusterConfig.GardenerConfig.MachineType)
+}
+
+func (s *ProvisioningSuite) AssertZonesCount(zonesCount *int, planID string) {
+	input := s.fetchProvisionInput()
+
+	switch planID {
+	case broker.AzureHAPlanID:
+		if zonesCount != nil {
+			// zonesCount was provided in provisioning request
+			assert.Equal(s.t, *zonesCount, len(input.ClusterConfig.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones))
+			break
+		}
+		// zonesCount was not provided, should use default value
+		assert.Equal(s.t, provider.DefaultAzureHAZonesCount, len(input.ClusterConfig.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones))
+	default:
+	}
 }
 
 func (s *ProvisioningSuite) AssertSharedSubscription(shared bool) {

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -375,9 +375,10 @@ func fixK8sResources(defaultKymaVersion string, additionalKymaVersions []string)
 			Namespace: "kcp-system",
 			Labels: map[string]string{
 				fmt.Sprintf("overrides-version-%s", defaultKymaVersion): "true",
-				"overrides-plan-azure": "true",
-				"overrides-plan-trial": "true",
-				"overrides-plan-aws":   "true",
+				"overrides-plan-azure":    "true",
+				"overrides-plan-trial":    "true",
+				"overrides-plan-aws":      "true",
+				"overrides-plan-azure_ha": "true",
 			},
 		},
 		Data: map[string]string{
@@ -699,6 +700,18 @@ func (s *ProvisioningSuite) AssertMinimalNumberOfNodes(nodes int) {
 	input := s.fetchProvisionInput()
 
 	assert.Equal(s.t, nodes, input.ClusterConfig.GardenerConfig.AutoScalerMin)
+}
+
+func (s *ProvisioningSuite) AssertMaximumNumberOfNodes(nodes int) {
+	input := s.fetchProvisionInput()
+
+	assert.Equal(s.t, nodes, input.ClusterConfig.GardenerConfig.AutoScalerMax)
+}
+
+func (s *ProvisioningSuite) AssertMachineType(machineType string) {
+	input := s.fetchProvisionInput()
+
+	assert.Equal(s.t, machineType, input.ClusterConfig.GardenerConfig.MachineType)
 }
 
 func (s *ProvisioningSuite) AssertSharedSubscription(shared bool) {

--- a/components/kyma-environment-broker/common/hyperscaler/account_provider.go
+++ b/components/kyma-environment-broker/common/hyperscaler/account_provider.go
@@ -40,7 +40,7 @@ func HyperscalerTypeForPlanID(planID string) (Type, error) {
 	switch planID {
 	case broker.GCPPlanID:
 		return GCP, nil
-	case broker.AzurePlanID, broker.AzureLitePlanID:
+	case broker.AzurePlanID, broker.AzureLitePlanID, broker.AzureHAPlanID:
 		return Azure, nil
 	case broker.OpenStackPlanID:
 		return Openstack, nil

--- a/components/kyma-environment-broker/common/hyperscaler/azure/env.go
+++ b/components/kyma-environment-broker/common/hyperscaler/azure/env.go
@@ -49,7 +49,7 @@ func mapRegion(credentials hyperscaler.Credentials, parameters internal.Provisio
 	}
 	region := *(parameters.Parameters.Region)
 	switch parameters.PlanID {
-	case broker.AzurePlanID, broker.AzureLitePlanID:
+	case broker.AzurePlanID, broker.AzureLitePlanID, broker.AzureHAPlanID:
 		if !isInList(broker.AzureRegions(), region) {
 			return "", fmt.Errorf("supplied region \"%v\" is not a valid region for Azure", region)
 		}

--- a/components/kyma-environment-broker/common/hyperscaler/azure/env_test.go
+++ b/components/kyma-environment-broker/common/hyperscaler/azure/env_test.go
@@ -93,6 +93,16 @@ func Test_mapRegion(t *testing.T) {
 			wantRegion: "japaneast",
 			wantErr:    false,
 		},
+		{
+			name: "valid azure ha region",
+			args: args{
+				hyperscalerType: hyperscaler.Azure,
+				planID:          broker.AzureHAPlanID,
+				region:          "japaneast",
+			},
+			wantRegion: "japaneast",
+			wantErr:    false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/components/kyma-environment-broker/internal/broker/instance_create_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create_test.go
@@ -51,7 +51,7 @@ func TestProvision_Provision(t *testing.T) {
 
 		// #create provisioner endpoint
 		provisionEndpoint := broker.NewProvision(
-			broker.Config{EnablePlans: []string{"gcp", "azure"}, OnlySingleTrialPerGA: true},
+			broker.Config{EnablePlans: []string{"gcp", "azure", "azure_ha"}, OnlySingleTrialPerGA: true},
 			gardener.Config{Project: "test", ShootDomain: "example.com"},
 			memoryStorage.Operations(),
 			memoryStorage.Instances(),
@@ -108,7 +108,7 @@ func TestProvision_Provision(t *testing.T) {
 
 		// #create provisioner endpoint
 		provisionEndpoint := broker.NewProvision(
-			broker.Config{EnablePlans: []string{"gcp", "azure", "azure_lite"}, OnlySingleTrialPerGA: true},
+			broker.Config{EnablePlans: []string{"gcp", "azure", "azure_lite", "azure_ha"}, OnlySingleTrialPerGA: true},
 			gardener.Config{Project: "test", ShootDomain: "example.com"},
 			memoryStorage.Operations(),
 			memoryStorage.Instances(),

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -139,7 +139,7 @@ func AzureHASchema(machineTypes []string) []byte {
 	properties := NewProvisioningProperties(machineTypes, AzureRegions())
 	properties.ZonesCount = &Type{
 		Type:        "integer",
-		Minimum:     1,
+		Minimum:     2,
 		Maximum:     3,
 		Default:     2,
 		Description: "Specifies the number of availability zones for HA cluster",

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -137,7 +137,16 @@ func AzureSchema(machineTypes []string) []byte {
 
 func AzureHASchema(machineTypes []string) []byte {
 	properties := NewProvisioningProperties(machineTypes, AzureRegions())
-	schema := NewSchema(properties, DefaultControlsOrder())
+	properties.ZonesCount = &Type{
+		Type:        "integer",
+		Minimum:     1,
+		Maximum:     3,
+		Default:     2,
+		Description: "Specifies the number of availability zones for HA cluster",
+	}
+	azureHaControlsOrder := DefaultControlsOrder()
+	azureHaControlsOrder = append(azureHaControlsOrder, "zonesCount")
+	schema := NewSchema(properties, azureHaControlsOrder)
 
 	properties.AutoScalerMin.Default = 4
 	properties.AutoScalerMin.Minimum = 4

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -18,6 +18,8 @@ const (
 	AzurePlanName     = "azure"
 	AzureLitePlanID   = "8cb22518-aa26-44c5-91a0-e669ec9bf443"
 	AzureLitePlanName = "azure_lite"
+	AzureHAPlanID     = "f2951649-02ca-43a5-9188-9c07fb612491"
+	AzureHAPlanName   = "azure_ha"
 	TrialPlanID       = "7d55d31d-35ae-4438-bf13-6ffdfa107d9f"
 	TrialPlanName     = "trial"
 	OpenStackPlanID   = "03b812ac-c991-4528-b5bd-08b303523a63"
@@ -29,6 +31,7 @@ var PlanNamesMapping = map[string]string{
 	AWSPlanID:       AWSPlanName,
 	AzurePlanID:     AzurePlanName,
 	AzureLitePlanID: AzureLitePlanName,
+	AzureHAPlanID:   AzureHAPlanName,
 	TrialPlanID:     TrialPlanName,
 	OpenStackPlanID: OpenStackPlanName,
 }
@@ -37,6 +40,7 @@ var PlanIDsMapping = map[string]string{
 	AzurePlanName:     AzurePlanID,
 	AWSPlanName:       AWSPlanID,
 	AzureLitePlanName: AzureLitePlanID,
+	AzureHAPlanName:   AzureHAPlanID,
 	GCPPlanName:       GCPPlanID,
 	TrialPlanName:     TrialPlanID,
 	OpenStackPlanName: OpenStackPlanID,
@@ -222,6 +226,22 @@ func Plans(plans PlansConfig) map[string]Plan {
 				Name:        AzureLitePlanName,
 				Description: defaultDescription(AzureLitePlanName, plans),
 				Metadata:    defaultMetadata(AzureLitePlanName, plans),
+				Schemas: &domain.ServiceSchemas{
+					Instance: domain.ServiceInstanceSchema{
+						Create: domain.Schema{
+							Parameters: make(map[string]interface{}),
+						},
+					},
+				},
+			},
+			provisioningRawSchema: AzureSchema([]string{"Standard_D4_v3"}),
+		},
+		AzureHAPlanID: {
+			PlanDefinition: domain.ServicePlan{
+				ID:          AzureHAPlanID,
+				Name:        AzureHAPlanName,
+				Description: defaultDescription(AzureHAPlanName, plans),
+				Metadata:    defaultMetadata(AzureHAPlanName, plans),
 				Schemas: &domain.ServiceSchemas{
 					Instance: domain.ServiceInstanceSchema{
 						Create: domain.Schema{

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -135,6 +135,23 @@ func AzureSchema(machineTypes []string) []byte {
 	return bytes
 }
 
+func AzureHASchema(machineTypes []string) []byte {
+	properties := NewProvisioningProperties(machineTypes, AzureRegions())
+	schema := NewSchema(properties, DefaultControlsOrder())
+
+	properties.AutoScalerMin.Default = 4
+	properties.AutoScalerMin.Minimum = 4
+
+	properties.AutoScalerMax.Default = 10
+	properties.AutoScalerMax.Maximum = 10
+
+	bytes, err := json.Marshal(schema)
+	if err != nil {
+		panic(err)
+	}
+	return bytes
+}
+
 func TrialSchema() []byte {
 	schema := NewSchema(
 		ProvisioningProperties{
@@ -250,7 +267,7 @@ func Plans(plans PlansConfig) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AzureSchema([]string{"Standard_D4_v3"}),
+			provisioningRawSchema: AzureHASchema([]string{"Standard_D4_v3"}),
 		},
 		TrialPlanID: {
 			PlanDefinition: domain.ServicePlan{

--- a/components/kyma-environment-broker/internal/broker/plans_schema.go
+++ b/components/kyma-environment-broker/internal/broker/plans_schema.go
@@ -18,6 +18,7 @@ type ProvisioningProperties struct {
 	MachineType   *Type `json:"machineType,omitempty"`
 	AutoScalerMin *Type `json:"autoScalerMin,omitempty"`
 	AutoScalerMax *Type `json:"autoScalerMax,omitempty"`
+	ZonesCount    *Type `json:"zonesCount,omitempty"`
 }
 
 type Type struct {

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -37,6 +37,12 @@ func TestSchemaGenerator(t *testing.T) {
 			file:         "azure-lite-schema.json",
 		},
 		{
+			name:         "AzureHA schema is correct",
+			generator:    AzureSchema, // TODO: adjust AzureSchema() function to pass autoScalerMin/autoScalerMax parameter for proper plan schema properties
+			machineTypes: []string{"Standard_D4_v3"},
+			file:         "azure-ha-schema.json",
+		},
+		{
 			name:         "GCP schema is correct",
 			generator:    GCPSchema,
 			machineTypes: []string{"n1-standard-2", "n1-standard-4", "n1-standard-8", "n1-standard-16", "n1-standard-32", "n1-standard-64"},

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -38,7 +38,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name:         "AzureHA schema is correct",
-			generator:    AzureSchema, // TODO: adjust AzureSchema() function to pass autoScalerMin/autoScalerMax parameter for proper plan schema properties
+			generator:    AzureHASchema,
 			machineTypes: []string{"Standard_D4_v3"},
 			file:         "azure-ha-schema.json",
 		},

--- a/components/kyma-environment-broker/internal/broker/plans_validator.go
+++ b/components/kyma-environment-broker/internal/broker/plans_validator.go
@@ -17,7 +17,7 @@ type JSONSchemaValidator interface {
 type PlansSchemaValidator map[string]JSONSchemaValidator
 
 func NewPlansSchemaValidator(plansConfig PlansConfig) (PlansSchemaValidator, error) {
-	planIDs := []string{GCPPlanID, AWSPlanID, AzurePlanID, AzureLitePlanID, TrialPlanID, OpenStackPlanID}
+	planIDs := []string{GCPPlanID, AWSPlanID, AzurePlanID, AzureLitePlanID, AzureHAPlanID, TrialPlanID, OpenStackPlanID}
 	validators := PlansSchemaValidator{}
 	plans := Plans(plansConfig)
 

--- a/components/kyma-environment-broker/internal/broker/plans_validator_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_validator_test.go
@@ -60,7 +60,7 @@ func TestNewPlansSchemaValidatorSuccess(t *testing.T) {
 	validator, err := NewPlansSchemaValidator(PlansConfig{})
 	require.NoError(t, err)
 
-	for _, id := range []string{GCPPlanID, AzurePlanID, TrialPlanID} {
+	for _, id := range []string{GCPPlanID, AzurePlanID, AzureHAPlanID, TrialPlanID} {
 		// when
 		result, err := validator[id].ValidateString(validJSON)
 		require.NoError(t, err)

--- a/components/kyma-environment-broker/internal/broker/services_test.go
+++ b/components/kyma-environment-broker/internal/broker/services_test.go
@@ -18,7 +18,7 @@ func TestServices_Services(t *testing.T) {
 	)
 
 	cfg := broker.Config{
-		EnablePlans: []string{"gcp", "azure", "openstack", "aws"},
+		EnablePlans: []string{"gcp", "azure", "azure_ha", "openstack", "aws"},
 	}
 	servicesConfig := map[string]broker.Service{
 		broker.KymaServiceName: {
@@ -36,7 +36,7 @@ func TestServices_Services(t *testing.T) {
 	// then
 	require.NoError(t, err)
 	assert.Len(t, services, 1)
-	assert.Len(t, services[0].Plans, 4)
+	assert.Len(t, services[0].Plans, 5)
 
 	assert.Equal(t, name, services[0].Metadata.DisplayName)
 	assert.Equal(t, supportURL, services[0].Metadata.SupportUrl)

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
@@ -19,14 +19,14 @@
     "autoScalerMin": {
       "type": "integer",
       "description": "Specifies the minimum number of virtual machines to create",
-      "minimum": 2,
-      "default": 2
+      "minimum": 4,
+      "default": 4
     },
     "autoScalerMax": {
       "type": "integer",
       "description": "Specifies the maximum number of virtual machines to create",
       "minimum": 2,
-      "maximum": 40,
+      "maximum": 10,
       "default": 10
     }},
   "required": [

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
@@ -32,7 +32,7 @@
     "zonesCount": {
       "type": "integer",
       "description": "Specifies the number of availability zones for HA cluster",
-      "minimum": 1,
+      "minimum": 2,
       "maximum": 3,
       "default": 2
     }},

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Cluster Name",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9-]*$"
+    },
+    "region": {
+      "type": "string",
+      "enum": [ "eastus", "centralus", "westus2", "uksouth", "northeurope", "westeurope", "japaneast", "southeastasia" ]
+    },
+    "machineType": {
+      "type": "string",
+      "enum": ["Standard_D4_v3"]
+    },
+    "autoScalerMin": {
+      "type": "integer",
+      "description": "Specifies the minimum number of virtual machines to create",
+      "minimum": 2,
+      "default": 2
+    },
+    "autoScalerMax": {
+      "type": "integer",
+      "description": "Specifies the maximum number of virtual machines to create",
+      "minimum": 2,
+      "maximum": 40,
+      "default": 10
+    }},
+  "required": [
+    "name"
+  ],
+  "_show_form_view": true,
+  "_controlsOrder": [
+    "name",
+    "region",
+    "machineType",
+    "autoScalerMin",
+    "autoScalerMax"
+  ]
+}

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
@@ -28,6 +28,13 @@
       "minimum": 2,
       "maximum": 10,
       "default": 10
+    },
+    "zonesCount": {
+      "type": "integer",
+      "description": "Specifies the number of availability zones for HA cluster",
+      "minimum": 1,
+      "maximum": 3,
+      "default": 2
     }},
   "required": [
     "name"
@@ -38,6 +45,7 @@
     "region",
     "machineType",
     "autoScalerMin",
-    "autoScalerMax"
+    "autoScalerMax",
+    "zonesCount"
   ]
 }

--- a/components/kyma-environment-broker/internal/dto.go
+++ b/components/kyma-environment-broker/internal/dto.go
@@ -61,6 +61,7 @@ type ProvisioningParametersDTO struct {
 	// with "provisioning-runtime-override" label when LicenceType is "TestDevelopmentAndDemo"
 	LicenceType                 *string  `json:"licence_type"`
 	Zones                       []string `json:"zones"`
+	ZonesCount                  *int     `json:"zonesCount"`
 	AutoScalerMin               *int     `json:"autoScalerMin"`
 	AutoScalerMax               *int     `json:"autoScalerMax"`
 	MaxSurge                    *int     `json:"maxSurge"`

--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -79,7 +79,7 @@ func NewInputBuilderFactory(optComponentsSvc OptionalComponentService, disabledC
 
 func (f *InputBuilderFactory) IsPlanSupport(planID string) bool {
 	switch planID {
-	case broker.AWSPlanID, broker.GCPPlanID, broker.AzurePlanID, broker.AzureLitePlanID, broker.TrialPlanID, broker.OpenStackPlanID:
+	case broker.AWSPlanID, broker.GCPPlanID, broker.AzurePlanID, broker.AzureLitePlanID, broker.AzureHAPlanID, broker.TrialPlanID, broker.OpenStackPlanID:
 		return true
 	default:
 		return false
@@ -97,6 +97,8 @@ func (f *InputBuilderFactory) getHyperscalerProviderForPlanID(planID string, par
 		provider = &cloudProvider.AzureInput{}
 	case broker.AzureLitePlanID:
 		provider = &cloudProvider.AzureLiteInput{}
+	case broker.AzureHAPlanID:
+		provider = &cloudProvider.AzureHAInput{}
 	case broker.TrialPlanID:
 		provider = f.forTrialPlan(parametersProvider)
 	case broker.AWSPlanID:

--- a/components/kyma-environment-broker/internal/process/input/builder_test.go
+++ b/components/kyma-environment-broker/internal/process/input/builder_test.go
@@ -30,6 +30,7 @@ func TestInputBuilderFactory_IsPlanSupport(t *testing.T) {
 	// when/then
 	assert.True(t, ibf.IsPlanSupport(broker.GCPPlanID))
 	assert.True(t, ibf.IsPlanSupport(broker.AzurePlanID))
+	assert.True(t, ibf.IsPlanSupport(broker.AzureHAPlanID))
 	assert.True(t, ibf.IsPlanSupport(broker.TrialPlanID))
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/resolve_creds.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/resolve_creds.go
@@ -27,7 +27,7 @@ func getHyperscalerType(pp internal.ProvisioningParameters) (hyperscaler.Type, e
 		return hyperscaler.GCP, nil
 	case broker.AWSPlanID:
 		return hyperscaler.AWS, nil
-	case broker.AzurePlanID, broker.AzureLitePlanID:
+	case broker.AzurePlanID, broker.AzureLitePlanID, broker.AzureHAPlanID:
 		return hyperscaler.Azure, nil
 	case broker.OpenStackPlanID:
 		return hyperscaler.Openstack, nil

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -8,8 +8,8 @@ import (
 )
 
 const (
-	DefaultAzureRegion  = "westeurope"
-	MultizoneZonesCount = 2
+	DefaultAzureRegion       = "westeurope"
+	DefaultAzureHAZonesCount = 2
 )
 
 var europeAzure = "westeurope"
@@ -154,7 +154,7 @@ func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",
-					Zones:    generateMultipleAzureZones(MultizoneZonesCount),
+					Zones:    generateMultipleAzureZones(DefaultAzureHAZonesCount),
 				},
 			},
 		},
@@ -162,6 +162,10 @@ func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
 }
 
 func (p *AzureHAInput) ApplyParameters(input *gqlschema.ClusterConfigInput, pp internal.ProvisioningParameters) {
+	if pp.Parameters.Zones == nil && pp.Parameters.ZonesCount != nil {
+		updateSlice(&input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones, generateMultipleAzureZones(*pp.Parameters.ZonesCount))
+		return
+	}
 	updateSlice(&input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones, pp.Parameters.Zones)
 }
 

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -8,7 +8,8 @@ import (
 )
 
 const (
-	DefaultAzureRegion = "westeurope"
+	DefaultAzureRegion  = "westeurope"
+	MultizoneZonesCount = 2
 )
 
 var europeAzure = "westeurope"
@@ -153,7 +154,7 @@ func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",
-					Zones:    []string{"1", "2"},
+					Zones:    generateMultipleAzureZones(MultizoneZonesCount),
 				},
 			},
 		},

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -29,6 +29,7 @@ type (
 	AzureTrialInput struct {
 		PlatformRegionMapping map[string]string
 	}
+	AzureHAInput struct{}
 )
 
 func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
@@ -134,6 +135,37 @@ func (p *AzureTrialInput) ApplyParameters(input *gqlschema.ClusterConfigInput, p
 	}
 
 	updateSlice(&input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones, params.Zones)
+}
+
+func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
+	return &gqlschema.ClusterConfigInput{
+		GardenerConfig: &gqlschema.GardenerConfigInput{
+			DiskType:       ptr.String("Standard_LRS"),
+			VolumeSizeGb:   ptr.Integer(50),
+			MachineType:    "Standard_D4_v3",
+			Region:         DefaultAzureRegion,
+			Provider:       "azure",
+			WorkerCidr:     "10.250.0.0/19",
+			AutoScalerMin:  4,
+			AutoScalerMax:  10,
+			MaxSurge:       4,
+			MaxUnavailable: 0,
+			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
+				AzureConfig: &gqlschema.AzureProviderConfigInput{
+					VnetCidr: "10.250.0.0/19",
+					Zones:    []string{"1", "2"},
+				},
+			},
+		},
+	}
+}
+
+func (p *AzureHAInput) ApplyParameters(input *gqlschema.ClusterConfigInput, pp internal.ProvisioningParameters) {
+	updateSlice(&input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones, pp.Parameters.Zones)
+}
+
+func (p *AzureHAInput) Profile() gqlschema.KymaProfile {
+	return gqlschema.KymaProfileProduction
 }
 
 func (p *AzureTrialInput) Profile() gqlschema.KymaProfile {

--- a/components/kyma-environment-broker/internal/provider/azure_provider_test.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider_test.go
@@ -92,3 +92,16 @@ func TestAzureTrialInput_ApplyParametersWithRegion(t *testing.T) {
 		assert.Equal(t, "westeurope", input.GardenerConfig.Region)
 	})
 }
+
+func TestAzureHAInput_Defaults(t *testing.T) {
+	// given
+	svc := AzureHAInput{}
+
+	// when
+	input := svc.Defaults()
+
+	// then
+	assert.Equal(t, 4, input.GardenerConfig.AutoScalerMin)
+	assert.Equal(t, 10, input.GardenerConfig.AutoScalerMax)
+	assert.Equal(t, 2, len(input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones))
+}

--- a/components/kyma-environment-broker/internal/provider/common.go
+++ b/components/kyma-environment-broker/internal/provider/common.go
@@ -37,3 +37,10 @@ func generateRandomAzureZone() string {
 
 	return strconv.Itoa(getRandomNumber())
 }
+
+func generateMultipleAzureZones(zoneCount int) []string {
+	zones := []string{"1", "2", "3"}
+	rand.Seed(time.Now().UnixNano())
+	rand.Shuffle(len(zones), func(i, j int) { zones[i], zones[j] = zones[j], zones[i] })
+	return zones[:zoneCount]
+}

--- a/components/kyma-environment-broker/internal/runtime/disabled_components.go
+++ b/components/kyma-environment-broker/internal/runtime/disabled_components.go
@@ -37,6 +37,10 @@ func NewDisabledComponentsProvider() DisabledComponentsProvider {
 			components.NatsStreaming:           {},
 			components.KnativeProvisionerNatss: {},
 		},
+		broker.AzureHAPlanID: {
+			components.NatsStreaming:           {},
+			components.KnativeProvisionerNatss: {},
+		},
 		broker.AWSPlanID: {
 			components.KnativeEventingKafka: {},
 		},

--- a/resources/kcp/charts/kyma-environment-broker/files/catalog.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/files/catalog.yaml
@@ -46,6 +46,10 @@ services:
         description: "Azure Lite"
         metadata:
           displayName: "Azure Lite"
+      azure_ha:
+        description: "Azure HA"
+        metadata:
+          displayName: "Azure HA"
       trial:
         description: "Trial"
         metadata:

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -75,7 +75,7 @@ kymaVersion: "1.13.0"
 kymaVersionOnDemand: "false"
 
 disableProcessOperationsInProgress: "false"
-enablePlans: "azure,gcp,azure_lite,trial"
+enablePlans: "azure,gcp,azure_lite,azure_ha,trial"
 onlySingleTrialPerGA: "true"
 
 osbUpdateProcessingEnabled: "false"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-650"
     kyma_environment_broker:
       dir:
-      version: "PR-687"
+      version: "PR-671"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
For Multizone PoC we need new High Availability plans with multiple zones - `azure_ha` plan uses 2 zones by default (randomly generated from `[1;3]`) on 4 nodes, machine type `Standard_D4_v3`. A new provisioning parameter `zonesCount` is introduced in `Azure_HA` plan schema to allow the user to choose more than 2 zones.

Changes proposed in this pull request:

- Added new plan: `azure-ha` with 2 zones - `planID: f2951649-02ca-43a5-9188-9c07fb612491`
- Added new `zonesCount` provisioning parameter (only visible in schema for `Azure_HA` plan) which controls how many AZ are created for a cluster

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/1308
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
