### PR TITLE
Add ebensom to code owners of KEB and e2e provisioning tests

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,19 +8,19 @@
 * @PK85 @crabtree @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa @piotrmiskiewicz @ksputo @szwedm @voigt @wozniakjan
 
 # All developers working on this repository are able to edit main values.yaml file.
-/resources/kcp/values.yaml @PK85 @crabtree @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @szwedm @ksputo @koala7659 @rafalpotempa @k15r @marcobebway @nachtmaar @radufa @sayanh @themue @voigt @wozniakjan
+/resources/kcp/values.yaml @PK85 @crabtree @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @szwedm @ksputo @koala7659 @rafalpotempa @k15r @marcobebway @nachtmaar @radufa @sayanh @themue @voigt @wozniakjan @ebensom
 
 # All developers working on this repository are able to edit scripts directory.
-/scripts @PK85 @crabtree @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @szwedm @ksputo @koala7659 @rafalpotempa @voigt @wozniakjan
+/scripts @PK85 @crabtree @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @szwedm @ksputo @koala7659 @rafalpotempa @voigt @wozniakjan @ebensom
 
 # Registration job is used by provisioner and kyma-environment-broker
 /resources/kcp/templates/registration-job.yaml @PK85 @crabtree @tgorgol @akgalwas @janmedrek @Szymongib @franpog859 @Maladie @piotrmiskiewicz @szwedm @ksputo @koala7659 @rafalpotempa @voigt @wozniakjan
 
 # Kyma Environment Broker
-/resources/kcp/charts/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan
-/components/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan
-/docs/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan
-/components/schema-migrator/migrations/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan
+/resources/kcp/charts/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan @ebensom
+/components/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan @ebensom
+/docs/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan @ebensom
+/components/schema-migrator/migrations/kyma-environment-broker @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan @ebensom
 
 # Runtime Provisioner
 /resources/kcp/charts/provisioner @janmedrek @akgalwas @Szymongib @franpog859 @Maladie @koala7659 @rafalpotempa
@@ -31,7 +31,7 @@
 
 
 # e2e-provisioning
-/tests/e2e/provisioning @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan
+/tests/e2e/provisioning @PK85 @piotrmiskiewicz @ksputo @crabtree @szwedm @voigt @wozniakjan @ebensom
 
 # Kyma metrics collector
 /resources/kcp/charts/kyma-metrics-collector @k15r @lilitgh @marcobebway @nachtmaar @radufa @sayanh @themue


### PR DESCRIPTION

**Description**

Add @ebensom to code owners of KEB and e2e provisioning. The reason is that there are some places of KEB heavily influenced and developed by me (orchestration, upgrade operations, runtime/orchestration query API handlers), and SRE still contributes to these parts actively.

List of contributions by me (88 commits    20,041 ++    7,950 --):
https://github.com/kyma-project/control-plane/commits?author=ebensom

