### PR TITLE
KEB: Move shootName recovering to an Instance model

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -97,3 +97,25 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 	}
 }
+
+func TestUnsuspensionWithoutShootName(t *testing.T) {
+	// given
+	suite := NewProvisioningSuite(t)
+
+	// when
+	// Create an instance, succeeded suspension operation in the past and a pending unsuspensionOperationID operation
+	unsuspensionOperationID := suite.CreateUnsuspension(RuntimeOptions{})
+
+	// then
+	suite.WaitForProvisioningState(unsuspensionOperationID, domain.InProgress)
+	suite.AssertProvisionerStartedProvisioning(unsuspensionOperationID)
+
+	// when
+	suite.FinishProvisioningOperationByProvisioner(unsuspensionOperationID)
+
+	// then
+	suite.WaitForProvisioningState(unsuspensionOperationID, domain.Succeeded)
+	suite.AssertAllStepsFinished(unsuspensionOperationID)
+	suite.AssertDirectorGrafanaTag(unsuspensionOperationID)
+	suite.AssertProvisioningRequest()
+}

--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -103,7 +103,7 @@ func TestUnsuspensionWithoutShootName(t *testing.T) {
 	suite := NewProvisioningSuite(t)
 
 	// when
-	// Create an instance, succeeded suspension operation in the past and a pending unsuspensionOperationID operation
+	// Create an instance, succeeded suspension operation in the past and a pending unsuspension operation
 	unsuspensionOperationID := suite.CreateUnsuspension(RuntimeOptions{})
 
 	// then

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -563,8 +563,6 @@ func (s *ProvisioningSuite) CreateUnsuspension(options RuntimeOptions) string {
 		},
 	}
 
