### PR TITLE
WIP: Print operation states in log to help check why metrics are miss…

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/operation_duration.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_duration.go
@@ -54,6 +54,10 @@ func (c *OperationDurationCollector) OnProvisioningStepProcessed(ctx context.Con
 
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
+
+	fmt.Printf("ProvisionDuration state check: stepProcessed.OldOperation.State: %s, stepProcessed.Operation.State: %s",
+		stepProcessed.OldOperation.State, stepProcessed.Operation.State)
+
 	if stepProcessed.OldOperation.State == domain.InProgress && op.State == domain.Succeeded {
 		minutes := op.UpdatedAt.Sub(op.CreatedAt).Minutes()
 		c.provisioningHistogram.


### PR DESCRIPTION
…ing for provisioning_duration_minutes

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Print operation states in log to help check why metrics are missing for provisioning_duration_minutes
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
