### PR TITLE
Fix Installation status checking while provisioning a Runtime

### DIFF
--- a/components/provisioner/go.sum
+++ b/components/provisioner/go.sum
@@ -613,6 +613,8 @@ github.com/kyma-incubator/compass/components/director v0.0.0-20200813093525-96b1
 github.com/kyma-incubator/compass/components/director v0.0.0-20200813093525-96b1a733a11b/go.mod h1:mXQbZvsoQH+zJB8ywkFIqtG2Rp8Lt7bhwIzKPRRnlNA=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210218125820-f7a76ec2075a h1:pBFrUyRtOjD1JlGdhF83VwQVeVtVho6HNqUobKkR3mw=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210218125820-f7a76ec2075a/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
+github.com/kyma-incubator/hydroform/install v0.0.0-20210423204324-77f0d2c745ab h1:S99b/U+K+sqnCAa3HcRsstwDEJay9fezeI6nKPMkI38=
+github.com/kyma-incubator/hydroform/install v0.0.0-20210423204324-77f0d2c745ab/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20200818080816-8c81ea09adc7/go.mod h1:LUlTpeBF6hz7DyOtROez1IjluZOrFFgJH9vx8/me5p8=
 github.com/kyma-project/kyma/components/compass-runtime-agent v0.0.0-20200902131640-31c29c8feb0c h1:ojgMJoX7H9KVe9KM5IrSE3uPQxsihL5eeC9iVeUF7e0=
 github.com/kyma-project/kyma/components/compass-runtime-agent v0.0.0-20200902131640-31c29c8feb0c/go.mod h1:aR7hDBCzR0sN0tEF6+RnwsvAM/FYlBR+tYxZs0BmmvA=

--- a/components/provisioner/internal/installation/installation.go
+++ b/components/provisioner/internal/installation/installation.go
@@ -90,8 +90,7 @@ func (s *installationService) triggerAction(
 		Configuration: NewInstallationConfiguration(globalConfig, componentsConfig),
 	}
 