-	shootName := gardener.CreateShootName()
-
 	operation, err := internal.NewProvisioningOperationWithID(operationID, instanceID, provisioningParameters)
 	operation.State = orchestration.Pending
 	require.NoError(s.t, err)

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -568,8 +568,6 @@ func (s *ProvisioningSuite) CreateUnsuspension(options RuntimeOptions) string {
 	operation, err := internal.NewProvisioningOperationWithID(operationID, instanceID, provisioningParameters)
 	operation.State = orchestration.Pending
 	require.NoError(s.t, err)
-	operation.ShootName = shootName
-	operation.ShootDomain = fmt.Sprintf("%s.%s.%s", shootName, "garden-dummy", strings.Trim("kyma.io", "."))
 
 	err = s.storage.Operations().InsertProvisioningOperation(operation)
 	require.NoError(s.t, err)

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -121,7 +121,7 @@ func (i *Instance) GetInstanceDetails() (InstanceDetails, error) {
 		logrus.Infof("extracting shoot name/domain from dashboard_url %s for instance %s", i.DashboardURL, i.InstanceID)
 		shoot, domain, e := i.extractShootNameAndDomain()
 		if e != nil {
-			logrus.Errorf("unable to extract shoot name: %s (instance %s)", e.Error())
+			logrus.Errorf("unable to extract shoot name: %s (instance %s)", e.Error(), i.InstanceID)
 			return result, e
 		}
 		result.ShootName = shoot

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -2,7 +2,12 @@ package internal
 
 import (
 	"database/sql"
+	"fmt"
+	"net/url"
+	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/servicemanager"
 	"github.com/sirupsen/logrus"
@@ -108,6 +113,34 @@ type Instance struct {
 	DeletedAt time.Time
 
 	Version int
+}
+
+func (i *Instance) GetInstanceDetails() (InstanceDetails, error) {
+	result := i.InstanceDetails
+	if result.ShootName == "" {
+		logrus.Infof("extracting shoot name/domain from dashboard_url %s for instance %s", i.DashboardURL, i.InstanceID)
+		shoot, domain, e := i.extractShootNameAndDomain()
+		if e != nil {
+			logrus.Errorf("unable to extract shoot name: %s (instance %s)", e.Error())
+			return result, e
+		}
+		result.ShootName = shoot
+		result.ShootDomain = domain
+	}
+	return result, nil
+}
+
+func (i *Instance) extractShootNameAndDomain() (string, string, error) {
+	parsed, err := url.Parse(i.DashboardURL)
+	if err != nil {
+		return "", "", errors.Wrapf(err, "while parsing dashboard url %s", i.DashboardURL)
+	}
+
+	parts := strings.Split(parsed.Host, ".")
+	if len(parts) <= 1 {
+		return "", "", fmt.Errorf("host is too short: %s", parsed.Host)
+	}
+	return parts[1], parsed.Host[len(parts[0])+1:], nil
 }
 
 // OperationType defines the possible types of an asynchronous operation to a broker.
@@ -357,6 +390,10 @@ func NewProvisioningOperationWithID(operationID, instanceID string, parameters P
 
 // NewDeprovisioningOperationWithID creates a fresh (just starting) instance of the DeprovisioningOperation with provided ID
 func NewDeprovisioningOperationWithID(operationID string, instance *Instance) (DeprovisioningOperation, error) {
+	details, err := instance.GetInstanceDetails()
+	if err != nil {
+		return DeprovisioningOperation{}, err
+	}
 	return DeprovisioningOperation{
 		Operation: Operation{
 			ID:              operationID,
@@ -367,7 +404,7 @@ func NewDeprovisioningOperationWithID(operationID string, instance *Instance) (D
 			CreatedAt:       time.Now(),
 			UpdatedAt:       time.Now(),
 			Type:            OperationTypeDeprovision,
-			InstanceDetails: instance.InstanceDetails,
+			InstanceDetails: details,
 			FinishedSteps:   make(map[string]struct{}, 0),
 		},
 	}, nil

--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
@@ -115,10 +115,14 @@ func (s *InitialisationStep) run(operation internal.DeprovisioningOperation, log
 	switch {
 	case err == nil:
 		if operation.State == orchestration.Pending {
+			details, err := instance.GetInstanceDetails()
+			if err != nil {
+				return s.operationManager.OperationFailed(operation, "unable to provide instance details", log)
+			}
 			log.Info("Setting state 'in progress' and refreshing instance details")
 			operation, retry := s.operationManager.UpdateOperation(operation, func(operation *internal.DeprovisioningOperation) {
 				operation.State = domain.InProgress
-				operation.InstanceDetails = instance.InstanceDetails
+				operation.InstanceDetails = details
 			}, log)
 			if retry > 0 {
 				return operation, retry, nil

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go
@@ -58,12 +58,13 @@ func (s *CreateRuntimeStep) Run(operation internal.ProvisioningOperation, log lo
 
 	var provisionerResponse gqlschema.OperationStatus
 	if operation.ProvisionerOperationID == "" {
-		log.Infof("call ProvisionRuntime: kymaVersion=%s, kubernetesVersion=%s, region=%s, kymaProfile=%s, provider=%s",
+		log.Infof("call ProvisionRuntime: kymaVersion=%s, kubernetesVersion=%s, region=%s, kymaProfile=%s, provider=%s, name=%s",
 			requestInput.KymaConfig.Version,
 			requestInput.ClusterConfig.GardenerConfig.KubernetesVersion,
 			requestInput.ClusterConfig.GardenerConfig.Region,
 			requestInput.KymaConfig.Profile,
-			requestInput.ClusterConfig.GardenerConfig.Provider)
+			requestInput.ClusterConfig.GardenerConfig.Provider,
+			requestInput.ClusterConfig.GardenerConfig.Name)
 
 		provisionerResponse, err := s.provisionerClient.ProvisionRuntime(operation.ProvisioningParameters.ErsContext.GlobalAccountID, operation.ProvisioningParameters.ErsContext.SubAccountID, requestInput)
 		switch {

--- a/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/initialisation.go
@@ -128,7 +128,11 @@ func (s *InitialisationStep) Run(operation internal.ProvisioningOperation, log l
 				return operation, time.Second, nil
 			}
 			log.Infof("Setting the newest InstanceDetails")
-			operation.InstanceDetails = inst.InstanceDetails
+			operation.InstanceDetails, err = inst.GetInstanceDetails()
+			if err != nil {
+				log.Errorf("Unable to provide Instance details: %s", err.Error())
+				return s.operationManager.OperationFailed(operation, "Unable to provide Instance details.", log)
+			}
 		}
 		log.Infof("Setting the operation to 'InProgress'")
 		operation.State = domain.InProgress

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-646"
     kyma_environment_broker:
       dir:
-      version: "PR-612"
+      version: "PR-687"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- old instances does not have shootName saved (and shootDomain) and there is a logic which takes it from dashboardURL. Unfortunately, this logic is not executed in every instance details copying. This PR is fixing it

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
