### PR TITLE
Makefile for provisioner should check go mod tidy for empty response

### DIFF
--- a/components/provisioner/Makefile
+++ b/components/provisioner/Makefile
@@ -32,9 +32,9 @@ mod-verify-local:
 go-mod-check-local:
 	@echo make go-mod-check
 	go mod tidy
-	@if [ -z "$$(git status -s go.*)" ]; then \
+	@if [ -n "$$(git status -s go.*)" ]; then \
 		echo -e "${RED}✗ go mod tidy modified go.mod or go.sum files${NC}"; \
-		git status -s git status -s go.*; \
+		git status -s go.*; \
 		exit 1; \
 	fi;
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Provisioner Makefile has a small bug where it passes when `go mod tidy` results in changes and fails when `go mod tidy` has clean result

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
