### PR TITLE
Move freemium SKRs from production AVS group to trial AVS group

### DIFF
--- a/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
+++ b/components/kyma-environment-broker/internal/avs/internal_eval_assistant.go
@@ -34,7 +34,7 @@ func (iec *InternalEvalAssistant) CreateBasicEvaluationRequest(operations intern
 
 func (iec *InternalEvalAssistant) AppendOverrides(inputCreator internal.ProvisionerInputCreator, evaluationId int64, pp internal.ProvisioningParameters) {
 	apiKey := iec.avsConfig.ApiKey
-	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+	if (broker.IsTrialPlan(pp.PlanID) || broker.IsFreemiumPlan(pp.PlanID)) && iec.avsConfig.IsTrialConfigured() {
 		apiKey = iec.avsConfig.TrialApiKey
 	}
 	inputCreator.AppendOverrides(ComponentName, []*gqlschema.ConfigEntryInput{
@@ -63,21 +63,21 @@ func (iec *InternalEvalAssistant) ProvideSuffix() string {
 }
 
 func (iec *InternalEvalAssistant) ProvideTesterAccessId(pp internal.ProvisioningParameters) int64 {
-	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+	if (broker.IsTrialPlan(pp.PlanID) || broker.IsFreemiumPlan(pp.PlanID)) && iec.avsConfig.IsTrialConfigured() {
 		return iec.avsConfig.TrialInternalTesterAccessId
 	}
 	return iec.avsConfig.InternalTesterAccessId
 }
 
 func (iec *InternalEvalAssistant) ProvideGroupId(pp internal.ProvisioningParameters) int64 {
-	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+	if (broker.IsTrialPlan(pp.PlanID) || broker.IsFreemiumPlan(pp.PlanID)) && iec.avsConfig.IsTrialConfigured() {
 		return iec.avsConfig.TrialGroupId
 	}
 	return iec.avsConfig.GroupId
 }
 
 func (iec *InternalEvalAssistant) ProvideParentId(pp internal.ProvisioningParameters) int64 {
-	if broker.IsTrialPlan(pp.PlanID) && iec.avsConfig.IsTrialConfigured() {
+	if (broker.IsTrialPlan(pp.PlanID) || broker.IsFreemiumPlan(pp.PlanID)) && iec.avsConfig.IsTrialConfigured() {
 		return iec.avsConfig.TrialParentId
 	}
 	return iec.avsConfig.ParentId

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -447,3 +447,12 @@ func IsAzurePlan(planID string) bool {
 		return false
 	}
 }
+
+func IsFreemiumPlan(planID string) bool {
+	switch planID {
+	case FreemiumPlanID:
+		return true
+	default:
+		return false
+	}
+}

--- a/components/kyma-environment-broker/internal/process/provisioning/external_eval_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/external_eval_step.go
@@ -27,8 +27,8 @@ func (e ExternalEvalStep) Name() string {
 }
 
 func (s *ExternalEvalStep) Run(operation internal.ProvisioningOperation, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
-	if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) {
-		log.Debug("skipping AVS external evaluation creation for trial plan")
+	if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
+		log.Debug("skipping AVS external evaluation creation for trial/freemium plan")
 		return operation, 0, nil
 	}
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-805"
     kyma_environment_broker:
       dir:
-      version: "PR-828"
+      version: "PR-830"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-723"


### PR DESCRIPTION

**Description**

External evaluation must not be created for freemium clusters. Internal evaluation must be created in the trial AVS group instead of production.


**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/1638