### PR TITLE
Fix UpgradeShootInput to always contain admins list

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -270,6 +270,9 @@ func (r *RuntimeInput) applyProvisioningParametersForUpgradeShoot() error {
 		newAdministrators := make([]string, 0, len(r.provisioningParameters.Parameters.RuntimeAdministrators))
 		newAdministrators = append(newAdministrators, r.provisioningParameters.Parameters.RuntimeAdministrators...)
 		r.upgradeShootInput.Administrators = newAdministrators
+	} else {
+		// get default admin (user_id from provisioning operation)
+		r.upgradeShootInput.Administrators = []string{r.provisioningParameters.ErsContext.UserID}
 	}
 
 	return nil

--- a/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
+++ b/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
@@ -91,19 +91,12 @@ func (s *UpgradeShootStep) createUpgradeShootInput(operation internal.UpdatingOp
 		return fullInput, errors.Wrap(err, "while building upgradeShootInput for provisioner")
 	}
 
-	// modify OIDC configuration
+	// modify configuration
 	result := gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: fullInput.GardenerConfig.OidcConfig,
 		},
-	}
-
-	// modify runtime admins list
-	if len(fullInput.Administrators) != 0 {
-		result.Administrators = append(
-			result.Administrators,
-			fullInput.Administrators...,
-		)
+		Administrators: fullInput.Administrators,
 	}
 
 	return result, nil

--- a/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step_test.go
+++ b/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step_test.go
@@ -28,6 +28,7 @@ func TestUpgradeShootStep_Run(t *testing.T) {
 	operation := fixture.FixUpdatingOperation("op-id", "inst-id")
 	operation.RuntimeID = "runtime-id"
 	operation.ProvisionerOperationID = ""
+	operation.ProvisioningParameters.ErsContext.UserID = "test-user-id"
 	operation.ProvisioningParameters.Parameters.OIDC = &internal.OIDCConfigDTO{
 		ClientID:       "client-id",
 		GroupsClaim:    "groups",
@@ -56,7 +57,7 @@ func TestUpgradeShootStep_Run(t *testing.T) {
 				UsernamePrefix: "-",
 			},
 		},
-		Administrators: nil,
+		Administrators: []string{"test-user-id"},
 	}, req)
 	assert.NotEmpty(t, newOperation.ProvisionerOperationID)
 }

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
@@ -53,6 +53,7 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 				UsernamePrefix: expectedOIDC.UsernamePrefix,
 			},
 		},
+		Administrators: []string{provisioningOperation.ProvisioningParameters.ErsContext.UserID},
 	}).Return(gqlschema.OperationStatus{
 		ID:        StringPtr(fixProvisionerOperationID),
 		Operation: "",

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-869"
     kyma_environment_broker:
       dir:
-      version: "PR-882"
+      version: "PR-886"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-857"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- fix missing administrator list in request for Provisioner bug,
- add more tests regarding input creation for Provisioner.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
