### PR TITLE
Fix nil pointer panic in orchestration manager

### DIFF
--- a/components/kyma-environment-broker/internal/orchestration/manager/manager.go
+++ b/components/kyma-environment-broker/internal/orchestration/manager/manager.go
@@ -147,11 +147,11 @@ func (m *orchestrationManager) resolveOperations(o *internal.Orchestration, poli
 			result = append(result, op)
 		}
 
-		if o.Parameters.Kyma.Version == "" {
-			o.Parameters.Kyma.Version = m.kymaVersion
+		if o.Parameters.Kyma == nil || o.Parameters.Kyma.Version == "" {
+			o.Parameters.Kyma = &orchestration.KymaParameters{Version: m.kymaVersion}
 		}
-		if o.Parameters.Kubernetes.KubernetesVersion == "" {
-			o.Parameters.Kubernetes.KubernetesVersion = m.kubernetesVersion
+		if o.Parameters.Kubernetes == nil || o.Parameters.Kubernetes.KubernetesVersion == "" {
+			o.Parameters.Kubernetes = &orchestration.KubernetesParameters{KubernetesVersion: m.kubernetesVersion}
 		}
 
 		if len(runtimes) != 0 {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-981"
     kyma_environment_broker:
       dir:
-      version: "PR-991"
+      version: "PR-994"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-938"


### PR DESCRIPTION
**Description**

Fix `orchestration.Manager` crashing due to empty Kyma/Kubernetes parameters.

**Related issue(s)**
#866 