### PR TITLE
bump alpine to eu.gcr.io/kyma-project/external/alpine:3.14.2

### DIFF
--- a/components/kubeconfig-service/Dockerfile
+++ b/components/kubeconfig-service/Dockerfile
@@ -17,7 +17,7 @@ COPY . .
 RUN go build -v -o main ./cmd/generator/main.go
 RUN mkdir /app && mv ./main /app/main && mv ./licenses /app/licenses
 
-FROM alpine:3.13.5
+FROM eu.gcr.io/kyma-project/external/alpine:3.14.2
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump alpine to eu.gcr.io/kyma-project/external/alpine:3.14.2
**Related issue(s)**
Resolves: CVE-2021-3711, CVE-2021-3712