### PR TITLE
Sync the node autoscale params during KEB cluster upgrade

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -348,6 +348,12 @@ func (f *InputBuilderFactory) initUpgradeShootInput(provider HyperscalerInputPro
 		input.GardenerConfig.MachineImageVersion = &f.config.MachineImageVersion
 	}
 
+	// sync with the autoscaler settings
+	input.GardenerConfig.AutoScalerMin = &provider.Defaults().GardenerConfig.AutoScalerMin
+	input.GardenerConfig.AutoScalerMax = &provider.Defaults().GardenerConfig.AutoScalerMax
+	input.GardenerConfig.MaxSurge = &provider.Defaults().GardenerConfig.MaxSurge
+	input.GardenerConfig.MaxUnavailable = &provider.Defaults().GardenerConfig.MaxUnavailable
+
 	return input
 }
 

--- a/components/kyma-environment-broker/internal/process/input/builder_test.go
+++ b/components/kyma-environment-broker/internal/process/input/builder_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/input/automock"
+	cloudProvider "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provider"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/runtime"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
@@ -213,6 +214,70 @@ func TestInputBuilderFactory_ForPlan(t *testing.T) {
 		assert.Nil(t, result.provisionRuntimeInput.ClusterConfig)
 		assert.NotNil(t, result.upgradeRuntimeInput.KymaConfig.Profile)
 		assert.Equal(t, gqlschema.KymaProfileEvaluation, *result.upgradeRuntimeInput.KymaConfig.Profile)
+	})
+
+	t.Run("should build CreateUpgradeShootInput with proper plan", func(t *testing.T) {
+		// given
+		var provider HyperscalerInputProvider
+
+		componentsProvider := &automock.ComponentListProvider{}
+		componentsProvider.On("AllComponents", "1.10").Return([]v1alpha1.KymaComponent{}, nil).Once()
+		defer componentsProvider.AssertExpectations(t)
+
+		ibf, err := NewInputBuilderFactory(nil, runtime.NewDisabledComponentsProvider(), componentsProvider,
+			Config{}, "1.10", fixTrialRegionMapping(), fixTrialProviders(), fixture.FixOIDCConfigDTO())
+		assert.NoError(t, err)
+		pp := fixProvisioningParameters(broker.GCPPlanID, "")
+		provider = &cloudProvider.GcpInput{} // for broker.GCPPlanID
+
+		// when
+		input, err := ibf.CreateUpgradeShootInput(pp)
+
+		// Then
+		assert.NoError(t, err)
+		require.IsType(t, &RuntimeInput{}, input)
+
+		result := input.(*RuntimeInput)
+		autoscalerMax := *result.upgradeShootInput.GardenerConfig.AutoScalerMax
+		autoscalerMin := *result.upgradeShootInput.GardenerConfig.AutoScalerMin
+		maxSurge := *result.upgradeShootInput.GardenerConfig.MaxSurge
+		maxUnavailable := *result.upgradeShootInput.GardenerConfig.MaxUnavailable
+
+		assert.Equal(t, autoscalerMax, provider.Defaults().GardenerConfig.AutoScalerMax)
+		assert.Equal(t, autoscalerMin, provider.Defaults().GardenerConfig.AutoScalerMin)
+		assert.Equal(t, maxSurge, provider.Defaults().GardenerConfig.MaxSurge)
+		assert.Equal(t, maxUnavailable, provider.Defaults().GardenerConfig.MaxUnavailable)
+		//t.Logf("%v, %v, %v, %v", autoscalerMax, autoscalerMin, maxSurge, maxUnavailable)
+
+		// given
+		pp = fixProvisioningParameters(broker.TrialPlanID, "")
+		switch *pp.Parameters.Provider {
+		case internal.GCP:
+			provider = &cloudProvider.GcpTrialInput{}
+		case internal.AWS:
+			provider = &cloudProvider.AWSTrialInput{}
+		default:
+			provider = &cloudProvider.AzureTrialInput{}
+		}
+
+		// when
+		input, err = ibf.CreateUpgradeShootInput(pp)
+
+		// Then
+		assert.NoError(t, err)
+		require.IsType(t, &RuntimeInput{}, input)
+
+		result = input.(*RuntimeInput)
+		autoscalerMax = *result.upgradeShootInput.GardenerConfig.AutoScalerMax
+		autoscalerMin = *result.upgradeShootInput.GardenerConfig.AutoScalerMin
+		maxSurge = *result.upgradeShootInput.GardenerConfig.MaxSurge
+		maxUnavailable = *result.upgradeShootInput.GardenerConfig.MaxUnavailable
+
+		assert.Equal(t, autoscalerMax, provider.Defaults().GardenerConfig.AutoScalerMax)
+		assert.Equal(t, autoscalerMin, provider.Defaults().GardenerConfig.AutoScalerMin)
+		assert.Equal(t, maxSurge, provider.Defaults().GardenerConfig.MaxSurge)
+		assert.Equal(t, maxUnavailable, provider.Defaults().GardenerConfig.MaxUnavailable)
+		//t.Logf("%v, %v, %v, %v", autoscalerMax, autoscalerMin, maxSurge, maxUnavailable)
 	})
 
 }

--- a/components/kyma-environment-broker/internal/provisioner/client_test.go
+++ b/components/kyma-environment-broker/internal/provisioner/client_test.go
@@ -31,6 +31,10 @@ var (
 	testKubernetesVersion   = "1.17.16"
 	testMachineImage        = "gardenlinux"
 	testMachineImageVersion = "184.0.0"
+	testAutoScalerMin       = 2
+	testAutoScalerMax       = 4
+	testMaxSurge            = 4
+	testMaxUnavailable      = 1
 )
 
 func TestClient_ProvisionRuntime(t *testing.T) {
@@ -607,6 +611,10 @@ func fixUpgradeShootInput() schema.UpgradeShootInput {
 			KubernetesVersion:   &testKubernetesVersion,
 			MachineImage:        &testMachineImage,
 			MachineImageVersion: &testMachineImageVersion,
+			AutoScalerMin:       &testAutoScalerMin,
+			AutoScalerMax:       &testAutoScalerMax,
+			MaxSurge:            &testMaxSurge,
+			MaxUnavailable:      &testMaxUnavailable,
 		},
 	}
 }

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
@@ -147,10 +147,10 @@ func Test_GardenerConfigInputToGraphQL(t *testing.T) {
 		diskType: "Standard_LRS",
 		targetSecret: "scr",
 		workerCidr: "10.250.0.0/19",
-        autoScalerMin: 0,
-        autoScalerMax: 0,
-        maxSurge: 0,
-		maxUnavailable: 0,
+        autoScalerMin: 2,
+        autoScalerMax: 4,
+        maxSurge: 4,
+		maxUnavailable: 1,
 	}`
 
 	// when
@@ -165,6 +165,10 @@ func Test_GardenerConfigInputToGraphQL(t *testing.T) {
 		TargetSecret:      "scr",
 		MachineType:       "Standard_D4_v3",
 		KubernetesVersion: "1.18",
+		AutoScalerMin:     2,
+		AutoScalerMax:     4,
+		MaxSurge:          4,
+		MaxUnavailable:    1,
 	})
 
 	// then


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Set/Sync the autoscale params (AutoScalerMin, AutoScalerMax, MaxSurge, MaxUnavailable) from the plan file in [plan provider](https://github.com/kyma-project/control-plane/tree/main/components/kyma-environment-broker/internal/provider) during the KEB cluster upgrade.
- Add the unit subtest for `CreateUpgradeShootInput` in `builder.go` to verify the autoscale settings sync

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
