### PR TITLE
Distinguish recoverable vs. unrecoverable Kyma installation errors

### DIFF
--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/gorilla/mux v1.7.4
 	github.com/kubernetes-sigs/service-catalog v0.3.0
 	github.com/kyma-incubator/compass/components/director v0.0.0-20200813093525-96b1a733a11b
-	github.com/kyma-incubator/hydroform/install v0.0.0-20210423204324-77f0d2c745ab
+	github.com/kyma-incubator/hydroform/install v0.0.0-20210514061348-c71b69cb362e
 	github.com/kyma-project/kyma/components/compass-runtime-agent v0.0.0-20200902131640-31c29c8feb0c
 	github.com/kyma-project/kyma/components/kyma-operator v0.0.0-20201117100007-62918ff463e5
 	github.com/lib/pq v1.7.0

--- a/components/provisioner/go.sum
+++ b/components/provisioner/go.sum
@@ -615,6 +615,8 @@ github.com/kyma-incubator/hydroform/install v0.0.0-20210218125820-f7a76ec2075a h
 github.com/kyma-incubator/hydroform/install v0.0.0-20210218125820-f7a76ec2075a/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210423204324-77f0d2c745ab h1:S99b/U+K+sqnCAa3HcRsstwDEJay9fezeI6nKPMkI38=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210423204324-77f0d2c745ab/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
+github.com/kyma-incubator/hydroform/install v0.0.0-20210514061348-c71b69cb362e h1:4C94RY8f40Qg6W13MAuOcgWY2DGnA9aIuCVHkwxmHo8=
+github.com/kyma-incubator/hydroform/install v0.0.0-20210514061348-c71b69cb362e/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20200818080816-8c81ea09adc7/go.mod h1:LUlTpeBF6hz7DyOtROez1IjluZOrFFgJH9vx8/me5p8=
 github.com/kyma-project/kyma/components/compass-runtime-agent v0.0.0-20200902131640-31c29c8feb0c h1:ojgMJoX7H9KVe9KM5IrSE3uPQxsihL5eeC9iVeUF7e0=
 github.com/kyma-project/kyma/components/compass-runtime-agent v0.0.0-20200902131640-31c29c8feb0c/go.mod h1:aR7hDBCzR0sN0tEF6+RnwsvAM/FYlBR+tYxZs0BmmvA=

--- a/components/provisioner/internal/operations/stages/provisioning/wait_for_installation.go
+++ b/components/provisioner/internal/operations/stages/provisioning/wait_for_installation.go
@@ -57,7 +57,11 @@ func (s *WaitForInstallationStep) Run(cluster model.Cluster, operation model.Ope
 			message := fmt.Sprintf("Installation error occurred: %s", installErr.Error())
 			logger.Warn(message)
 			s.saveInstallationState(message, logger, operation)
-			return operations.StageResult{Stage: s.Name(), Delay: 30 * time.Second}, nil
+			if installErr.Recoverable {
+				return operations.StageResult{Stage: s.Name(), Delay: 30 * time.Second}, nil
+			}
+
+			return operations.StageResult{}, operations.NewNonRecoverableError(err)
 		}
 
 		return operations.StageResult{}, fmt.Errorf("error: failed to check installation state: %s", err.Error())

--- a/components/provisioner/internal/operations/stages/upgrade/upgrade_kyma.go
+++ b/components/provisioner/internal/operations/stages/upgrade/upgrade_kyma.go
@@ -50,18 +50,23 @@ func (s *UpgradeKymaStep) Run(cluster model.Cluster, _ model.Operation, logger l
 	if err != nil {
 		installErr := installationSDK.InstallationError{}
 		if errors.As(err, &installErr) {
-			logger.Warnf("Upgrade already in progress, proceeding to next step...")
-			return operations.StageResult{Stage: s.nextStep, Delay: 30 * time.Second}, nil
-		}
+			if installErr.Recoverable {
+				logger.Warnf("Upgrade already in progress, proceeding to next step...")
+				return operations.StageResult{Stage: s.nextStep, Delay: 30 * time.Second}, nil
+			}
 
-		return operations.StageResult{}, fmt.Errorf("error: failed to check installation CR state: %s", err.Error())
+			logger.Warnf("Installation is in unrecoverable error state, triggering the upgrade ...")
+			installationState.State = "Error"
+		} else {
+			return operations.StageResult{}, fmt.Errorf("error: failed to check installation CR state: %s", err.Error())
+		}
 	}
 
 	if installationState.State == installationSDK.NoInstallationState {
 		return operations.StageResult{}, operations.NewNonRecoverableError(fmt.Errorf("error: Installation CR not found in the cluster, cannot trigger upgrade"))
 	}
 
-	if installationState.State == "Installed" {
+	if installationState.State == "Installed" || installationState.State == "Error" {
 		err = s.installationClient.TriggerUpgrade(
 			k8sConfig,
 			cluster.KymaConfig.Profile,

--- a/components/provisioner/internal/operations/stages/upgrade/upgrade_kyma_test.go
+++ b/components/provisioner/internal/operations/stages/upgrade/upgrade_kyma_test.go
@@ -99,7 +99,25 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 	t.Run("should return next step when upgrade already in progress", func(t *testing.T) {
 		//given
 		installationClient := &installationMocks.Service{}
-		installationClient.On("CheckInstallationState", mock.Anything).Return(installation.InstallationState{}, installation.InstallationError{ShortMessage: "upgrade in progress"})
+		installationClient.On("CheckInstallationState", mock.Anything).Return(installation.InstallationState{}, installation.InstallationError{ShortMessage: "upgrade in progress", Recoverable: true})
+
+		upgradeStep := NewUpgradeKymaStep(installationClient, nextStageName, 0)
+
+		cluster := model.Cluster{Kubeconfig: util.StringPtr(kubeconfig)}
+
+		//when
+		result, err := upgradeStep.Run(cluster, model.Operation{}, logrus.New())
+
+		//then
+		require.NoError(t, err)
+		assert.Equal(t, nextStageName, result.Stage)
+	})
+
+	t.Run("should trigger upgrade when installation is in unrecoverable error state", func(t *testing.T) {
+		//given
+		installationClient := &installationMocks.Service{}
+		installationClient.On("CheckInstallationState", mock.Anything).Return(installation.InstallationState{}, installation.InstallationError{ShortMessage: "error", Recoverable: false})
+		installationClient.On("TriggerUpgrade", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 		upgradeStep := NewUpgradeKymaStep(installationClient, nextStageName, 0)
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -9,7 +9,7 @@ global:
       version: "PR-639"
     provisioner:
       dir:
-      version: "PR-715"
+      version: "PR-730"
     kyma_environment_broker:
       dir:
       version: "PR-726"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Stop waiting for Kyma installation (step used both during provisioning and upgrade) when unrecoverable error is detected, and fail the operation
- Allow triggering Kyma upgrade when the current installation state is unrecoverable (terminal) error.
