### PR TITLE
Remove m4 machine type support

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -249,7 +249,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AWSSchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "m4.16xlarge"}),
+			provisioningRawSchema: AWSSchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"}),
 		},
 		GCPPlanID: {
 			PlanDefinition: domain.ServicePlan{

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -23,7 +23,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:         "AWS schema is correct",
 			generator:    AWSSchema,
-			machineTypes: []string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "m4.16xlarge"},
+			machineTypes: []string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
 			file:         "aws-schema.json",
 		},
 		{

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-schema.json
@@ -15,7 +15,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m4.2xlarge", "m4.4xlarge", "m4.10xlarge", "m4.16xlarge"]
+      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",


### PR DESCRIPTION
**Description**

M4 machines should be removed as available machine types from BTP cockpit.

JFYI: M4 support was only required because the static env-page dialog of the "Enable Kyma"-button in BTP cockpit was sending a hard-coded m4 machine type to KEB. This dialog is now replaced by a fully dynamically generated HTML-form which is using the exposed JSONSchema from KEB for rendering the form-fields.

**Related issue(s)**
Reverting #669

