### PR TITLE
add AWSPlanID for metrics

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/operations_collector.go
+++ b/components/kyma-environment-broker/internal/metrics/operations_collector.go
@@ -20,7 +20,7 @@ import (
 // - compass_keb_operations_{plan_name}_deprovisioning_succeeded_total
 
 var (
-	supportedPlansIDs = []string{broker.AzurePlanID, broker.AzureLitePlanID, broker.TrialPlanID}
+	supportedPlansIDs = []string{broker.AzurePlanID, broker.AzureLitePlanID, broker.TrialPlanID, broker.AWSPlanID}
 )
 
 type OperationsStatsGetter interface {


### PR DESCRIPTION
Try to implement the[ [kcp grafana] add planID label for AWS provisioning/deprovisioning metrics in kcp](https://github.tools.sap/kyma/backlog/issues/1475)