### PR TITLE
Recreate AVS evaluations during unsuspension

### DIFF
--- a/components/kyma-environment-broker/internal/avs/delegator.go
+++ b/components/kyma-environment-broker/internal/avs/delegator.go
@@ -39,7 +39,7 @@ func (del *Delegator) CreateEvaluation(log logrus.FieldLogger, operation interna
 	var updatedOperation internal.ProvisioningOperation
 	d := 0 * time.Second
 
-	if evalAssistant.IsAlreadyCreated(operation.Avs) {
+	if evalAssistant.IsValid(operation.Avs) {
 		log.Infof("step has already been finished previously")
 		updatedOperation = operation
 	} else {
@@ -65,6 +65,7 @@ func (del *Delegator) CreateEvaluation(log logrus.FieldLogger, operation interna
 		}
 		updatedOperation, d = del.provisionManager.UpdateOperation(operation, func(operation *internal.ProvisioningOperation) {
 			evalAssistant.SetEvalId(&operation.Avs, evalResp.Id)
+			evalAssistant.SetDeleted(&operation.Avs, false)
 		}, log)
 	}
 
@@ -190,7 +191,7 @@ func (del *Delegator) DeleteAvsEvaluation(deProvisioningOperation internal.Depro
 		return deProvisioningOperation, err
 	}
 
-	assistant.markDeleted(&deProvisioningOperation.Avs)
+	assistant.SetDeleted(&deProvisioningOperation.Avs, true)
 
 	updatedDeProvisioningOp, err := del.operationsStorage.UpdateDeprovisioningOperation(deProvisioningOperation)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/avs/eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/eval_assistant.go
@@ -19,7 +19,7 @@ type EvalAssistant interface {
 	IsAlreadyDeleted(lifecycleData internal.AvsLifecycleData) bool
 	GetEvaluationId(lifecycleData internal.AvsLifecycleData) int64
 	ProvideParentId(pp internal.ProvisioningParameters) int64
-	markDeleted(lifecycleData *internal.AvsLifecycleData)
+	SetDeleted(lifecycleData *internal.AvsLifecycleData, deleted bool)
 	provideRetryConfig() *RetryConfig
 }
 

--- a/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/external_eval_assistant.go
@@ -99,8 +99,8 @@ func (eea *ExternalEvalAssistant) GetEvaluationId(lifecycleData internal.AvsLife
 	return lifecycleData.AVSEvaluationExternalId
 }
 
-func (eea *ExternalEvalAssistant) markDeleted(lifecycleData *internal.AvsLifecycleData) {
-	lifecycleData.AVSExternalEvaluationDeleted = true
+func (eea *ExternalEvalAssistant) SetDeleted(lifecycleData *internal.AvsLifecycleData, deleted bool) {
+	lifecycleData.AVSExternalEvaluationDeleted = deleted
 }
 
 func (eea *ExternalEvalAssistant) provideRetryConfig() *RetryConfig {

--- a/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
@@ -130,8 +130,8 @@ func (iec *InternalEvalAssistant) GetEvaluationId(lifecycleData internal.AvsLife
 	return lifecycleData.AvsEvaluationInternalId
 }
 
-func (iec *InternalEvalAssistant) markDeleted(lifecycleData *internal.AvsLifecycleData) {
-	lifecycleData.AVSInternalEvaluationDeleted = true
+func (iec *InternalEvalAssistant) SetDeleted(lifecycleData *internal.AvsLifecycleData, deleted bool) {
+	lifecycleData.AVSInternalEvaluationDeleted = deleted
 }
 
 func (iec *InternalEvalAssistant) provideRetryConfig() *RetryConfig {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-697"
     kyma_environment_broker:
       dir:
-      version: "PR-713"
+      version: "PR-716"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-627"


### PR DESCRIPTION
**Description**

During unsuspension the AVS evaluation for the Kyma runtime is not recreated, as the previous AVS lifecycle data is kept and the code does not check correctly whether it should recreate the evaluation or not.
