### PR TITLE
Update codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,22 +5,22 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of the `control-plane` repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @PK85 @crabtree @kfurgol @tgorgol @kjaksik @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa @piotrmiskiewicz @polskikiel @ksputo @jasiu001
+* @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa @piotrmiskiewicz @ksputo @jasiu001
 
 # All developers working on this repository are able to edit main values.yaml file.
-/resources/kcp/values.yaml @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @kjaksik @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa @k15r @marcobebway @nachtmaar @radufa @sayanh @themue
+/resources/kcp/values.yaml @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @ksputo @jasiu001 @koala7659 @rafalpotempa @k15r @marcobebway @nachtmaar @radufa @sayanh @themue
 
 # All developers working on this repository are able to edit scripts directory.
-/scripts @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @kjaksik @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
+/scripts @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @ksputo @jasiu001 @koala7659 @rafalpotempa
 
 # Registration job is used by provisioner and kyma-environment-broker
-/resources/kcp/templates/registration-job.yaml @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @kjaksik @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @koala7659 @rafalpotempa
+/resources/kcp/templates/registration-job.yaml @PK85 @crabtree @kfurgol @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @ksputo @jasiu001 @koala7659 @rafalpotempa
 
 # Kyma Environment Broker
-/resources/kcp/charts/kyma-environment-broker @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
-/components/kyma-environment-broker @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
-/docs/kyma-environment-broker @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
-/components/schema-migrator/migrations/kyma-environment-broker @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
+/resources/kcp/charts/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @jasiu001 @crabtree
+/components/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @jasiu001 @crabtree
+/docs/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @jasiu001 @crabtree
+/components/schema-migrator/migrations/kyma-environment-broker @PK85 @piotrmiskiewicz  @ksputo @jasiu001 @crabtree
 
 # Runtime Provisioner
 /resources/kcp/charts/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
@@ -31,7 +31,7 @@
 
 
 # e2e-provisioning
-/tests/e2e/provisioning @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
+/tests/e2e/provisioning @PK85 @piotrmiskiewicz @ksputo @jasiu001 @crabtree
 
 # Kyma metrics collector
 /resources/kcp/charts/kyma-metrics-collector @k15r @lilitgh @marcobebway @nachtmaar @radufa @sayanh @themue
@@ -42,10 +42,10 @@
 /resources/oidc-kubeconfig-service @piotrmsc @kubadz @strekm @jakkab @Tomasz-Smelcerz-SAP @Demonsthere @colunira
 
 # KCP CLI
-/tools/cli @ebensom @fhivemind @lauraanddola @life0215 @lumi017 @PK85 @piotrmiskiewicz @polskikiel @ksputo @jasiu001 @crabtree @kjaksik
+/tools/cli @ebensom @fhivemind @lauraanddola @life0215 @lumi017 @PK85 @piotrmiskiewicz @ksputo @jasiu001 @crabtree
 
 # All .md files
-*.md @klaudiagrz @kazydek @mmitoraj @majakurcius @alexandra-simeonova @superojla
+*.md @klaudiagrz @kazydek @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @aerfio @pPrecel @magicmatatjahu


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Recently, Karol Jaksik, Michał Kempski, and Justyna Sztyper left the company. According to the [offboarding guidelines](https://kyma-project.io/community/governance#kyma-working-model-kyma-working-model-when-does-a-maintainer-lose-the-maintainer-status), a person should be removed from codeowners in case they are no longer interested in contributing or haven't contributed to the project for more than 3 months. Also, Nina Hingerl went through the probationary period and thus should be added to codeowners.

Changes proposed in this pull request:
- Remove `kjaksik` from codeowners
- Remove `polskikiel` from codeowners
- Remove `superojla` from codeowners
- Add `NHingerl` to codeowners

**Related issue(s)**
https://github.tools.sap/kyma/community/issues/80
https://github.tools.sap/kyma/community/issues/88