### PR TITLE
Fix compass_keb_upgrade_cluster_result metric

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -144,7 +144,7 @@ func (c *OperationResultCollector) OnUpgradeClusterStepProcessed(ctx context.Con
 	}
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
-	c.upgradeKymaResultGauge.
+	c.upgradeClusterResultGauge.
 		WithLabelValues(op.Operation.ID, op.Operation.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-771"
     kyma_environment_broker:
       dir:
-      version: "PR-776"
+      version: "PR-787"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
**Description**
 Cluster upgrade operation result is wrongly exposed as compass_keb_upgrade_kyma_result metric.

