### PR TITLE
Support client credential login in CLI; Support multiple OIDC clients on KEB endpoints

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/oathkeeper-rule.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/oathkeeper-rule.yaml
@@ -44,7 +44,6 @@ spec:
       jwks_urls: ["{{ tpl .Values.oidc.keysURL $ }}"]
       scope_strategy: exact
       required_scope: ["{{ .Values.oidc.groups.operator }}"]
-      target_audience: ["{{ .Values.oidc.client }}"]
       trusted_issuers: ["{{ tpl .Values.oidc.issuer $ }}"]
   authorizer:
     handler: allow
@@ -67,7 +66,6 @@ spec:
       jwks_urls: ["{{ tpl .Values.oidc.keysURL $ }}"]
       scope_strategy: exact
       required_scope: ["{{ .Values.oidc.groups.admin }}"]
-      target_audience: ["{{ .Values.oidc.client }}"]
       trusted_issuers: ["{{ tpl .Values.oidc.issuer $ }}"]
   authorizer:
     handler: allow
@@ -91,7 +89,6 @@ spec:
       jwks_urls: ["{{ tpl .Values.oidc.keysURL $ }}"]
       scope_strategy: exact
       required_scope: ["{{ .Values.oidc.groups.admin }}"]
-      target_audience: ["{{ .Values.oidc.client }}"]
       trusted_issuers: ["{{ tpl .Values.oidc.issuer $ }}"]
   authorizer:
     handler: allow

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -190,7 +190,6 @@ cis:
 oidc:
   issuer: https://dex.{{ .Values.global.ingress.domainName }}
   keysURL: http://dex-service.kyma-system.svc.cluster.local:5556/keys
-  client: "kyma-env-broker"
   groups:
     admin: runtimeAdmin
     operator: runtimeOperator

--- a/tools/cli/pkg/command/login.go
+++ b/tools/cli/pkg/command/login.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/kyma-project/control-plane/tools/cli/pkg/logger"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 // LoginCommand represents an execution of the kcp login command
@@ -45,11 +46,14 @@ func (cmd *LoginCommand) Run() error {
 	} else {
 		_, err = cred.GetTokenByROPC(cmd.cobraCmd.Context(), cmd.username, cmd.password)
 	}
-
 	if err != nil {
 		return err
 	}
-	return nil
+
+	viper.Set(GlobalOpts.username, cmd.username)
+	err = viper.WriteConfig()
+
+	return err
 }
 
 // Validate checks the input parameters of the login command

--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -46,6 +46,7 @@ const (
 type GlobalOptionsKey struct {
 	oidcIssuerURL      string
 	oidcClientID       string
+	oidcClientSecret   string
 	kebAPIURL          string
 	kubeconfigAPIURL   string
 	gardenerKubeconfig string
@@ -57,6 +58,7 @@ type GlobalOptionsKey struct {
 var GlobalOpts = GlobalOptionsKey{
 	oidcIssuerURL:      "oidc-issuer-url",
 	oidcClientID:       "oidc-client-id",
+	oidcClientSecret:   "oidc-client-secret",
 	kebAPIURL:          "keb-api-url",
 	kubeconfigAPIURL:   "kubeconfig-api-url",
 	gardenerKubeconfig: "gardener-kubeconfig",
@@ -71,6 +73,9 @@ func SetGlobalOpts(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().String(GlobalOpts.oidcClientID, "", "OIDC client ID to use for login. Can also be set using the KCP_OIDC_CLIENT_ID environment variable.")
 	viper.BindPFlag(GlobalOpts.oidcClientID, cmd.PersistentFlags().Lookup(GlobalOpts.oidcClientID))
+
+	cmd.PersistentFlags().String(GlobalOpts.oidcClientSecret, "", "OIDC client secret to use for login. Can also be set using the KCP_OIDC_CLIENT_SECRET environment variable.")
+	viper.BindPFlag(GlobalOpts.oidcClientSecret, cmd.PersistentFlags().Lookup(GlobalOpts.oidcClientSecret))
 
 	cmd.PersistentFlags().String(GlobalOpts.kebAPIURL, "", "Kyma Environment Broker API URL to use for all commands. Can also be set using the KCP_KEB_API_URL environment variable.")
 	viper.BindPFlag(GlobalOpts.kebAPIURL, cmd.PersistentFlags().Lookup(GlobalOpts.kebAPIURL))
@@ -111,6 +116,11 @@ func (keys *GlobalOptionsKey) OIDCIssuerURL() string {
 // OIDCClientID gets the oidc-client-id global parameter
 func (keys *GlobalOptionsKey) OIDCClientID() string {
 	return viper.GetString(keys.oidcClientID)
+}
+
+// OIDCClientSecret gets the oidc-client-secret global parameter
+func (keys *GlobalOptionsKey) OIDCClientSecret() string {
+	return viper.GetString(keys.oidcClientSecret)
 }
 
 // KEBAPIURL gets the keb-api-url global parameter

--- a/tools/cli/pkg/command/root.go
+++ b/tools/cli/pkg/command/root.go
@@ -91,5 +91,5 @@ func initConfig() {
 
 // CLICredentialManager returns a credential.Manager configured using the CLI global options
 func CLICredentialManager(logger logger.Logger) credential.Manager {
-	return credential.NewManager(GlobalOpts.OIDCIssuerURL(), GlobalOpts.OIDCClientID(), GlobalOpts.Username(), logger)
+	return credential.NewManager(GlobalOpts.OIDCIssuerURL(), GlobalOpts.OIDCClientID(), GlobalOpts.OIDCClientSecret(), GlobalOpts.Username(), logger)
 }

--- a/tools/cli/pkg/credential/manager.go
+++ b/tools/cli/pkg/credential/manager.go
@@ -56,7 +56,7 @@ func (w *tokenWriter) Write(out credentialpluginwriter.Output) error {
 }
 
 // NewManager Constructs a new credential.Manager using the given OIDC provider and client credentials
-func NewManager(oidcIssuerURL, oidcClientID, username string, log logger.Logger) Manager {
+func NewManager(oidcIssuerURL, oidcClientID, oidcClientSecret, username string, log logger.Logger) Manager {
 	clock := &clock.Real{}
 	reader := &reader.Reader{}
 	auth := &authentication.Authentication{
@@ -85,6 +85,7 @@ func NewManager(oidcIssuerURL, oidcClientID, username string, log logger.Logger)
 		input: credentialplugin.Input{
 			IssuerURL:     oidcIssuerURL,
 			ClientID:      oidcClientID,
+			ClientSecret:  oidcClientSecret,
 			TokenCacheDir: defaultTokenCacheDir,
 		},
 	}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- KCP CLI: Support client credential login besides auth code grant + PKCE login (needed)
- KEB: Support multiple OIDC clients on KEB endpoints, don't verify OIDC client as audience in JWT.

