### PR TITLE
Update endpoint for autoscaler options for KEB

### DIFF
--- a/components/kyma-environment-broker/internal/dto.go
+++ b/components/kyma-environment-broker/internal/dto.go
@@ -102,6 +102,31 @@ type ProvisioningParametersDTO struct {
 type UpdatingParametersDTO struct {
 	OIDC                  *OIDCConfigDTO `json:"oidc,omitempty"`
 	RuntimeAdministrators []string       `json:"administrators,omitempty"`
+	AutoScalerMin         *int           `json:"autoScalerMin"`
+	AutoScalerMax         *int           `json:"autoScalerMax"`
+	MaxSurge              *int           `json:"maxSurge"`
+	MaxUnavailable        *int           `json:"maxUnavailable"`
+}
+
+func (u UpdatingParametersDTO) UpdateAutoScaler(p *ProvisioningParametersDTO) bool {
+	updated := false
+	if u.AutoScalerMin != nil {
+		updated = true
+		p.AutoScalerMin = u.AutoScalerMin
+	}
+	if u.AutoScalerMax != nil {
+		updated = true
+		p.AutoScalerMax = u.AutoScalerMax
+	}
+	if u.MaxSurge != nil {
+		updated = true
+		p.MaxSurge = u.MaxSurge
+	}
+	if u.MaxUnavailable != nil {
+		updated = true
+		p.MaxUnavailable = u.MaxUnavailable
+	}
+	return updated
 }
 
 type ERSContext struct {

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -469,6 +469,8 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 		op.ProvisioningParameters.Parameters.RuntimeAdministrators = updatingParams.RuntimeAdministrators
 	}
 
+	updatingParams.UpdateAutoScaler(&op.ProvisioningParameters.Parameters)
+
 	return op
 }
 

--- a/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
+++ b/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
@@ -94,7 +94,11 @@ func (s *UpgradeShootStep) createUpgradeShootInput(operation internal.UpdatingOp
 	// modify configuration
 	result := gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
-			OidcConfig: fullInput.GardenerConfig.OidcConfig,
+			OidcConfig:     fullInput.GardenerConfig.OidcConfig,
+			AutoScalerMax:  operation.UpdatingParameters.AutoScalerMax,
+			AutoScalerMin:  operation.UpdatingParameters.AutoScalerMin,
+			MaxSurge:       operation.UpdatingParameters.MaxSurge,
+			MaxUnavailable: operation.UpdatingParameters.MaxUnavailable,
 		},
 		Administrators: fullInput.Administrators,
 	}

--- a/resources/kcp/charts/kyma-environment-broker/files/swagger.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/files/swagger.yaml
@@ -1971,9 +1971,25 @@ components:
           format: uuid
           example: 054ac2c2-318f-45dd-855c-eee41513d40d
         parameters:
-          $ref: '#/components/schemas/Object'
+          $ref: '#/components/schemas/ServiceInstanceUpdateRequestParams'
         previous_values:
           $ref: '#/components/schemas/ServiceInstancePreviousValues'
+    
+    ServiceInstanceUpdateRequestParams:
+      type: object
+      properties:
+        autoScalerMin:
+          type: int
+          example: 3
+        autoScalerMax:
+          type: int
+          example: 10
+        maxSurge:
+          type: int
+          example: 2
+        maxUnavailable:
+          type: int
+          example: 2
 
     ServiceInstancePreviousValues:
       type: object

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-909"
     kyma_environment_broker:
       dir:
-      version: "PR-930"
+      version: "PR-920"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-930"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Enhance KEB instance update endpoint to allow users to modify autoscaler parameters

Sample test using port-forwarded deployment:
```
instance=test-jw34
curl -XPATCH "localhost:8080/oauth/v2/service_instances/$instance?accepts_incomplete=true" -i \
    -H "X-Broker-API-Version: 2.14" \
    -H "Content-Type: application/json" \
    --data-binary @- << EOF
{
   "service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281",
   "plan_id":"4deee563-e5ec-4731-b9b1-53b42d855f0c",
   "context":{
       "globalaccount_id":"***",
       "subaccount_id":"***",
       "user_id":"jan.wozniak@sap.com"
   },
   "parameters":{
       "name":"$instance",
       "autoScalerMin": 10,
       "autoScalerMax": 11,
       "maxSurge": 12,
       "maxUnavailable": 13
   }
}
EOF
```

and then connecting to the broker SQL database
```
broker=> select type, finished_stages, provisioning_parameters from operations where instance_id='test-jw34' order by created_at desc limit 5;
   type    |    finished_stages    |   provisioning_parameters
-----------+-----------------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 update    |                       | {"plan_id":"4deee563-e5ec-4731-b9b1-53b42d855f0c","service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281","ers_context":{"tenant_id":"","subaccount_id":"***","globalaccount_id":"***","active":true,"user_id":"jan.wozniak@sap.com"},"parameters":{"name":"test-jw34","targetSecret":null,"volumeSizeGb":null,"machineType":null,"region":null,"purpose":null,"licence_type":null,"zones":null,"zonesCount":null,"autoScalerMin":10,"autoScalerMax":11,"maxSurge":12,"maxUnavailable":13,"components":null,"kymaVersion":"","overridesVersion":"","administrators":null,"provider":null},"platform_region":"cf-eu10","platform_provider":"unknown"}
 provision | ,start,create_runtime | {"plan_id":"4deee563-e5ec-4731-b9b1-53b42d855f0c","service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281","ers_context":{"tenant_id":"","subaccount_id":"***","globalaccount_id":"***","user_id":"jan.wozniak@sap.com"},"parameters":{"name":"test-jw34","targetSecret":"sap-skr-dev-cust-00002-kyma-integration","volumeSizeGb":null,"machineType":null,"region":null,"purpose":null,"licence_type":null,"zones":null,"zonesCount":null,"autoScalerMin":5,"autoScalerMax":7,"maxSurge":3,"maxUnavailable":4,"components":null,"kymaVersion":"","overridesVersion":"","administrators":null,"provider":null},"platform_region":"cf-eu10","platform_provider":"unknown"}
```
in the `provisioning_parameters`, the values were updated:
* `autoScalerMin` 5 => 11
* `autoScalerMax` 7 => 12
* `maxSurge` 3 => 13
* `maxUnavailable` 4 => 14

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
