### PR TITLE
Configurable auto-update (maintenance) settings in KEB

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -350,11 +350,13 @@ func (f *InputBuilderFactory) initUpgradeShootInput(provider HyperscalerInputPro
 		input.GardenerConfig.MachineImageVersion = &f.config.MachineImageVersion
 	}
 
-	// sync with the autoscaler settings
+	// sync with the autoscaler and maintenance settings
 	input.GardenerConfig.AutoScalerMin = &provider.Defaults().GardenerConfig.AutoScalerMin
 	input.GardenerConfig.AutoScalerMax = &provider.Defaults().GardenerConfig.AutoScalerMax
 	input.GardenerConfig.MaxSurge = &provider.Defaults().GardenerConfig.MaxSurge
 	input.GardenerConfig.MaxUnavailable = &provider.Defaults().GardenerConfig.MaxUnavailable
+	input.GardenerConfig.EnableKubernetesVersionAutoUpdate = &f.config.AutoUpdateKubernetesVersion
+	input.GardenerConfig.EnableMachineImageVersionAutoUpdate = &f.config.AutoUpdateMachineImageVersion
 
 	return input
 }

--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -223,6 +223,8 @@ func (f *InputBuilderFactory) initProvisionRuntimeInput(provider HyperscalerInpu
 	}
 
 	provisionInput.ClusterConfig.GardenerConfig.KubernetesVersion = f.config.KubernetesVersion
+	provisionInput.ClusterConfig.GardenerConfig.EnableKubernetesVersionAutoUpdate = &f.config.AutoUpdateKubernetesVersion
+	provisionInput.ClusterConfig.GardenerConfig.EnableMachineImageVersionAutoUpdate = &f.config.AutoUpdateMachineImageVersion
 	if provisionInput.ClusterConfig.GardenerConfig.Purpose == nil {
 		provisionInput.ClusterConfig.GardenerConfig.Purpose = &f.config.DefaultGardenerShootPurpose
 	}