-	err := prepareFunction(installationConfig)
-	if err != nil {
+	if err := prepareFunction(installationConfig); err != nil {
 		return pkgErrors.Wrap(err, fmt.Sprintf("Failed to prepare %s", actionName))
 	}
 
@@ -99,8 +98,7 @@ func (s *installationService) triggerAction(
 	defer cancel()
 
 	// We are not waiting for events, just triggering installation
-	_, _, err = installer.StartInstallation(installationCtx)
-	if err != nil {
+	if _, _, err := installer.StartInstallation(installationCtx); err != nil {
 		return pkgErrors.Wrap(err, fmt.Sprintf("Failed to start Kyma %s", actionName))
 	}
 

--- a/components/provisioner/internal/operations/stages/provisioning/install_kyma.go
+++ b/components/provisioner/internal/operations/stages/provisioning/install_kyma.go
@@ -57,8 +57,6 @@ func (s *InstallKymaStep) Run(cluster model.Cluster, _ model.Operation, logger l
 		return operations.StageResult{}, fmt.Errorf("error: failed to check installation state: %s", err.Error())
 	}
 
-	// TODO: Check if running installationClient.TriggerInstallation() when it was already triggered
-	//       won't break anything. Previously, it failed while running kymaInstaller.PrepareInstallation()
 	if installationState.State != installationSDK.NoInstallationState && installationState.State != string(v1alpha1.StateEmpty) {
 		logger.Warnf("Installation already in progress, proceeding to next step...")
 		return operations.StageResult{Stage: s.nextStep, Delay: 0}, nil

--- a/components/provisioner/internal/operations/stages/provisioning/install_kyma_test.go
+++ b/components/provisioner/internal/operations/stages/provisioning/install_kyma_test.go
@@ -79,7 +79,7 @@ func TestInstallKymaStep_Run(t *testing.T) {
 			},
 		},
 		{
-			description: "should proceed to the next step after starting the installation",
+			description: "should proceed to the next step after starting the installation when installer has an empty state",
 			mockFunc: func(installationSvc *installationMocks.Service) {
 				installationSvc.On("CheckInstallationState", k8sConfig).
 					Return(installation.InstallationState{State: ""}, nil)

--- a/components/provisioner/internal/operations/stages/provisioning/install_kyma_test.go
+++ b/components/provisioner/internal/operations/stages/provisioning/install_kyma_test.go
@@ -82,6 +82,15 @@ func TestInstallKymaStep_Run(t *testing.T) {
 			description: "should proceed to the next step after starting the installation",
 			mockFunc: func(installationSvc *installationMocks.Service) {
 				installationSvc.On("CheckInstallationState", k8sConfig).
+					Return(installation.InstallationState{State: ""}, nil)
+				installationSvc.On("TriggerInstallation", k8sConfig, mock.MatchedBy(getProfileMatcher(cluster.KymaConfig.Profile)), release, globalConfig, components).
+					Return(nil)
+			},
+		},
+		{
+			description: "should proceed to the next step after starting the installation",
+			mockFunc: func(installationSvc *installationMocks.Service) {
+				installationSvc.On("CheckInstallationState", k8sConfig).
 					Return(installation.InstallationState{State: installation.NoInstallationState}, nil)
 				installationSvc.On("TriggerInstallation", k8sConfig, mock.MatchedBy(getProfileMatcher(cluster.KymaConfig.Profile)), release, globalConfig, components).
 					Return(nil)

--- a/components/provisioner/internal/operations/stages/provisioning/wait_for_installation.go
+++ b/components/provisioner/internal/operations/stages/provisioning/wait_for_installation.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kyma-project/control-plane/components/provisioner/internal/provisioning/persistence/dbsession"
-
 	installationSDK "github.com/kyma-incubator/hydroform/install/installation"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/model"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/operations"
+	"github.com/kyma-project/control-plane/components/provisioner/internal/provisioning/persistence/dbsession"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/util/k8s"
+	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
 	"github.com/sirupsen/logrus"
 )
 
@@ -63,7 +63,7 @@ func (s *WaitForInstallationStep) Run(cluster model.Cluster, operation model.Ope
 		return operations.StageResult{}, fmt.Errorf("error: failed to check installation state: %s", err.Error())
 	}
 
-	if installationState.State == "Installed" {
+	if installationState.State == string(v1alpha1.StateInstalled) {
 		message := fmt.Sprintf("Installation completed: %s", installationState.Description)
 		logger.Info(message)
 		s.saveInstallationState(message, logger, operation)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -9,7 +9,7 @@ global:
       version: "PR-639"
     provisioner:
       dir:
-      version: "PR-697"
+      version: "PR-715"
     kyma_environment_broker:
       dir:
       version: "PR-660"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix Installation status checking while provisioning a Runtime

I analyzed many cases that end up with installation timeout. All of them consist of such Provisioner's logs:

`log:time="123" level=error msg="error while processing operation, stage failed: error: failed to start installation: Failed to prepare installation: failed to create configuration secrets: failed to apply somesecret secret: Post \"https://host.com/api/v1/namespaces/kyma-installer/secrets\": unexpected EOF" Component=Executor OperationId=123 OperationType=PROVISION RuntimeId=123 ShootName=qwe Stage=StartingInstallation`
>First attempt of proceeding the `StartingInstallation` step ends with the error. Applying the configuration failed and there is no `action=label` present. But Installer is already deployed

`log:time="125" level=warning msg="Installation already in progress, proceeding to next step..." Component=Executor OperationId=123 OperationType=PROVISION RuntimeId=123 ShootName=qwe Stage=StartingInstallation`
>Second attempt ends up with proceeding to the next step without retriggering the previously failed installation process nor labeling the Installer with `action=install` label

`log:time="126" level=info msg="Installation in progress: " Component=Executor OperationId=123 OperationType=PROVISION RuntimeId=123 ShootName=qwe Stage=WaitingForInstallation`
>Provisioning fails with timeout while waiting for the installation having empty description

I found that the kyma-installation status is empty in such cases. It's not in progress, it hasn't been triggered:
```yaml
status:
  description: ""
  state: ""
```

I assume that [here](https://github.com/kyma-project/control-plane/blob/main/components/provisioner/internal/operations/stages/provisioning/install_kyma.go#L59-L62) we should also check if it's not in the `StateEmpty` and retrigger the installation if so