### PR TITLE
Fix OIDC param in the returned kubeconfig

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -314,7 +314,7 @@ func main() {
 	router.Handle("/metrics", promhttp.Handler())
 
 	// create SKR kubeconfig endpoint
-	kcBuilder := kubeconfig.NewBuilder(cfg.Kubeconfig, provisionerClient)
+	kcBuilder := kubeconfig.NewBuilder(provisionerClient)
 	kcHandler := kubeconfig.NewHandler(db, kcBuilder, cfg.Kubeconfig.AllowOrigins, logs.WithField("service", "kubeconfigHandle"))
 	kcHandler.AttachRoutes(router)
 

--- a/components/kyma-environment-broker/internal/kubeconfig/builder.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/builder.go
@@ -57,8 +57,8 @@ func (b *Builder) Build(instance *internal.Instance) (string, error) {
 		ContextName:   kubeCfg.CurrentContext,
 		CAData:        kubeCfg.Clusters[0].Cluster.CertificateAuthorityData,
 		ServerURL:     kubeCfg.Clusters[0].Cluster.Server,
-		OIDCIssuerURL: b.config.IssuerURL,
-		OIDCClientID:  b.config.ClientID,
+		OIDCIssuerURL: status.RuntimeConfiguration.ClusterConfig.OidcConfig.IssuerURL,
+		OIDCClientID:  status.RuntimeConfiguration.ClusterConfig.OidcConfig.ClientID,
 	})
 }
 

--- a/components/kyma-environment-broker/internal/kubeconfig/builder.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/builder.go
@@ -12,19 +12,15 @@ import (
 )
 
 type Config struct {
-	IssuerURL    string
-	ClientID     string
 	AllowOrigins string
 }
 
 type Builder struct {
-	config            Config
 	provisionerClient provisioner.Client
 }
 
-func NewBuilder(cfg Config, provisionerClient provisioner.Client) *Builder {
+func NewBuilder(provisionerClient provisioner.Client) *Builder {
 	return &Builder{
-		config:            cfg,
 		provisionerClient: provisionerClient,
 	}
 }

--- a/components/kyma-environment-broker/internal/kubeconfig/builder_test.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/builder_test.go
@@ -26,6 +26,16 @@ func TestBuilder_Build(t *testing.T) {
 		provisionerClient.On("RuntimeStatus", globalAccountID, runtimeID).Return(schema.RuntimeStatus{
 			RuntimeConfiguration: &schema.RuntimeConfig{
 				Kubeconfig: skrKubeconfig(),
+				ClusterConfig: &schema.GardenerConfig{
+					OidcConfig: &schema.OIDCConfig{
+						ClientID:       clientID,
+						GroupsClaim:    "gclaim",
+						IssuerURL:      issuerURL,
+						SigningAlgs:    nil,
+						UsernameClaim:  "uclaim",
+						UsernamePrefix: "-",
+					},
+				},
 			},
 		}, nil)
 		defer provisionerClient.AssertExpectations(t)

--- a/components/kyma-environment-broker/internal/kubeconfig/builder_test.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/builder_test.go
@@ -40,10 +40,7 @@ func TestBuilder_Build(t *testing.T) {
 		}, nil)
 		defer provisionerClient.AssertExpectations(t)
 
-		builder := NewBuilder(Config{
-			IssuerURL: issuerURL,
-			ClientID:  clientID,
-		}, provisionerClient)
+		builder := NewBuilder(provisionerClient)
 
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
@@ -64,7 +61,7 @@ func TestBuilder_Build(t *testing.T) {
 		provisionerClient.On("RuntimeStatus", globalAccountID, runtimeID).Return(schema.RuntimeStatus{}, fmt.Errorf("cannot return kubeconfig"))
 		defer provisionerClient.AssertExpectations(t)
 
-		builder := NewBuilder(Config{}, provisionerClient)
+		builder := NewBuilder(provisionerClient)
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
 			GlobalAccountID: globalAccountID,
@@ -88,7 +85,7 @@ func TestBuilder_Build(t *testing.T) {
 		}, nil)
 		defer provisionerClient.AssertExpectations(t)
 
-		builder := NewBuilder(Config{}, provisionerClient)
+		builder := NewBuilder(provisionerClient)
 		instance := &internal.Instance{
 			RuntimeID:       runtimeID,
 			GlobalAccountID: globalAccountID,

--- a/components/kyma-environment-broker/internal/provisioner/query.go
+++ b/components/kyma-environment-broker/internal/provisioner/query.go
@@ -68,6 +68,16 @@ func runtimeStatusData() string {
 			}`, clusterConfig())
 }
 
+/*
+type OIDCConfig {
+    clientID: String!
+    groupsClaim: String!
+    issuerURL: String!
+    signingAlgs: [String!]!
+    usernameClaim: String!
+    usernamePrefix: String!
+}
+*/
 func clusterConfig() string {
 	return fmt.Sprintf(`
 		name
@@ -88,6 +98,14 @@ func clusterConfig() string {
 		providerSpecificConfig {
 			%s
 		}
+        oidcConfig {
+			clientID
+			issuerURL
+			groupsClaim
+			signingAlgs
+			usernameClaim
+			usernamePrefix
+        }
 `, providerSpecificConfig())
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-892"
     kyma_environment_broker:
       dir:
-      version: "PR-834"
+      version: "PR-896"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-857"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- the kubeconfig endpoint fetches alsop oidc params from provisioner and put it to the result

