### PR TITLE
Return NotFound on KEB instance get when instance is missing

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -306,7 +306,7 @@ func main() {
 		broker.NewProvision(cfg.Broker, cfg.Gardener, db.Operations(), db.Instances(), provisionQueue, inputFactory, defaultPlansConfig, cfg.EnableOnDemandVersion, logs),
 		broker.NewDeprovision(db.Instances(), db.Operations(), deprovisionQueue, logs),
 		broker.NewUpdate(db.Instances(), db.Operations(), suspensionCtxHandler, cfg.UpdateProcessingEnabled, logs),
-		broker.NewGetInstance(db.Instances(), logs),
+		broker.NewGetInstance(db.Instances(), db.Operations(), logs),
 		broker.NewLastOperation(db.Operations(), logs),
 		broker.NewBind(logs),
 		broker.NewUnbind(logs),

--- a/components/kyma-environment-broker/internal/broker/instance_get_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_get_test.go
@@ -1,0 +1,26 @@
+package broker
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetEndpoint_GetNonExistingInstance(t *testing.T) {
+	// given
+	st := storage.NewMemoryStorage()
+	svc := NewGetInstance(st.Instances(), logrus.New())
+
+	// when
+	_, err := svc.GetInstance(context.Background(), instanceID)
+
+	// then
+	assert.IsType(t, err, &apiresponses.FailureResponse{}, "Get returned error of unexpected type")
+	apierr := err.(*apiresponses.FailureResponse)
+	assert.Equal(t, apierr.ValidatedStatusCode(nil), http.StatusNotFound, "Get status code not matching")
+}

--- a/components/kyma-environment-broker/internal/broker/instance_get_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_get_test.go
@@ -1,20 +1,27 @@
-package broker
+package broker_test
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/gardener"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker/automock"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/pivotal-cf/brokerapi/v7/domain"
 	"github.com/pivotal-cf/brokerapi/v7/domain/apiresponses"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestGetEndpoint_GetNonExistingInstance(t *testing.T) {
 	// given
 	st := storage.NewMemoryStorage()
-	svc := NewGetInstance(st.Instances(), logrus.New())
+	svc := broker.NewGetInstance(st.Instances(), st.Operations(), logrus.New())
 
 	// when
 	_, err := svc.GetInstance(context.Background(), instanceID)
@@ -22,5 +29,52 @@ func TestGetEndpoint_GetNonExistingInstance(t *testing.T) {
 	// then
 	assert.IsType(t, err, &apiresponses.FailureResponse{}, "Get returned error of unexpected type")
 	apierr := err.(*apiresponses.FailureResponse)
-	assert.Equal(t, apierr.ValidatedStatusCode(nil), http.StatusNotFound, "Get status code not matching")
+	assert.Equal(t, http.StatusNotFound, apierr.ValidatedStatusCode(nil), "Get status code not matching")
+}
+
+func TestGetEndpoint_GetProvisioningInstance(t *testing.T) {
+	// given
+	st := storage.NewMemoryStorage()
+	queue := &automock.Queue{}
+	queue.On("Add", mock.AnythingOfType("string"))
+
+	factoryBuilder := &automock.PlanValidator{}
+	factoryBuilder.On("IsPlanSupport", planID).Return(true)
+
+	createSvc := broker.NewProvision(
+		broker.Config{EnablePlans: []string{"gcp", "azure", "azure_ha"}, OnlySingleTrialPerGA: true},
+		gardener.Config{Project: "test", ShootDomain: "example.com"},
+		st.Operations(),
+		st.Instances(),
+		queue,
+		factoryBuilder,
+		broker.PlansConfig{},
+		false,
+		logrus.StandardLogger(),
+	)
+	getSvc := broker.NewGetInstance(st.Instances(), st.Operations(), logrus.New())
+
+	// when
+	createSvc.Provision(fixRequestContext(t, "req-region"), instanceID, domain.ProvisionDetails{
+		ServiceID:     serviceID,
+		PlanID:        planID,
+		RawParameters: json.RawMessage(fmt.Sprintf(`{"name": "%s"}`, clusterName)),
+		RawContext:    json.RawMessage(fmt.Sprintf(`{"globalaccount_id": "%s", "subaccount_id": "%s", "user_id": "%s"}`, globalAccountID, subAccountID, userID)),
+	}, true)
+
+	// then
+	_, err := getSvc.GetInstance(context.Background(), instanceID)
+	assert.IsType(t, err, &apiresponses.FailureResponse{}, "Get returned error of unexpected type")
+	apierr := err.(*apiresponses.FailureResponse)
+	assert.Equal(t, http.StatusNotFound, apierr.ValidatedStatusCode(nil), "Get status code not matching")
+	assert.Equal(t, "provisioning of instanceID d3d5dca4-5dc8-44ee-a825-755c2a3fb839 in progress", apierr.Error())
+
+	// when
+	op, _ := st.Operations().GetProvisioningOperationByInstanceID(instanceID)
+	op.State = domain.Succeeded
+	st.Operations().UpdateProvisioningOperation(*op)
+
+	// then
+	_, err = getSvc.GetInstance(context.Background(), instanceID)
+	assert.Equal(t, nil, err, "Get returned error when expected to pass")
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-771"
     kyma_environment_broker:
       dir:
-      version: "PR-755"
+      version: "PR-753"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- KEB to return 404 error on instance get method when instance is not found in db
- KEB to return 404 error when instance provisioning operation has not finished successfully

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Fixes https://github.com/kyma-project/control-plane/issues/751
Followup to https://github.com/kyma-project/control-plane/pull/736