### PR TITLE
Fix indention for list of pre-components

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/files/reconciler.yaml
+++ b/resources/kcp/charts/mothership-reconciler/files/reconciler.yaml
@@ -22,6 +22,6 @@ mothership:
         url: http://{{ $component }}-reconciler:8080/v1/run
 {{- end }}
 {{- if .Values.preComponents }}
-preComponents:
-{{ toYaml .Values.preComponents | indent 2 }}
+    preComponents:
+{{ toYaml .Values.preComponents | indent 6 }}
 {{- end }}


### PR DESCRIPTION
**Description**

Deployment of Kyma fails because priority of components is not considered by mothership-reconciler.

Reason is a wrong indention in the configuration file.

**Related issue(s)**

