### PR TITLE
Allow configuring shoot upgrade timeout (default 90 mins)

### DIFF
--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -108,6 +108,8 @@ spec:
               value: {{ .Values.gardener.clusterCreationTimeout | quote }}
             - name: APP_PROVISIONING_TIMEOUT_UPGRADE_TRIGGERING
               value: {{ .Values.upgrade.triggeringTimeout | quote }}
+            - name: APP_PROVISIONING_TIMEOUT_SHOOT_UPGRADE
+              value: {{ .Values.gardener.clusterUpgradeTimeout | quote }}
             - name: APP_DEPROVISIONING_TIMEOUT_CLUSTER_DELETION
               value: {{ .Values.gardener.clusterDeletionTimeout | quote }}
             - name: APP_DEPROVISIONING_TIMEOUT_WAITING_FOR_CLUSTER_DELETION

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -29,6 +29,7 @@ gardener:
   waitingForClusterDeletionTimeout: 4h
   clusterCleanupTimeout: 20m
   clusterCleanupResourceSelector: "https://service-manager."
+  clusterUpgradeTimeout: 90m
   defaultEnableKubernetesVersionAutoUpdate: false
   defaultEnableMachineImageVersionAutoUpdate: false
   forceAllowPrivilegedContainers: false


### PR DESCRIPTION
**Description**

Shoot upgrade timeout in provisioner is currently not configurable. The current hardcoded 30 minutes timeout is not enough in practice.
