### PR TITLE
Default PlanID from instance details for update when request doesn't specify any

### DIFF
--- a/components/kyma-environment-broker/internal/broker/instance_update.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update.go
@@ -155,7 +155,11 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 
 	logger.Debugf("creating update operation %v", params)
 	operation := internal.NewUpdateOperation(operationID, instance, params)
-	defaults, err := b.planDefaults(details.PlanID, instance.Provider, &instance.Provider)
+	planID := instance.Parameters.PlanID
+	if len(details.PlanID) != 0 {
+		planID = details.PlanID
+	}
+	defaults, err := b.planDefaults(planID, instance.Provider, &instance.Provider)
 	if err != nil {
 		logger.Errorf("unable to obtain plan defaults: %s", err.Error())
 		return domain.UpdateServiceSpec{}, errors.New("unable to obtain plan defaults")


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

I introduced a bug in https://github.com/kyma-project/control-plane/pull/958 which required users to pass `PlanID` for updating instances. According to [OSB API](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md), it shouldn't be required and we should default to `PlanID` provided during provisioning when the update param doesn't contain `PlanID`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
