### PR TITLE
Bump e2e-provisioning test image

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -31,7 +31,7 @@ global:
         version: "PR-650"
       e2e_provisioning:
         dir:
-        version: "PR-745"
+        version: "PR-722"
   isLocalEnv: false
   oauth2:
     host: oauth2


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Provisioning payload was changed in #722 - there was `UserID` field added to ERSContext. `broker_client.go` was adjusted to the new flow, but the image itself wasn't bumped which results in e2e pipelines failing with error:
```
"error":"while extracting ers context: UserID parameter cannot be empty"
```

Changes proposed in this pull request:

- Bumped `e2e_provisioning_test` image version to `PR-722`

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
