### PR TITLE
Fix e2e provisioning test

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests/e2e-provisioning-azure.yaml
@@ -40,6 +40,8 @@ spec:
               value: "false"
             - name: APP_CLEANUP_PHASE
               value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
             - name: APP_BROKER_PLAN_ID
               value: "{{ .Values.e2e.azure.planID }}"
             - name: APP_BROKER_CLIENT_NAME


### PR DESCRIPTION
**Description**

Fix e2e provisioning test by adding APP_BROKER_URL env to the `e2e-azure` test.
