### PR TITLE
Bump alpine version in cloudsql proxy image

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -1,7 +1,7 @@
 global:
   defaultTenant: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae
   images:
-    cloudsql_proxy_image: gcr.io/cloudsql-docker/gce-proxy:1.23.0-alpine
+    cloudsql_proxy_image: eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.23.0-alpine-6d753005
     containerRegistry:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:


### PR DESCRIPTION
**Description**

Bump alpine version in cloudsql proxy image from `3.13.5` to `3.14.0`

