### PR TITLE
Remove AWS us-west-1b Availability Zone

### DIFF
--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -65,7 +65,7 @@ var awsZones = map[string]string{
 	"ca-central-1":   "abd",
 	"sa-east-1":      "abc",
 	"us-east-1":      "abcdef",
-	"us-west-1":      "abc",
+	"us-west-1":      "ac",
 	"ap-northeast-1": "acd",
 	"ap-northeast-2": "abcd",
 	"ap-south-1":     "ab",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Remove AWS us-west-1b availability zone as you can't create VPC subnets in it and it breaks Gardener provisioning

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Internal 1467