### PR TITLE
Adjust HA plans and AWS supported zones

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -154,7 +154,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
-			expectedMachineType:                "Standard_D4_v3",
+			expectedMachineType:                "Standard_D8_v3",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
 			expectedProvider:                   "azure",
 			expectedSharedSubscription:         false,
@@ -165,7 +165,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
-			expectedMachineType:                "Standard_D4_v3",
+			expectedMachineType:                "Standard_D8_v3",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
 			expectedProvider:                   "azure",
 			expectedSharedSubscription:         false,
@@ -189,7 +189,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
-			expectedMachineType:                "m5.xlarge",
+			expectedMachineType:                "m5.2xlarge",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
 			expectedProvider:                   "aws",
 			expectedSharedSubscription:         false,
@@ -201,7 +201,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
-			expectedMachineType:                "m5.xlarge",
+			expectedMachineType:                "m5.2xlarge",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
 			expectedProvider:                   "aws",
 			expectedSharedSubscription:         false,

--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -152,7 +152,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			planID:     broker.AzureHAPlanID,
 			zonesCount: ptr.Integer(3),
 
-			expectedMinimalNumberOfNodes:       4,
+			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
 			expectedMachineType:                "Standard_D4_v3",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
@@ -163,7 +163,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 		"HA Azure - default zonesCount": {
 			planID: broker.AzureHAPlanID,
 
-			expectedMinimalNumberOfNodes:       4,
+			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
 			expectedMachineType:                "Standard_D4_v3",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
@@ -187,9 +187,9 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			zonesCount: ptr.Integer(3),
 			region:     "us-east-1",
 
-			expectedMinimalNumberOfNodes:       4,
+			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
-			expectedMachineType:                "m5d.xlarge",
+			expectedMachineType:                "m5.xlarge",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
 			expectedProvider:                   "aws",
 			expectedSharedSubscription:         false,
@@ -197,11 +197,11 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 		},
 		"HA AWS - default zonesCount": {
 			planID: broker.AWSHAPlanID,
-			region: "us-west-1",
+			region: "eu-central-1",
 
-			expectedMinimalNumberOfNodes:       4,
+			expectedMinimalNumberOfNodes:       1,
 			expectedMaximumNumberOfNodes:       10,
-			expectedMachineType:                "m5d.xlarge",
+			expectedMachineType:                "m5.xlarge",
 			expectedProfile:                    gqlschema.KymaProfileProduction,
 			expectedProvider:                   "aws",
 			expectedSharedSubscription:         false,

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -307,7 +307,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AWSHASchema([]string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"}),
+			provisioningRawSchema: AWSHASchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"}),
 		},
 		GCPPlanID: {
 			PlanDefinition: domain.ServicePlan{
@@ -403,7 +403,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AzureHASchema([]string{"Standard_D4_v3", "Standard_D8_v3"}),
+			provisioningRawSchema: AzureHASchema([]string{"Standard_D8_v3"}),
 		},
 		TrialPlanID: {
 			PlanDefinition: domain.ServicePlan{

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -148,19 +148,19 @@ func AWSHASchema(machineTypes []string) []byte {
 	properties := NewProvisioningProperties(machineTypes, AWSRegions())
 	properties.ZonesCount = &Type{
 		Type:        "integer",
-		Minimum:     2,
+		Minimum:     3,
 		Maximum:     3,
-		Default:     2,
+		Default:     3,
 		Description: "Specifies the number of availability zones for HA cluster",
 	}
 	awsHaControlsOrder := DefaultControlsOrder()
 	awsHaControlsOrder = append(awsHaControlsOrder, "zonesCount")
 	schema := NewSchema(properties, awsHaControlsOrder)
 
-	properties.AutoScalerMin.Default = 4
-	properties.AutoScalerMin.Minimum = 4
+	properties.AutoScalerMin.Default = 1
+	properties.AutoScalerMin.Minimum = 1
 
-	properties.AutoScalerMax.Minimum = 4
+	properties.AutoScalerMax.Minimum = 1
 
 	bytes, err := json.Marshal(schema)
 	if err != nil {
@@ -225,19 +225,19 @@ func AzureHASchema(machineTypes []string) []byte {
 	properties := NewProvisioningProperties(machineTypes, AzureRegions())
 	properties.ZonesCount = &Type{
 		Type:        "integer",
-		Minimum:     2,
+		Minimum:     3,
 		Maximum:     3,
-		Default:     2,
+		Default:     3,
 		Description: "Specifies the number of availability zones for HA cluster",
 	}
 	azureHaControlsOrder := DefaultControlsOrder()
 	azureHaControlsOrder = append(azureHaControlsOrder, "zonesCount")
 	schema := NewSchema(properties, azureHaControlsOrder)
 
-	properties.AutoScalerMin.Default = 4
-	properties.AutoScalerMin.Minimum = 4
+	properties.AutoScalerMin.Default = 1
+	properties.AutoScalerMin.Minimum = 1
 
-	properties.AutoScalerMax.Minimum = 4
+	properties.AutoScalerMax.Minimum = 1
 
 	bytes, err := json.Marshal(schema)
 	if err != nil {
@@ -297,7 +297,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AWSHASchema([]string{"m5d.xlarge"}),
+			provisioningRawSchema: AWSHASchema([]string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"}),
 		},
 		GCPPlanID: {
 			PlanDefinition: domain.ServicePlan{
@@ -393,7 +393,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider) map[string]Plan {
 					},
 				},
 			},
-			provisioningRawSchema: AzureHASchema([]string{"Standard_D4_v3"}),
+			provisioningRawSchema: AzureHASchema([]string{"Standard_D4_v3", "Standard_D8_v3"}),
 		},
 		TrialPlanID: {
 			PlanDefinition: domain.ServicePlan{

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -107,6 +107,12 @@ func AWSRegions() []string {
 		"ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2"}
 }
 
+func AWSHARegions() []string {
+	// be aware of zones defined in internal/provider/aws_provider.go
+	return []string{"eu-central-1", "eu-west-2", "ca-central-1", "sa-east-1", "us-east-1",
+		"ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2"}
+}
+
 func OpenStackRegions() []string {
 	return []string{"eu-de-1", "ap-sa-1"}
 }
@@ -145,7 +151,7 @@ func AWSSchema(machineTypes []string) []byte {
 }
 
 func AWSHASchema(machineTypes []string) []byte {
-	properties := NewProvisioningProperties(machineTypes, AWSRegions())
+	properties := NewProvisioningProperties(machineTypes, AWSHARegions())
 	properties.ZonesCount = &Type{
 		Type:        "integer",
 		Minimum:     3,
@@ -159,8 +165,10 @@ func AWSHASchema(machineTypes []string) []byte {
 
 	properties.AutoScalerMin.Default = 1
 	properties.AutoScalerMin.Minimum = 1
+	properties.AutoScalerMin.Description = "Specifies the minimum number of virtual machines to create per zone"
 
 	properties.AutoScalerMax.Minimum = 1
+	properties.AutoScalerMax.Description = "Specifies the maximum number of virtual machines to create per zone"
 
 	bytes, err := json.Marshal(schema)
 	if err != nil {
@@ -236,8 +244,10 @@ func AzureHASchema(machineTypes []string) []byte {
 
 	properties.AutoScalerMin.Default = 1
 	properties.AutoScalerMin.Minimum = 1
+	properties.AutoScalerMin.Description = "Specifies the minimum number of virtual machines to create per zone"
 
 	properties.AutoScalerMax.Minimum = 1
+	properties.AutoScalerMax.Description = "Specifies the maximum number of virtual machines to create per zone"
 
 	bytes, err := json.Marshal(schema)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -29,7 +29,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:         "AWS HA schema is correct",
 			generator:    AWSHASchema,
-			machineTypes: []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
+			machineTypes: []string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
 			file:         "aws-ha-schema.json",
 		},
 		{
@@ -47,7 +47,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:         "AzureHA schema is correct",
 			generator:    AzureHASchema,
-			machineTypes: []string{"Standard_D4_v3", "Standard_D8_v3"},
+			machineTypes: []string{"Standard_D8_v3"},
 			file:         "azure-ha-schema.json",
 		},
 		{

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -29,7 +29,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:         "AWS HA schema is correct",
 			generator:    AWSHASchema,
-			machineTypes: []string{"m5d.xlarge"},
+			machineTypes: []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
 			file:         "aws-ha-schema.json",
 		},
 		{
@@ -47,7 +47,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:         "AzureHA schema is correct",
 			generator:    AzureHASchema,
-			machineTypes: []string{"Standard_D4_v3"},
+			machineTypes: []string{"Standard_D4_v3", "Standard_D8_v3"},
 			file:         "azure-ha-schema.json",
 		},
 		{

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
@@ -20,7 +20,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
+      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
@@ -15,32 +15,32 @@
     },
     "region": {
       "type": "string",
-      "enum": ["eu-central-1", "eu-west-2", "ca-central-1", "sa-east-1", "us-east-1", "us-west-1",
+      "enum": ["eu-central-1", "eu-west-2", "ca-central-1", "sa-east-1", "us-east-1",
         "ap-northeast-1", "ap-northeast-2", "ap-south-1", "ap-southeast-1", "ap-southeast-2"]
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5d.xlarge"]
+      "enum": ["m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",
-      "description": "Specifies the minimum number of virtual machines to create",
-      "minimum": 4,
-      "default": 4
+      "description": "Specifies the minimum number of virtual machines to create per zone",
+      "minimum": 1,
+      "default": 1
     },
     "autoScalerMax": {
       "type": "integer",
-      "description": "Specifies the maximum number of virtual machines to create",
-      "minimum": 4,
+      "description": "Specifies the maximum number of virtual machines to create per zone",
+      "minimum": 1,
       "maximum": 40,
       "default": 10
     },
     "zonesCount": {
       "type": "integer",
       "description": "Specifies the number of availability zones for HA cluster",
-      "minimum": 2,
+      "minimum": 3,
       "maximum": 3,
-      "default": 2
+      "default": 3
     }},
   "required": [
     "name"

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
@@ -19,27 +19,27 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["Standard_D4_v3"]
+      "enum": ["Standard_D4_v3", "Standard_D8_v3"]
     },
     "autoScalerMin": {
       "type": "integer",
-      "description": "Specifies the minimum number of virtual machines to create",
-      "minimum": 4,
-      "default": 4
+      "description": "Specifies the minimum number of virtual machines to create per zone",
+      "minimum": 1,
+      "default": 1
     },
     "autoScalerMax": {
       "type": "integer",
-      "description": "Specifies the maximum number of virtual machines to create",
-      "minimum": 4,
+      "description": "Specifies the maximum number of virtual machines to create per zone",
+      "minimum": 1,
       "maximum": 40,
       "default": 10
     },
     "zonesCount": {
       "type": "integer",
       "description": "Specifies the number of availability zones for HA cluster",
-      "minimum": 2,
+      "minimum": 3,
       "maximum": 3,
-      "default": 2
+      "default": 3
     }},
   "required": [
     "name"

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-ha-schema.json
@@ -19,7 +19,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["Standard_D4_v3", "Standard_D8_v3"]
+      "enum": ["Standard_D8_v3"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	DefaultAWSRegion       = "eu-central-1"
-	DefaultAWSHAZonesCount = 2
+	DefaultAWSHAZonesCount = 3
 )
 
 var europeAWS = "eu-central-1"
@@ -71,13 +71,13 @@ func (p *AWSInput) Defaults() *gqlschema.ClusterConfigInput {
 var awsZones = map[string]string{
 	"eu-central-1":   "abc",
 	"eu-west-2":      "abc",
-	"ca-central-1":   "ab",
-	"sa-east-1":      "ac",
+	"ca-central-1":   "abd",
+	"sa-east-1":      "abc",
 	"us-east-1":      "abcdf",
-	"us-west-1":      "ac",
+	"us-west-1":      "ab",
 	"ap-northeast-1": "acd",
-	"ap-northeast-2": "ac",
-	"ap-south-1":     "ab",
+	"ap-northeast-2": "abc",
+	"ap-south-1":     "abc",
 	"ap-southeast-1": "abc",
 	"ap-southeast-2": "abc",
 }
@@ -167,13 +167,13 @@ func (p *AWSHAInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m5d.xlarge",
+			MachineType:    "m5.xlarge",
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",
-			AutoScalerMin:  4,
+			AutoScalerMin:  1,
 			AutoScalerMax:  10,
-			MaxSurge:       4,
+			MaxSurge:       2,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AwsConfig: &gqlschema.AWSProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -167,7 +167,7 @@ func (p *AWSHAInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m5.xlarge",
+			MachineType:    "m5.2xlarge",
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",

--- a/components/kyma-environment-broker/internal/provider/aws_provider_test.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider_test.go
@@ -103,7 +103,7 @@ func TestAWSHAInput_Defaults(t *testing.T) {
 	input := svc.Defaults()
 
 	// then
-	assert.Equal(t, 4, input.GardenerConfig.AutoScalerMin)
+	assert.Equal(t, 1, input.GardenerConfig.AutoScalerMin)
 	assert.Equal(t, 10, input.GardenerConfig.AutoScalerMax)
-	assert.Len(t, input.GardenerConfig.ProviderSpecificConfig.AwsConfig.AwsZones, 2)
+	assert.Len(t, input.GardenerConfig.ProviderSpecificConfig.AwsConfig.AwsZones, 3)
 }

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	DefaultAzureRegion       = "westeurope"
-	DefaultAzureHAZonesCount = 2
+	DefaultAzureHAZonesCount = 3
 )
 
 var europeAzure = "westeurope"
@@ -164,9 +164,9 @@ func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
 			Region:         DefaultAzureRegion,
 			Provider:       "azure",
 			WorkerCidr:     "10.250.0.0/19",
-			AutoScalerMin:  4,
+			AutoScalerMin:  1,
 			AutoScalerMax:  10,
-			MaxSurge:       4,
+			MaxSurge:       2,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -160,7 +160,7 @@ func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("Standard_LRS"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "Standard_D4_v3",
+			MachineType:    "Standard_D8_v3",
 			Region:         DefaultAzureRegion,
 			Provider:       "azure",
 			WorkerCidr:     "10.250.0.0/19",

--- a/components/kyma-environment-broker/internal/provider/azure_provider_test.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider_test.go
@@ -101,7 +101,7 @@ func TestAzureHAInput_Defaults(t *testing.T) {
 	input := svc.Defaults()
 
 	// then
-	assert.Equal(t, 4, input.GardenerConfig.AutoScalerMin)
+	assert.Equal(t, 1, input.GardenerConfig.AutoScalerMin)
 	assert.Equal(t, 10, input.GardenerConfig.AutoScalerMax)
-	assert.Equal(t, 2, len(input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones))
+	assert.Equal(t, 3, len(input.GardenerConfig.ProviderSpecificConfig.AzureConfig.Zones))
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-909"
     kyma_environment_broker:
       dir:
-      version: "PR-919"
+      version: "PR-921"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-857"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Azure and AWS HA plans create clusters spanning 3 zones (currently min and max are both fixed to 3)
- Azure and AWS HA plans create one node per zone with 8 vCPU / 32 GiB RAM by default (`autoscalerMin.mininum` = `autoscalerMin.default` = 1)
- AWS HA plan support provisioning clusters with machine types larger than 8 vCPU / 32 GiB RAM 
- HA plans should never create more than 2 surge nodes per zone during cluster maintenance
- Fix AWS supported zones mapping. In https://github.com/kyma-project/control-plane/pull/916 zones for `ca-central-1`, `sa-east-1`, `ap-northeast-2`, `ap-south-1` were removed, assuming we can't support them because they don't support M4 machine types, however our AWS plan only use M5 machines which are supported by the removed zones.


**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/1308