### PR TITLE
Remove async execution of suspension context update in e2e test

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -31,7 +31,7 @@ global:
         version: "PR-699"
       e2e_provisioning:
         dir:
-        version: "PR-844"
+        version: "PR-850"
   isLocalEnv: false
   oauth2:
     host: oauth2

--- a/tests/e2e/provisioning/pkg/client/broker/broker_client.go
+++ b/tests/e2e/provisioning/pkg/client/broker/broker_client.go
@@ -346,9 +346,9 @@ func (c *Client) prepareUpdateDetails(active *bool) ([]byte, error) {
 		return nil, errors.Wrap(err, "while marshalling context body")
 	}
 	requestBody := domain.UpdateDetails{
-		ServiceID:     kymaClassID,
-		PlanID:        c.brokerConfig.PlanID,
-		RawContext:    rawContext,
+		ServiceID:  kymaClassID,
+		PlanID:     c.brokerConfig.PlanID,
+		RawContext: rawContext,
 		MaintenanceInfo: &domain.MaintenanceInfo{
 			Version:     "0.1.0",
 			Description: "Kyma environment broker e2e-provisioning test",

--- a/tests/e2e/provisioning/pkg/client/broker/broker_client.go
+++ b/tests/e2e/provisioning/pkg/client/broker/broker_client.go
@@ -102,14 +102,14 @@ type provisionParameters struct {
 // ProvisionRuntime requests Runtime provisioning in KEB
 // kymaVersion is optional, if it is empty, the default KEB version will be used
 func (c *Client) ProvisionRuntime(kymaVersion string) (string, error) {
-	c.log.Infof("Provisioning Runtime [instanceID: %s, NAME: %s]", c.instanceID, c.clusterName)
+	c.log.Infof("Provisioning Runtime [instanceID: %s, NAME: %s]", c.InstanceID(), c.ClusterName())
 	requestByte, err := c.prepareProvisionDetails(kymaVersion)
 	if err != nil {
 		return "", errors.Wrap(err, "while preparing provision details")
 	}
 	c.log.Infof("Provisioning parameters: %v", string(requestByte))
 
-	provisionURL := fmt.Sprintf("%s/service_instances/%s", c.baseURL(), c.instanceID)
+	provisionURL := fmt.Sprintf("%s/service_instances/%s", c.baseURL(), c.InstanceID())
 	response := provisionResponse{}
 	err = wait.Poll(time.Second, time.Second*5, func() (bool, error) {
 		err := c.executeRequest(http.MethodPut, provisionURL, http.StatusAccepted, bytes.NewReader(requestByte), &response)
@@ -133,7 +133,7 @@ func (c *Client) ProvisionRuntime(kymaVersion string) (string, error) {
 
 func (c *Client) DeprovisionRuntime() (string, error) {
 	format := "%s/service_instances/%s?service_id=%s&plan_id=%s"
-	deprovisionURL := fmt.Sprintf(format, c.baseURL(), c.instanceID, kymaClassID, c.brokerConfig.PlanID)
+	deprovisionURL := fmt.Sprintf(format, c.baseURL(), c.InstanceID(), kymaClassID, c.brokerConfig.PlanID)
 
 	response := provisionResponse{}
 	c.log.Infof("Deprovisioning Runtime [ID: %s, NAME: %s]", c.instanceID, c.clusterName)
@@ -160,7 +160,7 @@ func (c *Client) SuspendRuntime() error {
 	}
 	c.log.Infof("Suspension parameters: %v", string(requestByte))
 
-	format := "%s/service_instances/%s?accepts_incomplete=true"
+	format := "%s/service_instances/%s"
 	suspensionURL := fmt.Sprintf(format, c.baseURL(), c.instanceID)
 
 	suspensionResponse := instanceDetailsResponse{}
@@ -180,15 +180,15 @@ func (c *Client) SuspendRuntime() error {
 }
 
 func (c *Client) UnsuspendRuntime() error {
-	c.log.Infof("Unsuspending Runtime [instanceID: %s, NAME: %s]", c.instanceID, c.clusterName)
+	c.log.Infof("Unsuspending Runtime [instanceID: %s, NAME: %s]", c.InstanceID(), c.ClusterName())
 	requestByte, err := c.prepareUpdateDetails(ptr.Bool(true))
 	if err != nil {
 		return errors.Wrap(err, "while preparing update details")
 	}
 	c.log.Infof("Unuspension parameters: %v", string(requestByte))
 
-	format := "%s/service_instances/%s?service_id=%s&plan_id=%s?accepts_incomplete=true"
-	suspensionURL := fmt.Sprintf(format, c.baseURL(), c.instanceID, kymaClassID, c.brokerConfig.PlanID)
+	format := "%s/service_instances/%s"
+	suspensionURL := fmt.Sprintf(format, c.baseURL(), c.InstanceID())
 
 	unsuspensionResponse := instanceDetailsResponse{}
 	err = wait.Poll(time.Second, time.Second*5, func() (bool, error) {
@@ -231,9 +231,9 @@ func (c *Client) ClusterName() string {
 }
 
 func (c *Client) AwaitOperationSucceeded(operationID string, timeout time.Duration) error {
-	lastOperationURL := fmt.Sprintf("%s/service_instances/%s/last_operation?operation=%s", c.baseURL(), c.instanceID, operationID)
+	lastOperationURL := fmt.Sprintf("%s/service_instances/%s/last_operation?operation=%s", c.baseURL(), c.InstanceID(), operationID)
 	if operationID == "" {
-		lastOperationURL = fmt.Sprintf("%s/service_instances/%s/last_operation", c.baseURL(), c.instanceID)
+		lastOperationURL = fmt.Sprintf("%s/service_instances/%s/last_operation", c.baseURL(), c.InstanceID())
 	}
 
 	c.log.Infof("Waiting for operation at most %s", timeout.String())
@@ -270,7 +270,7 @@ func (c *Client) AwaitOperationSucceeded(operationID string, timeout time.Durati
 }
 
 func (c *Client) FetchDashboardURL() (string, error) {
-	instanceDetailsURL := fmt.Sprintf("%s/service_instances/%s", c.baseURL(), c.instanceID)
+	instanceDetailsURL := fmt.Sprintf("%s/service_instances/%s", c.baseURL(), c.InstanceID())
 
 	c.log.Info("Fetching the Runtime's dashboard URL")
 	response := instanceDetailsResponse{}
@@ -335,18 +335,11 @@ func (c *Client) prepareProvisionDetails(customVersion string) ([]byte, error) {
 }
 
 func (c *Client) prepareUpdateDetails(active *bool) ([]byte, error) {
-	parameters := provisionParameters{
-		Name: c.clusterName,
-	}
 	ctx := inputContext{
 		TenantID:        "1eba80dd-8ff6-54ee-be4d-77944d17b10b",
 		SubAccountID:    c.subAccountID,
 		GlobalAccountID: c.globalAccountID,
 		Active:          active,
-	}
-	rawParameters, err := json.Marshal(parameters)
-	if err != nil {
-		return nil, errors.Wrap(err, "while marshalling parameters body")
 	}
 	rawContext, err := json.Marshal(ctx)
 	if err != nil {
@@ -355,7 +348,6 @@ func (c *Client) prepareUpdateDetails(active *bool) ([]byte, error) {
 	requestBody := domain.UpdateDetails{
 		ServiceID:     kymaClassID,
 		PlanID:        c.brokerConfig.PlanID,
-		RawParameters: rawParameters,
 		RawContext:    rawContext,
 		MaintenanceInfo: &domain.MaintenanceInfo{
 			Version:     "0.1.0",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Suspension/unsuspension update calls are executed without `?async_required=true` parameter in real scenario. Asynchronous execution of the update is only required when passing `parameters` in update call payload - in case of supsension/unsuspension, we only pass `context` and this has to be synchronous to reflect the real scenario.

Changes proposed in this pull request:

- Removed `async_required=true` parameter from URL when calling update (suspension and unsuspension, context update)
- nit: use `InstanceID(), ClusterName()` methods to access `client` non-exported fields

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
