### PR TITLE
Add CORS headers to the kubeconfig endpoint

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -334,7 +334,7 @@ func main() {
 
 	// create SKR kubeconfig endpoint
 	kcBuilder := kubeconfig.NewBuilder(cfg.Kubeconfig, provisionerClient)
-	kcHandler := kubeconfig.NewHandler(db, kcBuilder, logs.WithField("service", "kubeconfigHandle"))
+	kcHandler := kubeconfig.NewHandler(db, kcBuilder, cfg.Kubeconfig.AllowOrigins, logs.WithField("service", "kubeconfigHandle"))
 	kcHandler.AttachRoutes(router)
 
 	gardenerNamespace := fmt.Sprintf("garden-%s", cfg.Gardener.Project)

--- a/components/kyma-environment-broker/internal/kubeconfig/builder.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/builder.go
@@ -12,8 +12,9 @@ import (
 )
 
 type Config struct {
-	IssuerURL string
-	ClientID  string
+	IssuerURL    string
+	ClientID     string
+	AllowOrigins string
 }
 
 type Builder struct {

--- a/components/kyma-environment-broker/internal/kubeconfig/handler_test.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/handler_test.go
@@ -157,7 +157,7 @@ func TestHandler_specifyAllowOriginHeader(t *testing.T) {
 		corsHeaderExist    bool
 		corsExpectedHeader string
 	}{
-		"one origin witch exist": {
+		"one origin which exist": {
 			requestHeader:      map[string][]string{"Origin": {"https://example.com"}},
 			origins:            "https://example.com",
 			corsHeaderExist:    true,

--- a/components/kyma-environment-broker/internal/kubeconfig/handler_test.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/handler_test.go
@@ -117,7 +117,7 @@ func TestHandler_GetKubeconfig(t *testing.T) {
 
 			router := mux.NewRouter()
 
-			handler := NewHandler(db, builder, logger.NewLogDummy())
+			handler := NewHandler(db, builder, "", logger.NewLogDummy())
 			handler.AttachRoutes(router)
 
 			server := httptest.NewServer(router)
@@ -145,6 +145,70 @@ func TestHandler_GetKubeconfig(t *testing.T) {
 				err := json.Unmarshal(body, &errorResponse)
 				require.NoError(t, err)
 				require.Equal(t, d.expectedErrorMessage, errorResponse.Error)
+			}
+		})
+	}
+}
+
+func TestHandler_specifyAllowOriginHeader(t *testing.T) {
+	cases := map[string]struct {
+		requestHeader      http.Header
+		origins            string
+		corsHeaderExist    bool
+		corsExpectedHeader string
+	}{
+		"one origin witch exist": {
+			requestHeader:      map[string][]string{"Origin": {"https://example.com"}},
+			origins:            "https://example.com",
+			corsHeaderExist:    true,
+			corsExpectedHeader: "https://example.com",
+		},
+		"many origins which one exist": {
+			requestHeader:      map[string][]string{"Origin": {"https://example.com"}},
+			origins:            "https://acme.com,https://example.com,https://eggplant.io",
+			corsHeaderExist:    true,
+			corsExpectedHeader: "https://example.com",
+		},
+		"many origins non one exist": {
+			requestHeader:   map[string][]string{"Origin": {"https://example.com"}},
+			origins:         "https://acme.com,https://gopher.com,https://eggplant.io",
+			corsHeaderExist: false,
+		},
+		"accept all origins": {
+			requestHeader:      map[string][]string{"Origin": {"https://example.com"}},
+			origins:            "*",
+			corsHeaderExist:    true,
+			corsExpectedHeader: "*",
+		},
+		"no origin header in request": {
+			requestHeader:   map[string][]string{},
+			origins:         "https://acme.com,https://example.com,https://eggplant.io",
+			corsHeaderExist: false,
+		},
+		"wrong origin configuration": {
+			requestHeader:   map[string][]string{"Origin": {"https://example.com"}},
+			origins:         "https://acme.com;https://example.com;https://eggplant.io",
+			corsHeaderExist: false,
+		},
+	}
+
+	for name, d := range cases {
+		t.Run(name, func(t *testing.T) {
+			// given
+			request := &http.Request{Header: d.requestHeader}
+			response := &httptest.ResponseRecorder{}
+
+			handler := NewHandler(storage.NewMemoryStorage(), nil, d.origins, nil)
+
+			// when
+			handler.specifyAllowOriginHeader(request, response)
+
+			// then
+			if d.corsHeaderExist {
+				t.Log(response.Header())
+				require.Equal(t, d.corsExpectedHeader, response.Header().Get("Access-Control-Allow-Origin"))
+			} else {
+				require.NotContains(t, "Access-Control-Allow-Origin", response.Header())
 			}
 		})
 	}

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -310,6 +310,8 @@ spec:
               value: {{ .Values.kubeconfig.issuerURL }}
             - name: APP_KUBECONFIG_CLIENT_ID
               value: {{ .Values.kubeconfig.clientID }}
+            - name: APP_KUBECONFIG_ALLOW_ORIGINS
+              value: {{ .Values.kubeconfig.allowOrigins }}
             - name: APP_PROVISIONING_KUBERNETES_VERSION
               value: {{ .Values.gardener.kubernetesVersion }}
             - name: APP_PROVISIONING_MACHINE_IMAGE

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -311,7 +311,7 @@ spec:
             - name: APP_KUBECONFIG_CLIENT_ID
               value: {{ .Values.kubeconfig.clientID }}
             - name: APP_KUBECONFIG_ALLOW_ORIGINS
-              value: {{ .Values.kubeconfig.allowOrigins }}
+              value: "{{ .Values.kubeconfig.allowOrigins }}"
             - name: APP_PROVISIONING_KUBERNETES_VERSION
               value: {{ .Values.gardener.kubernetesVersion }}
             - name: APP_PROVISIONING_MACHINE_IMAGE

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -98,6 +98,7 @@ gardener:
 kubeconfig:
   issuerURL: "TBD"
   clientID: "TBD"
+  allowOrigins: "*"
 
 # It is used to provide own creds for Service Manager instead of using the one provided by external system
 # who execute provision call on Kyma Environment Broker. You can define `overrideMode` to be one of: Always, WhenNotSentInRequest, Never

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-805"
     kyma_environment_broker:
       dir:
-      version: "PR-814"
+      version: "PR-820"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION
**Description**

Add CORS headers to the kubeconfig endpoint. Origins can be set by `APP_KUBECONFIG_ALLOW_ORIGINS` environment.