### PR TITLE
Bump reconciler images to properly handle serverless secret

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -4,10 +4,10 @@ global:
     cloudsql_proxy_image: eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.25.0-alpine-ef998682
     mothership_reconciler:
       path: eu.gcr.io/kyma-project/incubator/reconciler/mothership
-      tag: "d3077133"
+      tag: "386284a8"
     component_reconciler:
       path: eu.gcr.io/kyma-project/incubator/reconciler/component
-      tag: "455f43a4"
+      tag: "386284a8"
     containerRegistry:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Include fix for endless regeneration of docker registry secret


**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/12401
