### PR TITLE
remove the compass-installer step in /cmd/run.sh

### DIFF
--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -23,7 +23,8 @@ fi
 kyma provision minikube
 kyma install -c $INSTALLER_CR_PATH -o $OVERRIDES_KYMA --source $KYMA_SOURCE
 
-bash "${ROOT_PATH}"/installation/scripts/run-compass-installer.sh
+#remove the compass-installer.sh
+#bash "${ROOT_PATH}"/installation/scripts/run-compass-installer.sh
 
 bash "${ROOT_PATH}"/installation/scripts/run-kcp-installer.sh
 bash "${ROOT_PATH}"/installation/scripts/is-installed.sh

--- a/installation/cmd/run.sh
+++ b/installation/cmd/run.sh
@@ -30,4 +30,4 @@ bash "${ROOT_PATH}"/installation/scripts/run-kcp-installer.sh
 bash "${ROOT_PATH}"/installation/scripts/is-installed.sh
 
 echo "Adding entries to /etc/hosts..."
-sudo sh -c 'echo "\n$(minikube ip) adapter-gateway.kyma.local adapter-gateway-mtls.kyma.local compass-gateway-mtls.kyma.local compass-gateway-auth-oauth.kyma.local compass-gateway.kyma.local compass.kyma.local compass-mf.kyma.local kyma-env-broker.kyma.local" >> /etc/hosts'
+sudo sh -c 'echo "\n$(minikube ip) kyma-env-broker.kyma.local" >> /etc/hosts'


### PR DESCRIPTION
**Description**
from @desislavaa's suggestion,  try to not install compass component when executing the `pre-main-control-plane-integration` case

```
#bash "${ROOT_PATH}"/installation/scripts/run-compass-installer.sh
```

**Related issue(s)**
[PR 861](https://github.com/kyma-project/control-plane/pull/861) test case failed at installing compass component see  https://status.build.kyma-project.io/view/gs/kyma-prow-logs/pr-logs/pull/kyma-project_control-plane/861/pre-main-control-plane-integration/1418488550613061632