### PR TITLE
Update Runtime Provisioner's documentation

### DIFF
--- a/components/provisioner/README.md
+++ b/components/provisioner/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you can choose whether to provision a cluster with Kyma (Kyma Runtime), by providing **kymaConfig**, or not.
+Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you have an option to provision a cluster with Kyma (Kyma Runtime), or without it. To provision a Kyma Runtime, provide its configuration as **kymaConfig**.
 
 For more details, see the Runtime Provisioner [documentation](https://github.com/kyma-project/control-plane/tree/main/docs/provisioner).
 

--- a/components/provisioner/README.md
+++ b/components/provisioner/README.md
@@ -2,19 +2,19 @@
 
 ## Overview
 
-The Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters with Kyma (Kyma Runtimes). The relationship between clusters and Runtimes is 1:1.
+Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. You can provision empty clusters or clusters with Kyma (Kyma Runtimes).
 
 For more details, see the Runtime Provisioner [documentation](https://github.com/kyma-project/control-plane/tree/main/docs/provisioner).
 
 ## Prerequisites
 
-Before you can run the Runtime Provisioner, you have to configure access to the PostgreSQL database. For development purposes, you can run a PostgreSQL instance in the Docker container executing the following command:
+Before you can run Runtime Provisioner, you have to configure access to the PostgreSQL database. For development purposes, you can run a PostgreSQL instance in the Docker container executing the following command:
 
 ```bash
 $ docker run --rm -p 5432:5432 -e POSTGRES_PASSWORD=password postgres
 ```
 
-The Runtime Provisioner also needs access to the cluster from which it fetches Secrets.  
+Runtime Provisioner also needs access to the cluster from which it fetches Secrets.  
 
 ## Development
 
@@ -28,7 +28,7 @@ For tests to run properly, update the database schema in `./assets/database/prov
 
 ### Run Provisioner
 
-To run the Runtime Provisioner, use the following command:
+To run Runtime Provisioner, use the following command:
 ```bash
 go run cmd/main.go
 ```

--- a/components/provisioner/README.md
+++ b/components/provisioner/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. You can provision empty clusters or clusters with Kyma (Kyma Runtimes).
+Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you can choose whether to provision a cluster with Kyma (Kyma Runtime), by providing **kymaConfig**, or not.
 
 For more details, see the Runtime Provisioner [documentation](https://github.com/kyma-project/control-plane/tree/main/docs/provisioner).
 

--- a/docs/provisioner/01-01-provisioner-overview.md
+++ b/docs/provisioner/01-01-provisioner-overview.md
@@ -3,7 +3,7 @@ title: Overview
 type: Overview
 ---
 
-The Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters with Kyma (Kyma Runtimes). The relationship between clusters and Runtimes is 1:1. The Runtime Provisioner is registered in Compass in the Director as an Integration System.
+Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. You can provision empty clusters or clusters with Kyma (Kyma Runtimes). Runtime Provisioner is registered in Compass in Director as an Integration System.
 
 It allows you to provision the clusters in the following ways:
 - [through Gardener](#tutorials-provision-clusters-through-gardener) on:
@@ -15,7 +15,11 @@ During the operation of provisioning, you can pass a list of Kyma components you
 
 Note that the operations of provisioning and deprovisioning are asynchronous. The operation of provisioning returns the Runtime Operation Status containing the Runtime ID and the operation ID. The operation of deprovisioning returns the operation ID. You can use the operation ID to [check the Runtime Operation Status](#tutorials-check-runtime-operation-status) and the Runtime ID to [check the Runtime Status](#tutorials-check-runtime-status).
 
-The Runtime Provisioner exposes an API to manage cluster provisioning, installation, and deprovisioning.
+Runtime Provisioner also provides extensions that let you leverage Gardener [DNS](https://github.com/gardener/external-dns-management) and [certificate management](https://github.com/gardener/cert-management). See the respective documentation for more details.
+
+  > **NOTE:** To take advantage of these extensions, you must have [`cert-management`](https://github.com/gardener/cert-management) and [`external-dns-management`](https://github.com/gardener/external-dns-management) installed. If you are not using Gardener for provisioning, see the components` documentation to learn how to install them. If you're using Gardener, the components are already included.
+
+Runtime Provisioner exposes an API to manage cluster provisioning, installation, and deprovisioning.
 
 Find the specification of the API [here](https://github.com/kyma-project/control-plane/blob/main/components/provisioner/pkg/gqlschema/schema.graphql).
 

--- a/docs/provisioner/01-01-provisioner-overview.md
+++ b/docs/provisioner/01-01-provisioner-overview.md
@@ -17,8 +17,6 @@ Note that the operations of provisioning and deprovisioning are asynchronous. Th
 
 Runtime Provisioner also provides extensions that let you leverage Gardener [DNS](https://github.com/gardener/external-dns-management) and [certificate management](https://github.com/gardener/cert-management). See the respective documentation for more details.
 
-  > **NOTE:** To take advantage of these extensions, you must have [`cert-management`](https://github.com/gardener/cert-management) and [`external-dns-management`](https://github.com/gardener/external-dns-management) installed. If you are not using Gardener for provisioning, see the components` documentation to learn how to install them. If you're using Gardener, the components are already included.
-
 Runtime Provisioner exposes an API to manage cluster provisioning, installation, and deprovisioning.
 
 Find the specification of the API [here](https://github.com/kyma-project/control-plane/blob/main/components/provisioner/pkg/gqlschema/schema.graphql).

--- a/docs/provisioner/01-01-provisioner-overview.md
+++ b/docs/provisioner/01-01-provisioner-overview.md
@@ -3,7 +3,8 @@ title: Overview
 type: Overview
 ---
 
-Runtime Provisioner is a Kyma Control Plane component registered in Compass in Director as an Integration System. It is responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you have an option to provision a cluster with Kyma (Kyma Runtime), or without it. To provision a Kyma Runtime, provide its configuration as **kymaConfig**.
+Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you have an option to provision a cluster with Kyma (Kyma Runtime), or without it. To provision a Kyma Runtime, provide its configuration as **kymaConfig**. 
+Runtime Provisioner is registered in Compass in Director as an Integration System.
 
 It allows you to provision the clusters in the following ways:
 - [through Gardener](#tutorials-provision-clusters-through-gardener) on:

--- a/docs/provisioner/01-01-provisioner-overview.md
+++ b/docs/provisioner/01-01-provisioner-overview.md
@@ -3,7 +3,7 @@ title: Overview
 type: Overview
 ---
 
-Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you can choose whether to provision a cluster with Kyma (Kyma Runtime), by providing **kymaConfig**, or not. Runtime Provisioner is registered in Compass in Director as an Integration System.
+Runtime Provisioner is a Kyma Control Plane component registered in Compass in Director as an Integration System. It is responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you have an option to provision a cluster with Kyma (Kyma Runtime), or without it. To provision a Kyma Runtime, provide its configuration as **kymaConfig**.
 
 It allows you to provision the clusters in the following ways:
 - [through Gardener](#tutorials-provision-clusters-through-gardener) on:

--- a/docs/provisioner/01-01-provisioner-overview.md
+++ b/docs/provisioner/01-01-provisioner-overview.md
@@ -3,7 +3,7 @@ title: Overview
 type: Overview
 ---
 
-Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. You can provision empty clusters or clusters with Kyma (Kyma Runtimes). Runtime Provisioner is registered in Compass in Director as an Integration System.
+Runtime Provisioner is a Kyma Control Plane component responsible for provisioning, installing, and deprovisioning clusters. When provisioning a cluster, you can choose whether to provision a cluster with Kyma (Kyma Runtime), by providing **kymaConfig**, or not. Runtime Provisioner is registered in Compass in Director as an Integration System.
 
 It allows you to provision the clusters in the following ways:
 - [through Gardener](#tutorials-provision-clusters-through-gardener) on:

--- a/docs/provisioner/05-01-app-entry-parameters.md
+++ b/docs/provisioner/05-01-app-entry-parameters.md
@@ -3,7 +3,7 @@ title: Provisioner chart
 type: Configuration
 ---
 
-To configure Runtime Provisioner chart, override the default values of its `values.yaml` file. This document describes the parameters that you can configure.
+To configure the Runtime Provisioner chart, override the default values of its `values.yaml` file. This document describes the parameters that you can configure.
 
 >**TIP:** To learn more about how to use overrides in Kyma, see [Helm overrides for Kyma installation](/root/kyma#configuration-helm-overrides-for-kyma-installation).
 

--- a/docs/provisioner/05-01-app-entry-parameters.md
+++ b/docs/provisioner/05-01-app-entry-parameters.md
@@ -3,7 +3,7 @@ title: Provisioner chart
 type: Configuration
 ---
 
-To configure the Runtime Provisioner chart, override the default values of its `values.yaml` file. This document describes the parameters that you can configure.
+To configure Runtime Provisioner chart, override the default values of its `values.yaml` file. This document describes the parameters that you can configure.
 
 >**TIP:** To learn more about how to use overrides in Kyma, see [Helm overrides for Kyma installation](/root/kyma#configuration-helm-overrides-for-kyma-installation).
 

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -136,8 +136,8 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 providerSpecificConfig: { gcpConfig: { zones: ["europe-west4-a"] } }
               }
             }
-            kymaConfig: {
-              version: "1.12.0"
+            kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+              version: "1.24.5"
               profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
               components: [
                 { component: "compass-runtime-agent", namespace: "compass-system" }
@@ -232,8 +232,8 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 providerSpecificConfig: { azureConfig: { vnetCidr: "10.250.0.0/19", zones: ["1", "2"] } }
               }
             }
-            kymaConfig: {
-              version: "1.12.0"
+            kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+              version: "1.24.5"
               profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
               components: [
                 { component: "compass-runtime-agent", namespace: "compass-system" }
@@ -342,8 +342,8 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 }
               }
             }
-            kymaConfig: {
-              version: "1.12.0"
+            kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+              version: "1.24.5"
               profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
               components: [
                 { component: "compass-runtime-agent", namespace: "compass-system" }
@@ -442,8 +442,8 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                    }
                 }
               }
-              kymaConfig: {
-                version: "1.12.0"
+              kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+                version: "1.24.5"
                 profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
                 components: [
                   { component: "compass-runtime-agent", namespace: "compass-system" }

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -136,7 +136,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 providerSpecificConfig: { gcpConfig: { zones: ["europe-west4-a"] } }
               }
             }
-            kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+            kymaConfig: { # Optional; if you don't provide it, a cluster without Kyma is provisioned
               version: "1.24.5"
               profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
               components: [
@@ -232,7 +232,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 providerSpecificConfig: { azureConfig: { vnetCidr: "10.250.0.0/19", zones: ["1", "2"] } }
               }
             }
-            kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+            kymaConfig: { # Optional; if you don't provide it, a cluster without Kyma is provisioned
               version: "1.24.5"
               profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
               components: [
@@ -342,7 +342,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                 }
               }
             }
-            kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+            kymaConfig: { # Optional; if you don't provide it, a cluster without Kyma is provisioned
               version: "1.24.5"
               profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
               components: [
@@ -442,7 +442,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
                    }
                 }
               }
-              kymaConfig: { # Optional; if you don't provide it, an empty cluster without Kyma is provisioned
+              kymaConfig: { # Optional; if you don't provide it, a cluster without Kyma is provisioned
                 version: "1.24.5"
                 profile: "Evaluation" # Optional resources profile; possible values: "Evaluation", "Production"
                 components: [

--- a/docs/provisioner/08-02-provisioning-gardener.md
+++ b/docs/provisioner/08-02-provisioning-gardener.md
@@ -85,7 +85,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
   
 </div>
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.   
+> **NOTE:** To access Runtime Provisioner, forward the port on which the GraphQL server is listening.   
 
 ## Steps
 
@@ -103,7 +103,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
 
   3. In the **Members** tab, create a service account for Gardener. 
     
-  4. Make a call to the Runtime Provisioner with a **tenant** header to create a cluster on GCP. 
+  4. Make a call to Runtime Provisioner with a **tenant** header to create a cluster on GCP. 
     
      > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                           
@@ -199,7 +199,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
 
   3. In the **Members** tab, create a service account for Gardener. 
 
-  4. Make a call to the Runtime Provisioner with a **tenant** header to create a cluster on Azure.
+  4. Make a call to Runtime Provisioner with a **tenant** header to create a cluster on Azure.
   
      > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                           
@@ -295,7 +295,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
     
   3. In the **Members** tab, create a service account for Gardener. 
 
-  4. Make a call to the Runtime Provisioner with a **tenant** header to create a cluster on AWS. 
+  4. Make a call to Runtime Provisioner with a **tenant** header to create a cluster on AWS. 
   
      > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                           
@@ -404,7 +404,7 @@ This tutorial shows how to provision clusters with Kyma Runtimes on Google Cloud
   
    3. In the **Members** tab, create a service account for Gardener. 
       
-   4. Make a call to the Runtime Provisioner with a **tenant** header to create a cluster on OpenStack. 
+   4. Make a call to Runtime Provisioner with a **tenant** header to create a cluster on OpenStack. 
       
        > **NOTE:** The Runtime Agent component (`compass-runtime-agent`) in the Kyma configuration is mandatory and the order of the components matters.
                                                                             

--- a/docs/provisioner/08-03-runtime-operation-status.md
+++ b/docs/provisioner/08-03-runtime-operation-status.md
@@ -7,9 +7,9 @@ This tutorial shows how to check the Runtime operation status for the operations
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
+> **NOTE:** To access Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
-Make a call to the Runtime Provisioner with a **tenant** header to verify that provisioning/deprovisioning succeeded. Pass the ID of the operation as `id`.
+Make a call to Runtime Provisioner with a **tenant** header to verify that provisioning/deprovisioning succeeded. Pass the ID of the operation as `id`.
 
 ```graphql
 query { 

--- a/docs/provisioner/08-04-runtime-status.md
+++ b/docs/provisioner/08-04-runtime-status.md
@@ -7,9 +7,9 @@ This tutorial shows how to check the Runtime status.
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
+> **NOTE:** To access Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
-Make a call to the Runtime Provisioner with a **tenant** header to check the Runtime status. Pass the Runtime ID as `id`. 
+Make a call to Runtime Provisioner with a **tenant** header to check the Runtime status. Pass the Runtime ID as `id`. 
 
 ```graphql
 query { runtimeStatus(id: "{RUNTIME_ID}") {

--- a/docs/provisioner/08-05-deprovisioning.md
+++ b/docs/provisioner/08-05-deprovisioning.md
@@ -7,9 +7,9 @@ This tutorial shows how to deprovision clusters with Kyma Runtimes.
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
+> **NOTE:** To access Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
-To deprovision a Runtime, make a call to the Runtime Provisioner with a **tenant** header using a mutation like this:  
+To deprovision a Runtime, make a call to Runtime Provisioner with a **tenant** header using a mutation like this:  
   
 ```graphql
 mutation { deprovisionRuntime(id: "61d1841b-ccb5-44ed-a9ec-45f70cd1b0d3") }

--- a/docs/provisioner/08-06-upgrading-shoots.md
+++ b/docs/provisioner/08-06-upgrading-shoots.md
@@ -7,9 +7,9 @@ This tutorial shows how to upgrade Gardener Shoot clusters for Kyma Runtimes.
 
 ## Steps
 
-> **NOTE:** To access the Runtime Provisioner, forward the port on which the GraphQL server is listening.
+> **NOTE:** To access Runtime Provisioner, forward the port on which the GraphQL server is listening.
 
-To upgrade a Gardener Shoot cluster used to host the Runtime of a given ID, make a call to the Runtime Provisioner with a **tenant** header using a mutation like this:  
+To upgrade a Gardener Shoot cluster used to host the Runtime of a given ID, make a call to Runtime Provisioner with a **tenant** header using a mutation like this:  
 
 ```graphql
 mutation { 


### PR DESCRIPTION
**Description**

Runtime Provisioner can now provision clusters without installing Kyma. 
Apart from that, it now also includes configuration to leverage Gardener [DNS](https://github.com/gardener/external-dns-management) and [certificate management](https://github.com/gardener/cert-management). 
Because of these changes, its documentation must be updated. 

Changes proposed in this pull request:

- Update info on provisioning clusters - state that provisioning with Kyma installation is optional
- Add info about extensions to leverage Gardener DNS and cert management
- Remove the definite article `the` from Runtime Provisioner's name

**Related issues**
#875 
#876

**Related PRs**
#887
#909 

