### PR TITLE
Enable OIDC authcode + PKCE flow in kubeconfig-service

### DIFF
--- a/components/kubeconfig-service/pkg/endpoints/endpoint.go
+++ b/components/kubeconfig-service/pkg/endpoints/endpoint.go
@@ -17,10 +17,7 @@ const (
 
 //EndpointClient Wrpper for Endpoints
 type EndpointClient struct {
-	gqlURL           string
-	oidcIssuerURL    string
-	oidcClientID     string
-	oidcClientSecret string
+	gqlURL string
 }
 
 //NewEndpointClient return new instance of EndpointClient

--- a/components/kubeconfig-service/pkg/env/env.go
+++ b/components/kubeconfig-service/pkg/env/env.go
@@ -16,9 +16,8 @@ type EnvConfig struct {
 	GraphqlURL string `envconfig:"default=http://127.0.0.1:3000/graphql"`
 	OIDC       struct {
 		Kubeconfig struct {
-			IssuerURL    string
-			ClientID     string
-			ClientSecret string
+			IssuerURL string
+			ClientID  string
 		}
 		IssuerURL string
 		ClientID  string

--- a/components/kubeconfig-service/pkg/transformer/kubeconfig.go
+++ b/components/kubeconfig-service/pkg/transformer/kubeconfig.go
@@ -49,6 +49,5 @@ users:
       - get-token
       - "--oidc-issuer-url={{ .OIDCIssuerURL }}"
       - "--oidc-client-id={{ .OIDCClientID }}"
-      - "--oidc-client-secret={{ .OIDCClientSecret }}"
       command: kubectl
 `

--- a/components/kubeconfig-service/pkg/transformer/transformer.go
+++ b/components/kubeconfig-service/pkg/transformer/transformer.go
@@ -11,12 +11,11 @@ import (
 
 //Client Wrapper for transformer operations
 type Client struct {
-	ContextName      string
-	CAData           string
-	ServerURL        string
-	OIDCIssuerURL    string
-	OIDCClientID     string
-	OIDCClientSecret string
+	ContextName   string
+	CAData        string
+	ServerURL     string
+	OIDCIssuerURL string
+	OIDCClientID  string
 }
 
 //NewClient Create new instance of TransformerClient
@@ -27,12 +26,11 @@ func NewClient(rawKubeCfg string) (*Client, error) {
 		return nil, err
 	}
 	return &Client{
-		ContextName:      kubeCfg.CurrentContext,
-		CAData:           kubeCfg.Clusters[0].Cluster.CertificateAuthorityData,
-		ServerURL:        kubeCfg.Clusters[0].Cluster.Server,
-		OIDCClientID:     env.Config.OIDC.Kubeconfig.ClientID,
-		OIDCClientSecret: env.Config.OIDC.Kubeconfig.ClientSecret,
-		OIDCIssuerURL:    env.Config.OIDC.Kubeconfig.IssuerURL,
+		ContextName:   kubeCfg.CurrentContext,
+		CAData:        kubeCfg.Clusters[0].Cluster.CertificateAuthorityData,
+		ServerURL:     kubeCfg.Clusters[0].Cluster.Server,
+		OIDCClientID:  env.Config.OIDC.Kubeconfig.ClientID,
+		OIDCIssuerURL: env.Config.OIDC.Kubeconfig.IssuerURL,
 	}, nil
 }
 

--- a/components/kubeconfig-service/pkg/transformer/transformer_test.go
+++ b/components/kubeconfig-service/pkg/transformer/transformer_test.go
@@ -11,7 +11,6 @@ import (
 func TestSpec(t *testing.T) {
 
 	env.Config.OIDC.Kubeconfig.ClientID = testClientID
-	env.Config.OIDC.Kubeconfig.ClientSecret = testClientSecret
 	env.Config.OIDC.Kubeconfig.IssuerURL = testIssuerURL
 
 	// Only pass t into top-level Convey calls
@@ -26,7 +25,6 @@ func TestSpec(t *testing.T) {
 				So(c.CAData, ShouldEqual, "LS0FakeFakeQo=")
 				So(c.ServerURL, ShouldEqual, "https://api.kymatest.com")
 				So(c.OIDCClientID, ShouldEqual, testClientID)
-				So(c.OIDCClientSecret, ShouldEqual, testClientSecret)
 				So(c.OIDCIssuerURL, ShouldEqual, testIssuerURL)
 			})
 		})
@@ -96,7 +94,6 @@ users:
       - get-token
       - "--oidc-issuer-url=testIssuerURL"
       - "--oidc-client-id=testClientId"
-      - "--oidc-client-secret=testClientSecret"
       command: kubectl
 `
 )

--- a/resources/oidc-kubeconfig-service/templates/deployment.yaml
+++ b/resources/oidc-kubeconfig-service/templates/deployment.yaml
@@ -45,8 +45,6 @@ spec:
               value: {{ .Values.config.oidc.kubeconfig.issuer | quote }}
             - name: OIDC_KUBECONFIG_CLIENT_ID
               value: {{ .Values.config.oidc.kubeconfig.client | quote }}
-            - name: OIDC_KUBECONFIG_CLIENT_SECRET
-              value: {{ .Values.config.oidc.kubeconfig.secret | quote }}
             - name: OIDC_ISSUER_URL
               value: {{ tpl .Values.config.oidc.issuer $ | quote }}
             - name: OIDC_CLIENT_ID

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -26,7 +26,6 @@ config:
     kubeconfig:
       issuer: https://kymatest.accounts400.ondemand.com
       client: 1234-5678-qwer
-      secret: foobar
     client: compass-ui
     issuer: https://dex.{{ .Values.global.ingress.domainName }}
     # caFile: /etc/dex-tls-cert/tls.crt

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
-  tag: "73d1e8fe"
+  tag: "PR-785"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
**Description**

With OIDC authorization code grant + PKCE flow the OIDC client secret is not needed in the generated kubeconfig of the SKR. 

