### PR TITLE
Change Azure HA AutoscalerMax parameter in docs

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -156,9 +156,7 @@ func AWSHASchema(machineTypes []string) []byte {
 	properties.AutoScalerMin.Default = 4
 	properties.AutoScalerMin.Minimum = 4
 
-	properties.AutoScalerMax.Default = 10
 	properties.AutoScalerMax.Minimum = 4
-	properties.AutoScalerMax.Maximum = 10
 
 	bytes, err := json.Marshal(schema)
 	if err != nil {
@@ -235,9 +233,7 @@ func AzureHASchema(machineTypes []string) []byte {
 	properties.AutoScalerMin.Default = 4
 	properties.AutoScalerMin.Minimum = 4
 
-	properties.AutoScalerMax.Default = 10
 	properties.AutoScalerMax.Minimum = 4
-	properties.AutoScalerMax.Maximum = 40
 
 	bytes, err := json.Marshal(schema)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
@@ -27,7 +27,7 @@
       "type": "integer",
       "description": "Specifies the maximum number of virtual machines to create",
       "minimum": 4,
-      "maximum": 10,
+      "maximum": 40,
       "default": 10
     },
     "zonesCount": {

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -105,7 +105,7 @@ These are the provisioning parameters for Azure that you can configure:
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `3` |
-| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `4` |
+| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `10` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable** | int | Specifies the maximum number of virtual machines that can be unavailable during an update. | No | `1` |
 | **zonesCount** | int | Specifies the number of availability zones for an SKR. | No | `2` |

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -70,7 +70,7 @@ These are the provisioning parameters for Azure that you can configure:
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
-| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `10` |
+| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create, up to `40` allowed. | No | `10` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable** | int | Specifies the maximum number of VMs that can be unavailable during an update. | No | `1` |
 
@@ -105,7 +105,7 @@ These are the provisioning parameters for Azure that you can configure:
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `3` |
-| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `10` |
+| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create, up to `40` allowed. | No | `10` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable** | int | Specifies the maximum number of virtual machines that can be unavailable during an update. | No | `1` |
 | **zonesCount** | int | Specifies the number of availability zones for an SKR. | No | `2` |
@@ -127,7 +127,7 @@ These are the provisioning parameters for AWS that you can configure:
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `3` |
-| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `10` |
+| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create, up to `40` allowed. | No | `10` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable** | int | Specifies the maximum number of virtual machines that can be unavailable during an update. | No | `1` |
 
@@ -144,7 +144,7 @@ These are the provisioning parameters for AWS that you can configure:
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
 | **autoScalerMin** | int | Specifies the minimum number of virtual machines to create. | No | `4` |
-| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create. | No | `10` |
+| **autoScalerMax** | int | Specifies the maximum number of virtual machines to create, up to `40` allowed. | No | `10` |
 | **maxSurge** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable** | int | Specifies the maximum number of virtual machines that can be unavailable during an update. | No | `1` |
 | **zonesCount** | int | Specifies the number of availability zones for an SKR. | No | `2` |


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- FIxed default value for `AutoScalerMax` for Azure HA plan in KEB docs
- `AutoscalerMax.Maximum` for AWS HA changed to `40`
- Removed unnecessary assignments for Autoscaler values - those have already proper values set in `NewProvisioningProperties()` and there is no need to override those
- Added info about maximum value of `AutoscalerMax` to docs

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
