### PR TITLE
collect provision_duration metrics

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/metrics.go
+++ b/components/kyma-environment-broker/internal/metrics/metrics.go
@@ -18,7 +18,7 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opResultCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.UpgradeKymaStepProcessed{}, opResultCollector.OnUpgradeKymaStepProcessed)
 	sub.Subscribe(process.UpgradeClusterStepProcessed{}, opResultCollector.OnUpgradeClusterStepProcessed)
-	sub.Subscribe(process.ProvisioningSucceeded{}, opDurationCollector.OnProvisioningStepProcessed)
+	sub.Subscribe(process.ProvisioningSucceeded{}, opDurationCollector.OnProvisioningSucceeded)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opDurationCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.ProvisioningStepProcessed{}, stepResultCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, stepResultCollector.OnDeprovisioningStepProcessed)

--- a/components/kyma-environment-broker/internal/metrics/metrics.go
+++ b/components/kyma-environment-broker/internal/metrics/metrics.go
@@ -18,7 +18,7 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opResultCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.UpgradeKymaStepProcessed{}, opResultCollector.OnUpgradeKymaStepProcessed)
 	sub.Subscribe(process.UpgradeClusterStepProcessed{}, opResultCollector.OnUpgradeClusterStepProcessed)
-	sub.Subscribe(process.ProvisioningStepProcessed{}, opDurationCollector.OnProvisioningStepProcessed)
+	sub.Subscribe(process.ProvisioningSucceeded{}, opDurationCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, opDurationCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.ProvisioningStepProcessed{}, stepResultCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, stepResultCollector.OnDeprovisioningStepProcessed)

--- a/components/kyma-environment-broker/internal/metrics/operation_duration.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_duration.go
@@ -54,6 +54,12 @@ func (c *OperationDurationCollector) OnProvisioningStepProcessed(ctx context.Con
 
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
+
+	fmt.Printf("ProvisioningStepProcessed: %s \n", stepProcessed.StepProcessed.StepName)
+	fmt.Printf("ProvisioningStepProcessed details: %+v \n", stepProcessed)
+	fmt.Printf("ProvisionDuration state check: stepProcessed.OldOperation.State: %s, stepProcessed.Operation.State: %s \n",
+		stepProcessed.OldOperation.State, stepProcessed.Operation.State)
+
 	if stepProcessed.OldOperation.State == domain.InProgress && op.State == domain.Succeeded {
 		minutes := op.UpdatedAt.Sub(op.CreatedAt).Minutes()
 		c.provisioningHistogram.

--- a/components/kyma-environment-broker/internal/metrics/operation_duration.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_duration.go
@@ -46,25 +46,17 @@ func (c *OperationDurationCollector) Collect(ch chan<- prometheus.Metric) {
 	c.deprovisioningHistogram.Collect(ch)
 }
 
-func (c *OperationDurationCollector) OnProvisioningStepProcessed(ctx context.Context, ev interface{}) error {
-	stepProcessed, ok := ev.(process.ProvisioningStepProcessed)
+func (c *OperationDurationCollector) OnProvisioningSucceeded(ctx context.Context, ev interface{}) error {
+	provision, ok := ev.(process.ProvisioningSucceeded)
 	if !ok {
-		return fmt.Errorf("expected process.ProvisioningStepProcessed but got %+v", ev)
+		return fmt.Errorf("expected process.ProvisioningSucceeded but got %+v", ev)
 	}
 
-	op := stepProcessed.Operation
+	op := provision.Operation
 	pp := op.ProvisioningParameters
-
-	fmt.Printf("ProvisioningStepProcessed: %s \n", stepProcessed.StepProcessed.StepName)
-	fmt.Printf("ProvisioningStepProcessed details: %+v \n", stepProcessed)
-	fmt.Printf("ProvisionDuration state check: stepProcessed.OldOperation.State: %s, stepProcessed.Operation.State: %s \n",
-		stepProcessed.OldOperation.State, stepProcessed.Operation.State)
-
-	if stepProcessed.OldOperation.State == domain.InProgress && op.State == domain.Succeeded {
-		minutes := op.UpdatedAt.Sub(op.CreatedAt).Minutes()
-		c.provisioningHistogram.
-			WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).Observe(minutes)
-	}
+	minutes := op.UpdatedAt.Sub(op.CreatedAt).Minutes()
+	c.provisioningHistogram.
+		WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).Observe(minutes)
 
 	return nil
 }

--- a/components/kyma-environment-broker/internal/process/events.go
+++ b/components/kyma-environment-broker/internal/process/events.go
@@ -42,3 +42,7 @@ type UpgradeClusterStepProcessed struct {
 	OldOperation internal.UpgradeClusterOperation
 	Operation    internal.UpgradeClusterOperation
 }
+
+type ProvisioningSucceeded struct {
+	Operation internal.ProvisioningOperation
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add ProvisioningSucceeded event
- For provision operation duration, instead of subscribing to every provision step,
it will subscribe to provision ProvisioningSucceeded event(sent from last step of last provision stage which finished without issue)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
