### PR TITLE
Bump KEB verstion to PR-669

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-646"
     kyma_environment_broker:
       dir:
-      version: "PR-655"
+      version: "PR-669"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
**Description**

Upgrade KEB version to PR-669 after adding support for AWS M4 + M5 VM machines.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
