### PR TITLE
Don't allow unavailable nodes during trial cluster upgrades

### DIFF
--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -113,7 +113,7 @@ func awsTrialDefaults() *gqlschema.ClusterConfigInput {
 			AutoScalerMin:  1,
 			AutoScalerMax:  1,
 			MaxSurge:       1,
-			MaxUnavailable: 1,
+			MaxUnavailable: 0,
 			Purpose:        &trialPurpose,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AwsConfig: &gqlschema.AWSProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -120,7 +120,7 @@ func azureTrialDefaults() *gqlschema.ClusterConfigInput {
 			AutoScalerMin:  1,
 			AutoScalerMax:  1,
 			MaxSurge:       1,
-			MaxUnavailable: 1,
+			MaxUnavailable: 0,
 			Purpose:        &trialPurpose,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/openstack_provider.go
+++ b/components/kyma-environment-broker/internal/provider/openstack_provider.go
@@ -26,7 +26,7 @@ func (p *OpenStackInput) Defaults() *gqlschema.ClusterConfigInput {
 			AutoScalerMin:  2,
 			AutoScalerMax:  4,
 			MaxSurge:       4,
-			MaxUnavailable: 1,
+			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				OpenStackConfig: &gqlschema.OpenStackProviderConfigInput{
 					Zones:                ZonesForOpenStack(DefaultOpenStackRegion),

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-769"
     kyma_environment_broker:
       dir:
-      version: "PR-556"
+      version: "PR-801"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"

--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -51,6 +51,7 @@ type GlobalOptionsKey struct {
 	gardenerKubeconfig string
 	gardenerNamespace  string
 	username           string
+	accessToken        string
 }
 
 // GlobalOpts is the convenience object for storing the fixed global conifguration (parameter) keys
@@ -61,7 +62,7 @@ var GlobalOpts = GlobalOptionsKey{
 	kubeconfigAPIURL:   "kubeconfig-api-url",
 	gardenerKubeconfig: "gardener-kubeconfig",
 	gardenerNamespace:  "gardener-namespace",
-	username:           "username",
+	accessToken:        "accessToken",
 }
 
 // SetGlobalOpts configures the global parameters on the given root command
@@ -84,7 +85,6 @@ func SetGlobalOpts(cmd *cobra.Command) {
 	cmd.PersistentFlags().String(GlobalOpts.gardenerNamespace, "", "Gardener Namespace (project) to use. Can also be set using the KCP_GARDENER_NAMESPACE environment variable.")
 	viper.BindPFlag(GlobalOpts.gardenerNamespace, cmd.PersistentFlags().Lookup(GlobalOpts.gardenerNamespace))
 
-	viper.BindEnv(GlobalOpts.username)
 }
 
 // ValidateGlobalOpts checks the presence of the required global configuration parameters

--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -51,7 +51,6 @@ type GlobalOptionsKey struct {
 	gardenerKubeconfig string
 	gardenerNamespace  string
 	username           string
-	accessToken        string
 }
 
 // GlobalOpts is the convenience object for storing the fixed global conifguration (parameter) keys
@@ -62,7 +61,7 @@ var GlobalOpts = GlobalOptionsKey{
 	kubeconfigAPIURL:   "kubeconfig-api-url",
 	gardenerKubeconfig: "gardener-kubeconfig",
 	gardenerNamespace:  "gardener-namespace",
-	accessToken:        "accessToken",
+	username:           "username",
 }
 
 // SetGlobalOpts configures the global parameters on the given root command
@@ -85,6 +84,7 @@ func SetGlobalOpts(cmd *cobra.Command) {
 	cmd.PersistentFlags().String(GlobalOpts.gardenerNamespace, "", "Gardener Namespace (project) to use. Can also be set using the KCP_GARDENER_NAMESPACE environment variable.")
 	viper.BindPFlag(GlobalOpts.gardenerNamespace, cmd.PersistentFlags().Lookup(GlobalOpts.gardenerNamespace))
 
+	viper.BindEnv(GlobalOpts.username)
 }
 
 // ValidateGlobalOpts checks the presence of the required global configuration parameters


### PR DESCRIPTION
**Description**

The autoscaler maxUnavailable is set to 1. With this setting, Gardener starts to drain the only single worker node while the new node is being created, causing several minutes downtime for all workloads.