--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -20,15 +20,17 @@ const (
 )
 
 type Config struct {
-	URL                         string
-	ProvisioningTimeout         time.Duration          `envconfig:"default=6h"`
-	DeprovisioningTimeout       time.Duration          `envconfig:"default=5h"`
-	KubernetesVersion           string                 `envconfig:"default=1.16.9"`
-	DefaultGardenerShootPurpose string                 `envconfig:"default=development"`
-	MachineImage                string                 `envconfig:"optional"`
-	MachineImageVersion         string                 `envconfig:"optional"`
-	TrialNodesNumber            int                    `envconfig:"optional"`
-	DefaultTrialProvider        internal.CloudProvider `envconfig:"default=Azure"` // could be: Azure, AWS, GCP
+	URL                           string
+	ProvisioningTimeout           time.Duration          `envconfig:"default=6h"`
+	DeprovisioningTimeout         time.Duration          `envconfig:"default=5h"`
+	KubernetesVersion             string                 `envconfig:"default=1.16.9"`
+	DefaultGardenerShootPurpose   string                 `envconfig:"default=development"`
+	MachineImage                  string                 `envconfig:"optional"`
+	MachineImageVersion           string                 `envconfig:"optional"`
+	TrialNodesNumber              int                    `envconfig:"optional"`
+	DefaultTrialProvider          internal.CloudProvider `envconfig:"default=Azure"` // could be: Azure, AWS, GCP
+	AutoUpdateKubernetesVersion   bool                   `envconfig:"default=false"`
+	AutoUpdateMachineImageVersion bool                   `envconfig:"default=false"`
 }
 
 type RuntimeInput struct {

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -23,15 +23,17 @@ import (
 )
 
 const (
-	kymaVersion            = "1.10"
-	k8sVersion             = "1.16.9"
-	shootName              = "c-1234567"
-	instanceID             = "58f8c703-1756-48ab-9299-a847974d1fee"
-	operationID            = "fd5cee4d-0eeb-40d0-a7a7-0708e5eba470"
-	globalAccountID        = "80ac17bd-33e8-4ffa-8d56-1d5367755723"
-	subAccountID           = "12df5747-3efb-4df6-ad6f-4414bb661ce3"
-	provisionerOperationID = "1a0ed09b-9bb9-4e6f-a88c-01955c5f1129"
-	runtimeID              = "2498c8ee-803a-43c2-8194-6d6dd0354c30"
+	kymaVersion                   = "1.10"
+	k8sVersion                    = "1.16.9"
+	shootName                     = "c-1234567"
+	instanceID                    = "58f8c703-1756-48ab-9299-a847974d1fee"
+	operationID                   = "fd5cee4d-0eeb-40d0-a7a7-0708e5eba470"
+	globalAccountID               = "80ac17bd-33e8-4ffa-8d56-1d5367755723"
+	subAccountID                  = "12df5747-3efb-4df6-ad6f-4414bb661ce3"
+	provisionerOperationID        = "1a0ed09b-9bb9-4e6f-a88c-01955c5f1129"
+	runtimeID                     = "2498c8ee-803a-43c2-8194-6d6dd0354c30"
+	autoUpdateKubernetesVersion   = true
+	autoUpdateMachineImageVersion = true
 
 	serviceManagerURL      = "http://sm.com"
 	serviceManagerUser     = "admin"
@@ -70,21 +72,23 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 		},
 		ClusterConfig: &gqlschema.ClusterConfigInput{
 			GardenerConfig: &gqlschema.GardenerConfigInput{
-				Name:              shootName,
-				KubernetesVersion: k8sVersion,
-				DiskType:          ptr.String("pd-standard"),
-				VolumeSizeGb:      ptr.Integer(30),
-				MachineType:       "n1-standard-4",
-				Region:            "europe-west4-a",
-				Provider:          "gcp",
-				Purpose:           &shootPurpose,
-				LicenceType:       nil,
-				WorkerCidr:        "10.250.0.0/19",
-				AutoScalerMin:     3,
-				AutoScalerMax:     4,
-				MaxSurge:          4,
-				MaxUnavailable:    1,
-				TargetSecret:      "",
+				Name:                                shootName,
+				KubernetesVersion:                   k8sVersion,
+				DiskType:                            ptr.String("pd-standard"),
+				VolumeSizeGb:                        ptr.Integer(30),
+				MachineType:                         "n1-standard-4",
+				Region:                              "europe-west4-a",
+				Provider:                            "gcp",
+				Purpose:                             &shootPurpose,
+				LicenceType:                         nil,
+				WorkerCidr:                          "10.250.0.0/19",
+				AutoScalerMin:                       3,
+				AutoScalerMax:                       4,
+				MaxSurge:                            4,
+				MaxUnavailable:                      1,
+				TargetSecret:                        "",
+				EnableKubernetesVersionAutoUpdate:   ptr.Bool(autoUpdateKubernetesVersion),
+				EnableMachineImageVersionAutoUpdate: ptr.Bool(autoUpdateMachineImageVersion),
 				ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 					GcpConfig: &gqlschema.GCPProviderConfigInput{
 						Zones: []string{"europe-west4-b", "europe-west4-c"},
@@ -259,8 +263,10 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 	defer componentsProvider.AssertExpectations(t)
 
 	ibf, err := input.NewInputBuilderFactory(optComponentsSvc, runtime.NewDisabledComponentsProvider(), componentsProvider, input.Config{
-		KubernetesVersion:           k8sVersion,
-		DefaultGardenerShootPurpose: shootPurpose,
+		KubernetesVersion:             k8sVersion,
+		DefaultGardenerShootPurpose:   shootPurpose,
+		AutoUpdateKubernetesVersion:   autoUpdateKubernetesVersion,
+		AutoUpdateMachineImageVersion: autoUpdateMachineImageVersion,
 	}, kymaVersion, fixTrialRegionMapping(), fixFreemiumProviders(), fixture.FixOIDCConfigDTO())
 	assert.NoError(t, err)
 

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
@@ -130,12 +130,14 @@ func (s *UpgradeClusterStep) createUpgradeShootInput(operation internal.UpgradeC
 
 func gardenerUpgradeInputToConfigInput(input gqlschema.UpgradeShootInput) *gqlschema.GardenerConfigInput {
 	result := &gqlschema.GardenerConfigInput{
-		MachineImage:        input.GardenerConfig.MachineImage,
-		MachineImageVersion: input.GardenerConfig.MachineImageVersion,
-		DiskType:            input.GardenerConfig.DiskType,
-		VolumeSizeGb:        input.GardenerConfig.VolumeSizeGb,
-		Purpose:             input.GardenerConfig.Purpose,
-		OidcConfig:          input.GardenerConfig.OidcConfig,
+		MachineImage:                        input.GardenerConfig.MachineImage,
+		MachineImageVersion:                 input.GardenerConfig.MachineImageVersion,
+		DiskType:                            input.GardenerConfig.DiskType,
+		VolumeSizeGb:                        input.GardenerConfig.VolumeSizeGb,
+		Purpose:                             input.GardenerConfig.Purpose,
+		OidcConfig:                          input.GardenerConfig.OidcConfig,
+		EnableKubernetesVersionAutoUpdate:   input.GardenerConfig.EnableKubernetesVersionAutoUpdate,
+		EnableMachineImageVersionAutoUpdate: input.GardenerConfig.EnableMachineImageVersionAutoUpdate,
 	}
 	if input.GardenerConfig.KubernetesVersion != nil {
 		result.KubernetesVersion = *input.GardenerConfig.KubernetesVersion

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
@@ -19,10 +19,12 @@ import (
 )
 
 const (
-	fixKymaVersion         = "1.19.0"
-	fixKubernetesVersion   = "1.17.16"
-	fixMachineImage        = "gardenlinux"
-	fixMachineImageVersion = "184.0.0"
+	fixKymaVersion                   = "1.19.0"
+	fixKubernetesVersion             = "1.17.16"
+	fixMachineImage                  = "gardenlinux"
+	fixMachineImageVersion           = "184.0.0"
+	fixAutoUpdateKubernetesVersion   = true
+	fixAutoUpdateMachineImageVersion = true
 )
 
 func TestUpgradeKymaStep_Run(t *testing.T) {
@@ -46,13 +48,15 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 	provisionerClient := &provisionerAutomock.Client{}
 	provisionerClient.On("UpgradeShoot", fixGlobalAccountID, fixRuntimeID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
-			KubernetesVersion:   ptr.String(fixKubernetesVersion),
-			MachineImage:        ptr.String(fixMachineImage),
-			MachineImageVersion: ptr.String(fixMachineImageVersion),
-			AutoScalerMin:       operation.ProvisioningParameters.Parameters.AutoScalerMin,
-			AutoScalerMax:       operation.ProvisioningParameters.Parameters.AutoScalerMax,
-			MaxSurge:            operation.ProvisioningParameters.Parameters.MaxSurge,
-			MaxUnavailable:      operation.ProvisioningParameters.Parameters.MaxUnavailable,
+			KubernetesVersion:                   ptr.String(fixKubernetesVersion),
+			MachineImage:                        ptr.String(fixMachineImage),
+			MachineImageVersion:                 ptr.String(fixMachineImageVersion),
+			AutoScalerMin:                       operation.ProvisioningParameters.Parameters.AutoScalerMin,
+			AutoScalerMax:                       operation.ProvisioningParameters.Parameters.AutoScalerMax,
+			MaxSurge:                            operation.ProvisioningParameters.Parameters.MaxSurge,
+			MaxUnavailable:                      operation.ProvisioningParameters.Parameters.MaxUnavailable,
+			EnableKubernetesVersionAutoUpdate:   ptr.Bool(fixAutoUpdateKubernetesVersion),
+			EnableMachineImageVersionAutoUpdate: ptr.Bool(fixAutoUpdateMachineImageVersion),
 			OidcConfig: &gqlschema.OIDCConfigInput{
 				ClientID:       expectedOIDC.ClientID,
 				GroupsClaim:    expectedOIDC.GroupsClaim,
@@ -119,10 +123,12 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 	defer componentsProvider.AssertExpectations(t)
 
 	ibf, err := input.NewInputBuilderFactory(nil, nil, componentsProvider, input.Config{
-		KubernetesVersion:   fixKubernetesVersion,
-		MachineImage:        fixMachineImage,
-		MachineImageVersion: fixMachineImageVersion,
-		TrialNodesNumber:    1,
+		KubernetesVersion:             fixKubernetesVersion,
+		MachineImage:                  fixMachineImage,
+		MachineImageVersion:           fixMachineImageVersion,
+		TrialNodesNumber:              1,
+		AutoUpdateKubernetesVersion:   fixAutoUpdateKubernetesVersion,
+		AutoUpdateMachineImageVersion: fixAutoUpdateMachineImageVersion,
 	}, fixKymaVersion, nil, nil, fixture.FixOIDCConfigDTO())
 	require.NoError(t, err, "Input factory creation error")
 

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
@@ -94,6 +94,12 @@ func (g *Graphqlizer) GardenerConfigInputToGraphQL(in gqlschema.GardenerConfigIn
         autoScalerMax: {{ .AutoScalerMax }},
         maxSurge: {{ .MaxSurge }},
 		maxUnavailable: {{ .MaxUnavailable }},
+		{{- if .EnableKubernetesVersionAutoUpdate }}
+		enableKubernetesVersionAutoUpdate: {{ .EnableKubernetesVersionAutoUpdate }},
+		{{- end }}
+		{{- if .EnableMachineImageVersionAutoUpdate }}
+		enableMachineImageVersionAutoUpdate: {{ .EnableMachineImageVersionAutoUpdate }},
+		{{- end }}
 		{{- if .ProviderSpecificConfig }}
 		providerSpecificConfig: {
 			{{- if .ProviderSpecificConfig.AzureConfig }}

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer.go
@@ -241,10 +241,10 @@ func (g *Graphqlizer) GardenerUpgradeInputToGraphQL(in gqlschema.GardenerUpgrade
       maxUnavailable: {{ .MaxUnavailable }},
       {{- end }}
       {{- if .EnableKubernetesVersionAutoUpdate }}
-      enableKubernetesVersionAutoUpdate: {{.EnableKubernetesVersionAutoUpdate}},
+      enableKubernetesVersionAutoUpdate: {{ .EnableKubernetesVersionAutoUpdate }},
       {{- end }}
       {{- if .EnableMachineImageVersionAutoUpdate }}
-      enableMachineImageVersionAutoUpdate: {{.EnableMachineImageVersionAutoUpdate}},
+      enableMachineImageVersionAutoUpdate: {{ .EnableMachineImageVersionAutoUpdate }},
       {{- end }}
       {{- if .OidcConfig }}
       oidcConfig: {

--- a/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
+++ b/components/kyma-environment-broker/internal/provisioner/graphqlizer_test.go
@@ -151,24 +151,28 @@ func Test_GardenerConfigInputToGraphQL(t *testing.T) {
         autoScalerMax: 4,
         maxSurge: 4,
 		maxUnavailable: 1,
+		enableKubernetesVersionAutoUpdate: true,
+		enableMachineImageVersionAutoUpdate: true,
 	}`
 
 	// when
 	name := "c-90a3016"
 	got, err := sut.GardenerConfigInputToGraphQL(gqlschema.GardenerConfigInput{
-		Name:              name,
-		Region:            "europe",
-		VolumeSizeGb:      ptr.Integer(50),
-		WorkerCidr:        "10.250.0.0/19",
-		Provider:          "Azure",
-		DiskType:          ptr.String("Standard_LRS"),
-		TargetSecret:      "scr",
-		MachineType:       "Standard_D4_v3",
-		KubernetesVersion: "1.18",
-		AutoScalerMin:     2,
-		AutoScalerMax:     4,
-		MaxSurge:          4,
-		MaxUnavailable:    1,
+		Name:                                name,
+		Region:                              "europe",
+		VolumeSizeGb:                        ptr.Integer(50),
+		WorkerCidr:                          "10.250.0.0/19",
+		Provider:                            "Azure",
+		DiskType:                            ptr.String("Standard_LRS"),
+		TargetSecret:                        "scr",
+		MachineType:                         "Standard_D4_v3",
+		KubernetesVersion:                   "1.18",
+		AutoScalerMin:                       2,
+		AutoScalerMax:                       4,
+		MaxSurge:                            4,
+		MaxUnavailable:                      1,
+		EnableKubernetesVersionAutoUpdate:   ptr.Bool(true),
+		EnableMachineImageVersionAutoUpdate: ptr.Bool(true),
 	})
 
 	// then

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -322,6 +322,10 @@ spec:
               value: {{ .Values.gardener.machineImageVersion }}
             - name: APP_PROVISIONER_TRIAL_NODES_NUMBER
               value: "{{ .Values.gardener.trialNodesNumber }}"
+            - name: APP_PROVISIONER_AUTO_UPDATE_KUBERNETES_VERSION
+              value: "{{ .Values.gardener.autoUpdateKubernetesVersion }}"
+            - name: APP_PROVISIONER_AUTO_UPDATE_MACHINE_IMAGE_VERSION
+              value: "{{ .Values.gardener.autoUpdateMachineImageVersion }}"
             - name: APP_DEFAULT_REQUEST_REGION
               value: "{{ .Values.broker.defaultRequestRegion }}"
             - name: APP_UPDATE_PROCESSING_ENABLED

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -106,6 +106,8 @@ gardener:
   trialNodesNumber: "1"
   freemiumProviders: "azure,aws"
   defaultTrialProvider: "Azure" # Azure, AWS
+  autoUpdateKubernetesVersion: "true"
+  autoUpdateMachineImageVersion: "false"
 
 kubeconfig:
   issuerURL: "TBD"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-892"
     kyma_environment_broker:
       dir:
-      version: "PR-896"
+      version: "PR-907"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-857"


### PR DESCRIPTION
**Description**

Introduce configuration for K8S version and machine image version auto-upgrade Gardener/provisioner parameters in KEB. 
Currently provision applies default values for these parameters, which have changed over time and not provisioner reapplies inconsistent settings from it's DB over the runtimes upon every upgrade orchestration.
