### PR TITLE
Fix KEB monitoring integration step issues

### DIFF
--- a/components/kyma-environment-broker/internal/monitoring/monitoring.go
+++ b/components/kyma-environment-broker/internal/monitoring/monitoring.go
@@ -13,6 +13,8 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/rest"
 	"k8s.io/klog"
+
+	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
 )
 
 const (
@@ -84,7 +86,7 @@ func (c *client) IsDeployed(releaseName string) (bool, error) {
 
 	releases, err := listAction.Run()
 	if err != nil {
-		return false, err
+		return false, kebError.AsTemporaryError(err, "unable to list releases")
 	}
 	for _, rel := range releases {
 		if rel.Name == releaseName {
@@ -110,7 +112,7 @@ func (c *client) IsPresent(releaseName string) (bool, error) {
 
 	releases, err := listAction.Run()
 	if err != nil {
-		return false, err
+		return false, kebError.AsTemporaryError(err, "unable to list releases")
 	}
 	for _, rel := range releases {
 		if rel.Name == releaseName {
@@ -136,7 +138,7 @@ func (c *client) InstallRelease(params Parameters) (*release.Release, error) {
 	overrides := c.generateOverrideMap(params)
 	reponse, err := installAction.Run(c.monitoringConfig.LocalChart, overrides)
 	if err != nil {
-		return nil, err
+		return nil, kebError.AsTemporaryError(err, "unable to install release")
 	}
 
 	return reponse, nil
@@ -156,7 +158,7 @@ func (c *client) UpgradeRelease(params Parameters) (*release.Release, error) {
 
 	response, err := upgradeAction.Run(releaseName, c.monitoringConfig.LocalChart, overrides)
 	if err != nil {
-		return nil, err
+		return nil, kebError.AsTemporaryError(err, "unable to upgrade release")
 	}
 
 	return response, err
@@ -172,7 +174,7 @@ func (c *client) UninstallRelease(releaseName string) (*release.UninstallRelease
 	uninstallAction.Timeout = 6 * time.Minute
 	response, err := uninstallAction.Run(releaseName)
 	if err != nil {
-		return nil, err
+		return nil, kebError.AsTemporaryError(err, "unable to delete release")
 	}
 
 	return response, err

--- a/components/kyma-environment-broker/internal/process/deprovisioning/monitoring_uninstall.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/monitoring_uninstall.go
@@ -52,7 +52,7 @@ func (s *MonitoringUnistallStep) handleError(operation internal.DeprovisioningOp
 	log.Errorf("%s: %s", msg, err)
 	switch {
 	case kebError.IsTemporaryError(err):
-		return s.operationManager.RetryOperation(operation, msg, 10*time.Second, time.Minute*30, log)
+		return s.operationManager.RetryOperation(operation, msg, 30*time.Second, 10*time.Minute, log)
 	default:
 		return s.operationManager.OperationFailed(operation, msg, log)
 	}

--- a/components/kyma-environment-broker/internal/process/provisioning/monitoring_integration.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/monitoring_integration.go
@@ -84,7 +84,7 @@ func (s *MonitoringIntegrationStep) Run(operation internal.ProvisioningOperation
 		vmPassword = operation.Monitoring.Password
 	}
 
-	log.Info("Override username and password")
+	log.Debug("Override username and password")
 	MonitoringOverrides := []*gqlschema.ConfigEntryInput{
 		{
 			Key:   "vmuser.username",
@@ -104,7 +104,7 @@ func (s *MonitoringIntegrationStep) handleError(operation internal.ProvisioningO
 	log.Errorf("%s: %s", msg, err)
 	switch {
 	case kebError.IsTemporaryError(err):
-		return s.operationManager.RetryOperation(operation, msg, 10*time.Second, time.Minute*30, log)
+		return s.operationManager.RetryOperation(operation, msg, 30*time.Second, 10*time.Minute, log)
 	default:
 		return s.operationManager.OperationFailed(operation, msg, log)
 	}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/monitoring_upgrade.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/monitoring_upgrade.go
@@ -103,7 +103,7 @@ func (s *MonitoringUpgradeStep) handleError(operation internal.UpgradeKymaOperat
 	log.Errorf("%s: %s", msg, err)
 	switch {
 	case kebError.IsTemporaryError(err):
-		return s.operationManager.RetryOperation(operation, msg, 10*time.Second, time.Minute*30, log)
+		return s.operationManager.RetryOperation(operation, msg, 30*time.Second, 10*time.Minute, log)
 	default:
 		return s.operationManager.OperationFailed(operation, msg, log)
 	}

--- a/resources/kcp/charts/kyma-environment-broker/templates/monitoring.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/monitoring.yaml
@@ -1,8 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: kcp-monitoring
-  namespace: kcp-system
 rules:
   - apiGroups: ["*"]
     resources: ["secrets"]
@@ -15,16 +14,15 @@ rules:
     verbs: ["*"]
 
 ---
-kind: RoleBinding
+kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: kcp-monitoring
-  namespace: kcp-system
 subjects:
   - kind: ServiceAccount
     name: {{ include "kyma-env-broker.fullname" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: Role
-  name: monitoring
+  kind: ClusterRole
+  name: kcp-monitoring
   apiGroup: rbac.authorization.k8s.io

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-909"
     kyma_environment_broker:
       dir:
-      version: "PR-894"
+      version: "PR-934"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-930"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Fix non-existent role in monitoring rolebinding
- Allow deploying the monitoring integration config to namespaces other than kcp-system (using ClusterRole & ClusterRoleBinding)
- Treat all helm API calls working with K8S API as KEB temporary error so that queue managers retry
- Only retry monitoring steps up to 10 minutes in 30 seconds intervals

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
