### PR TITLE
Add sending ServicePlan parameter to the EDP step

### DIFF
--- a/components/kyma-environment-broker/internal/edp/client.go
+++ b/components/kyma-environment-broker/internal/edp/client.go
@@ -20,6 +20,7 @@ const (
 	MaasConsumerEnvironmentKey = "maasConsumerEnvironment"
 	MaasConsumerRegionKey      = "maasConsumerRegion"
 	MaasConsumerSubAccountKey  = "maasConsumerSubAccount"
+	MaasConsumerServicePlan    = "maasConsumerServicePlan"
 
 	dataTenantTmpl     = "%s/namespaces/%s/dataTenants"
 	metadataTenantTmpl = "%s/namespaces/%s/dataTenants/%s/%s/metadata"

--- a/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration.go
@@ -39,6 +39,7 @@ func (s *EDPDeregistrationStep) Run(operation internal.DeprovisioningOperation, 
 		edp.MaasConsumerEnvironmentKey,
 		edp.MaasConsumerRegionKey,
 		edp.MaasConsumerSubAccountKey,
+		edp.MaasConsumerServicePlan,
 	} {
 		err := s.client.DeleteMetadataTenant(operation.SubAccountID, s.config.Environment, key)
 		if err != nil {

--- a/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration_test.go
@@ -20,23 +20,26 @@ const (
 func TestEDPDeregistration_Run(t *testing.T) {
 	// given
 	client := edp.NewFakeClient()
-	client.CreateDataTenant(edp.DataTenantPayload{
+	err := client.CreateDataTenant(edp.DataTenantPayload{
 		Name:        edpName,
 		Environment: edpEnvironment,
 		Secret:      base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s%s", edpName, edpEnvironment))),
 	})
+	assert.NoError(t, err)
 
 	metadataTenantKeys := []string{
 		edp.MaasConsumerEnvironmentKey,
 		edp.MaasConsumerRegionKey,
 		edp.MaasConsumerSubAccountKey,
+		edp.MaasConsumerServicePlan,
 	}
 
 	for _, key := range metadataTenantKeys {
-		client.CreateMetadataTenant(edpName, edpEnvironment, edp.MetadataTenantPayload{
+		err = client.CreateMetadataTenant(edpName, edpEnvironment, edp.MetadataTenantPayload{
 			Key:   key,
 			Value: "-",
 		})
+		assert.NoError(t, err)
 	}
 
 	step := NewEDPDeregistrationStep(client, edp.Config{

--- a/components/kyma-environment-broker/internal/process/provisioning/edp_registration.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/edp_registration.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/edp"
 	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
@@ -57,6 +58,7 @@ func (s *EDPRegistrationStep) Run(operation internal.ProvisioningOperation, log 
 		edp.MaasConsumerEnvironmentKey: s.selectEnvironmentKey(operation.ProvisioningParameters.PlatformRegion, log),
 		edp.MaasConsumerRegionKey:      operation.ProvisioningParameters.PlatformRegion,
 		edp.MaasConsumerSubAccountKey:  subAccountID,
+		edp.MaasConsumerServicePlan:    s.selectServicePlan(operation.ProvisioningParameters.PlanID),
 	} {
 		err = s.client.CreateMetadataTenant(subAccountID, s.config.Environment, edp.MetadataTenantPayload{
 			Key:   key,
@@ -101,6 +103,15 @@ func (s *EDPRegistrationStep) selectEnvironmentKey(region string, log logrus.Fie
 	default:
 		log.Warnf("region %s does not fit any of the options, default CF is used", region)
 		return "CF"
+	}
+}
+
+func (s *EDPRegistrationStep) selectServicePlan(planID string) string {
+	switch planID {
+	case broker.FreemiumPlanID:
+		return "free"
+	default:
+		return "standard"
 	}
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-699"
     kyma_environment_broker:
       dir:
-      version: "PR-811"
+      version: "PR-814"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
**Description**
EDP step, during the provisioning process, will make one extra call with a service plan name:
Call on:
```
POST /namespaces/{namespace}/dataTenants/{subAccountID}/{environment}/metadata
```
with body:
```
{
  "key": "maasConsumerServicePlan",
  "value": "standard|free" 
}
```