### PR TITLE
Change alpine-kubectl image to k8s-tools

### DIFF
--- a/components/kyma-environment-broker/internal/runtime/testdata/kyma-installer-cluster.yaml
+++ b/components/kyma-environment-broker/internal/runtime/testdata/kyma-installer-cluster.yaml
@@ -155,7 +155,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: certhelper
-          image: eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff
+          image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
           command:
             - bash
             - -c

--- a/resources/kcp/templates/registration-job.yaml
+++ b/resources/kcp/templates/registration-job.yaml
@@ -48,7 +48,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: {{ template "fullname" . }}-registration
-          image: "eu.gcr.io/kyma-project/test-infra/alpine-kubectl:v20200617-32c1f3ff"
+          image: eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229
           command:
             - bash
             - -c


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` is deprecated and removed from the test-infra repo. This PR changes image `eu.gcr.io/kyma-project/test-infra/alpine-kubectl` to `eu.gcr.io/kyma-project/tpi/k8s-tools:20210504-12243229`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/3647