### PR TITLE
Hotfix AVS eval creation step in KEB

### DIFF
--- a/components/kyma-environment-broker/internal/avs/model.go
+++ b/components/kyma-environment-broker/internal/avs/model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 )
 
 const (
@@ -120,22 +121,24 @@ func generateNameAndDescription(operation internal.ProvisioningOperation, beType
 	subAccountID := operation.ProvisioningParameters.ErsContext.SubAccountID
 	name := operation.ProvisioningParameters.Parameters.Name
 	shootName := operation.InstanceDetails.ShootName
-	beName := fmt.Sprintf("K8S-%s-Kyma-%s-%s-%s", providerCodeByPlan(operation), beType, subAccountID, name)
+	beName := fmt.Sprintf("K8S-%s-Kyma-%s-%s-%s", providerCodeByPlan(operation.ProvisioningParameters.PlanID), beType, subAccountID, name)
 	beDescription := fmt.Sprintf("SKR instance Name: %s, Global Account: %s, Subaccount: %s, Shoot: %s",
 		name, globalAccountID, subAccountID, shootName)
 
 	return truncateString(beName, 80), truncateString(beDescription, 255)
 }
 
-func providerCodeByPlan(operation internal.ProvisioningOperation) string {
-	switch operation.InputCreator.Provider() {
-	case internal.AWS:
+func providerCodeByPlan(planID string) string {
+	switch planID {
+	case broker.AWSPlanID, broker.AWSHAPlanID:
 		return "AWS"
-	case internal.GCP:
+	case broker.GCPPlanID:
 		return "GCP"
-	case internal.Azure:
+	case broker.AzurePlanID, broker.AzureLitePlanID, broker.AzureHAPlanID:
 		return "AZR"
-	case internal.Openstack:
+	case broker.TrialPlanID, broker.FreemiumPlanID:
+		return "AZR"
+	case broker.OpenStackPlanID:
 		return "CC"
 	default:
 		return "AZR"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-699"
     kyma_environment_broker:
       dir:
-      version: "PR-699"
+      version: "PR-810"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In #699 the way AVS eval description was changed to use `CloudProvider` logic which results in panic:

```
{"level":"error","msg":"panic error from process: runtime error: invalid memory address or nil pointer dereference. Stacktrace: goroutine 357 [running]:\nruntime/debug.Stack(0xc000b6fda8, 0x1bedaa0, 0x2df8ba0)\n\t/usr/local/go/src/runtime/debug/stack.go:24 +0x9f\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).worker.func1.1.1(0xc0007e4fc0, 0x2127e38, 0xc000054660, 0x1b6c2a0, 0xc000ce8110)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:82 +0x8c\npanic(0x1bedaa0, 0x2df8ba0)\n\t/usr/local/go/src/runtime/panic.go:965 +0x1b9\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs.providerCodeByPlan(0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs/model.go:131 +0x31\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs.generateNameAndDescription(0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs/model.go:123 +0xca\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs.newBasicEvaluationCreateRequest(0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs/model.go:95 +0x85\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs.(*ExternalEvalAssistant).CreateBasicEvaluationRequest(0xc00026b400, 0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs/external_eval_assistant.go:24 +0x89\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs.(*Delegator).CreateEvaluation(0xc000817760, 0x2135c10, 0xc00039cd20, 0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs/delegator.go:47 +0x34b\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning.(*ExternalEvalCreator).createEval(0xc000766ed0, 0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning/external_eval.go:30 +0x16d\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning.(*ExternalEvalStep).Run(0xc0000b6648, 0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning/external_eval_step.go:35 +0xf7\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning.(*StagedManager).runStep(0xc00037ca10, 0x20e0ca8, 0xc0000b6648, 0x6c43d1c, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go:169 +0x13d\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning.(*StagedManager).Execute(0xc00037ca10, 0xc000c64ae0, 0x24, 0xc0001ec1c0, 0xc000420850, 0x1f3a2c8)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go:122 +0x846\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).worker.func1.1(0x2127e38, 0xc000054660, 0xc0007e4fc0, 0xc000767b60, 0xc000781310, 0xc000743700)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:87 +0x1ab\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).worker.func1()\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:100 +0x86\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc0007d1f50)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc0007d1f50, 0x20cf8a0, 0xc0007d1f80, 0xc0007d1f01, 0xc0006d0960)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b\nk8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0007d1f50, 0x3b9aca00, 0x0, 0xc000767b01, 0xc0006d0960)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98\nk8s.io/apimachinery/pkg/util/wait.Until(...)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90\ngithub.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).createWorker.func1(0xc000781310, 0x2127e38, 0xc000054660, 0xc000767b60, 0x2135d00, 0xc000420850, 0xc0006d0960, 0xc000781330)\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:64 +0x94\ncreated by github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).createWorker\n\t/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:63 +0x95\n","operationID":"8c85320c-4451-4324-bbf2-89072671946a","time":"2021-06-23T12:35:34Z"}
```

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
