### PR TITLE
Return NotFound on KEB instance updates when instance is missing

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-730"
     kyma_environment_broker:
       dir:
-      version: "PR-739"
+      version: "PR-736"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
**Description**

Changes proposed in this pull request:

- KEB returns 5xx error on instance update method when instance is not found in db. This proposes a simple change to return 404 instead.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/orgs/kyma-project/projects/10#card-60954090