### PR TITLE
One KEB stage for provisioning steps

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -564,15 +564,15 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *provi
 	provisionManager.DefineStages([]string{startStageName, createRuntimeStageName,
 		checkKymaStageName, postActionsStageName})
 	/*
-		The provisioning process contains the following stages:
-		1. "start" - changes the state from pending to in progress if no deprovisioning is ongoing.
-		2. "create_runtime" - collects all information needed to make an input for the Provisioner request as overrides and labels.
-		Those data is collected using an InputCreator which is not persisted. That's why all steps which prepares such data must be in the same stage as "create runtime step".
-	    checks the runtime provisioning and retries if in progress. All steps which requires InputCreator must be run in this stage.
-		3. "check_kyma" - checks if the Kyma is installed
-		4. "post_actions" - all steps which must be executed after the runtime is provisioned
+			The provisioning process contains the following stages:
+			1. "start" - changes the state from pending to in progress if no deprovisioning is ongoing.
+			2. "create_runtime" - collects all information needed to make an input for the Provisioner request as overrides and labels.
+			Those data is collected using an InputCreator which is not persisted. That's why all steps which prepares such data must be in the same stage as "create runtime step".
+		    checks the runtime provisioning and retries if in progress. All steps which requires InputCreator must be run in this stage.
+			3. "check_kyma" - checks if the Kyma is installed
+			4. "post_actions" - all steps which must be executed after the runtime is provisioned
 
-		Once the stage is done it will never be retried.
+			Once the stage is done it will never be retried.
 	*/
 
 	provisioningSteps := []struct {

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -568,7 +568,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *provi
 			1. "start" - changes the state from pending to in progress if no deprovisioning is ongoing.
 			2. "create_runtime" - collects all information needed to make an input for the Provisioner request as overrides and labels.
 			Those data is collected using an InputCreator which is not persisted. That's why all steps which prepares such data must be in the same stage as "create runtime step".
-		    checks the runtime provisioning and retries if in progress. All steps which requires InputCreator must be run in this stage.
+		    All steps which requires InputCreator must be run in this stage.
 			3. "check_kyma" - checks if the Kyma is installed
 			4. "post_actions" - all steps which must be executed after the runtime is provisioned
 

--- a/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go
@@ -36,7 +36,9 @@ func (s *CreateClusterConfigurationStep) Name() string {
 func (s *CreateClusterConfigurationStep) Run(operation internal.ProvisioningOperation, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
 	operation.InputCreator.SetRuntimeID(operation.RuntimeID).
 		SetInstanceID(operation.InstanceID).
-		SetKubeconfig(operation.Kubeconfig)
+		SetKubeconfig(operation.Kubeconfig).
+		SetShootName(operation.ShootName).
+		SetProvisioningParameters(operation.ProvisioningParameters)
 
 	clusterConfigurtation, err := operation.InputCreator.CreateClusterConfiguration()
 	if err != nil {

--- a/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go
@@ -198,7 +198,7 @@ func (m *StagedManager) runStep(step Step, operation internal.ProvisioningOperat
 		// - the step does not need a retry
 		// - step returns an error
 		// - the loop takes too much time (to not block the worker too long)
-		if when == 0 || err != nil || time.Since(begin) > 5*time.Minute {
+		if when == 0 || err != nil || time.Since(begin) > 10*time.Minute {
 			return processedOperation, when, err
 		}
 		time.Sleep(when / time.Duration(m.speedFactor))

--- a/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go
@@ -198,7 +198,7 @@ func (m *StagedManager) runStep(step Step, operation internal.ProvisioningOperat
 		// - the step does not need a retry
 		// - step returns an error
 		// - the loop takes too much time (to not block the worker too long)
-		if when == 0 || err != nil || time.Since(begin) > 5 * time.Minute {
+		if when == 0 || err != nil || time.Since(begin) > 5*time.Minute {
 			return processedOperation, when, err
 		}
 		time.Sleep(when / time.Duration(m.speedFactor))

--- a/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/staged_manager.go
@@ -198,7 +198,7 @@ func (m *StagedManager) runStep(step Step, operation internal.ProvisioningOperat
 		// - the step does not need a retry
 		// - step returns an error
 		// - the loop takes too much time (to not block the worker too long)
-		if when == 0 || err != nil || time.Since(begin) > 15*time.Minute {
+		if when == 0 || err != nil || time.Since(begin) > 5 * time.Minute {
 			return processedOperation, when, err
 		}
 		time.Sleep(when / time.Duration(m.speedFactor))

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -42,7 +42,7 @@ resources:
   #   memory: 128Mi
 
 reconciler:
-  URL: "http://kcp-reconciler.kcp-system.svc.cluster.local"
+  URL: "http://kcp-mothership-reconciler.kcp-system.svc.cluster.local"
 
 provisioner:
   URL: "http://kcp-provisioner.kcp-system.svc.cluster.local:3000/graphql"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "PR-940"
     kyma_environment_broker:
       dir:
-      version: "PR-912"
+      version: "PR-941"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-930"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This PR fixes a problem with stages in provisioning process. The InputCreator (a field in the opertation) is created in the create_runtime stage. If the stage is finished, it won't be retried. N ext steps will be executed. If any step is taking more than 15 minutes, the engine will put the operation to the queue and start again by loading the operation from the storage (without Inpiut Creator). That's why all steps which plays with the input creator must be in the same stage.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
