### PR TITLE
Expose upgrade cluster operation results in metrics

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/metrics.go
+++ b/components/kyma-environment-broker/internal/metrics/metrics.go
@@ -16,7 +16,8 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 
 	sub.Subscribe(process.ProvisioningStepProcessed{}, opResultCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opResultCollector.OnDeprovisioningStepProcessed)
-	sub.Subscribe(process.UpgradeKymaStepProcessed{}, opResultCollector.OnUpgradeStepProcessed)
+	sub.Subscribe(process.UpgradeKymaStepProcessed{}, opResultCollector.OnUpgradeKymaStepProcessed)
+	sub.Subscribe(process.UpgradeClusterStepProcessed{}, opResultCollector.OnUpgradeClusterStepProcessed)
 	sub.Subscribe(process.ProvisioningStepProcessed{}, opDurationCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opDurationCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.ProvisioningStepProcessed{}, stepResultCollector.OnProvisioningStepProcessed)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-715"
     kyma_environment_broker:
       dir:
-      version: "PR-701"
+      version: "PR-726"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Rename `compass_keb_upgrade_result` metric to `compass_keb_upgrade_kyma_result`  ⚠️Will require adjustment in all uses, e.g. in `PrometheusRules` ⚠️
- Expose upgrade cluster operation states when processed in  `compass_keb_upgrade_cluster_result` metric

