### PR TITLE
Assign cluster-admin to owners when provisioning kyma

### DIFF
--- a/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
+++ b/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
@@ -20,9 +20,9 @@ const (
 	l3OperatorClusterRoleBindingName            = "l3-operator-admin"
 	administratorOperatorClusterRoleBindingName = "administrator"
 
-	l2OperatorClusterRoleBindingRoleRefName            = "view"
-	l3OperatorClusterRoleBindingRoleRefName            = "cluster-admin"
-	administratorOperatorClusterRoleBindingRoleRefName = "kyma-admin"
+	l2OperatorClusterRoleBindingRoleRefName = "view"
+	l3OperatorClusterRoleBindingRoleRefName = "cluster-admin"
+	ownerClusterRoleBindingRoleRefName      = "cluster-admin"
 
 	groupKindSubject = "Group"
 	userKindSubject  = "User"
@@ -96,7 +96,7 @@ func (s *CreateBindingsForOperatorsStep) Run(cluster model.Cluster, _ model.Oper
 				buildClusterRoleBinding(
 					fmt.Sprintf("%s%d", administratorOperatorClusterRoleBindingName, i),
 					administrator,
-					administratorOperatorClusterRoleBindingRoleRefName,
+					ownerClusterRoleBindingRoleRefName,
 					userKindSubject,
 					map[string]string{"app": "kyma", "type": "admin"}))
 		}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Assign cluster-admin to cluster owners when provisioning

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
