### PR TITLE
update kubeconfig-service image after alpine bump

### DIFF
--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
-  tag: "PR-785"
+  tag: "ce7e228f"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
**Description**
update kubeconfig-service image after alpine bump (#948)

**Related issue(s)**
Resolves: CVE-2021-3711, CVE-2021-3712