### PR TITLE
Set cloud provider type in AVS evaluation names correctly

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-697"
     kyma_environment_broker:
       dir:
-      version: "PR-660"
+      version: "PR-713"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
**Description**

The AVS evaluation names have to reflect the correct cloud provider type correctly:

- for Azure it should be AZR
- for AWS it's AWS

Added shoot name to the AVS evaluation description.
 
