### PR TITLE
Randomize maintenance window for non-porduction clusters

### DIFF
--- a/components/provisioner/internal/gardener/provisioner.go
+++ b/components/provisioner/internal/gardener/provisioner.go
@@ -64,8 +64,12 @@ func (g *GardenerProvisioner) ProvisionCluster(cluster model.Cluster, operationI
 	}
 
 	region := cluster.ClusterConfig.Region
+	purpose := ""
+	if cluster.ClusterConfig.Purpose != nil {
+		purpose = *cluster.ClusterConfig.Purpose
+	}
 
-	if g.shouldSetMaintenanceWindow() {
+	if g.shouldSetMaintenanceWindow(purpose) {
 		err := g.setMaintenanceWindow(shootTemplate, region)
 
 		if err != nil {
@@ -209,8 +213,8 @@ func annotateWithConfirmDeletion(shoot *gardener_types.Shoot) {
 	shoot.Annotations["confirmation.gardener.cloud/deletion"] = "true"
 }
 
-func (g *GardenerProvisioner) shouldSetMaintenanceWindow() bool {
-	return g.maintenanceWindowConfigPath != ""
+func (g *GardenerProvisioner) shouldSetMaintenanceWindow(purpose string) bool {
+	return g.maintenanceWindowConfigPath != "" && purpose == "production"
 }
 
 func newDeprovisionOperation(id, runtimeId, message string, state model.OperationState, stage model.OperationStage, startTime time.Time) model.Operation {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -9,7 +9,7 @@ global:
       version: "PR-808"
     provisioner:
       dir:
-      version: "6c4c534b"
+      version: "PR-821"
     kyma_environment_broker:
       dir:
       version: "PR-822"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...Randomize maintenance window for non-porduction clusters
- ...Add purpose attribute to provision unit test
- ...Update image version in kcp chart to PR-821

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #1583