### PR TITLE
Makefile for KEB should check go mod tidy for empty response

### DIFF
--- a/components/kyma-environment-broker/Makefile
+++ b/components/kyma-environment-broker/Makefile
@@ -36,7 +36,7 @@ go-mod-check: go-mod-check-local
 go-mod-check-local:
 	@echo make go-mod-check
 	go mod tidy
-	@if [ -z "$$(git status -s go.*)" ]; then \
+	@if [ -n "$$(git status -s go.*)" ]; then \
 		echo -e "${RED}✗ go mod tidy modified go.mod or go.sum files${NC}"; \
 		git status -s git status -s go.*; \
 		exit 1; \


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- KEB Makefile has a small bug where it passes when `go mod tidy` results in changes and fails when `go mod tidy` has clean result


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- similar change to https://github.com/kyma-project/control-plane/pull/772
- introduced as copy-paste error in https://github.com/kyma-project/control-plane/pull/743#discussion_r636890726