### PR TITLE
KCP CLI: use KEB runtime state

### DIFF
--- a/components/kyma-environment-broker/internal/orchestration/runtime_lister.go
+++ b/components/kyma-environment-broker/internal/orchestration/runtime_lister.go
@@ -48,7 +48,9 @@ func (rl RuntimeLister) ListAllRuntimes() ([]runtime.RuntimeDTO, error) {
 		if len(pOprs) > 0 {
 			rl.converter.ApplyProvisioningOperation(&dto, &pOprs[len(pOprs)-1])
 		}
-		rl.converter.ApplyUnsuspensionOperations(&dto, pOprs)
+		if len(pOprs) > 1 {
+			rl.converter.ApplyUnsuspensionOperations(&dto, pOprs[:len(pOprs)-1])
+		}
 
 		dOprs, err := rl.operationsDb.ListDeprovisioningOperationsByInstanceID(inst.InstanceID)
 		if err != nil && !dberr.IsNotFound(err) {

--- a/components/kyma-environment-broker/internal/runtime/converter.go
+++ b/components/kyma-environment-broker/internal/runtime/converter.go
@@ -142,18 +142,16 @@ func (c *converter) ApplySuspensionOperations(dto *pkg.RuntimeDTO, oprs []intern
 }
 
 func (c *converter) ApplyUnsuspensionOperations(dto *pkg.RuntimeDTO, oprs []internal.ProvisioningOperation) {
-	if len(oprs) <= 1 {
+	if len(oprs) <= 0 {
 		return
 	}
 	dto.Status.Unsuspension = &pkg.OperationsData{}
 	dto.Status.Unsuspension.Data = make([]pkg.Operation, 0)
 
-	unsuspensionOps := oprs[:len(oprs)-1]
+	dto.Status.Unsuspension.TotalCount = len(oprs)
+	dto.Status.Unsuspension.Count = len(oprs)
 
-	dto.Status.Unsuspension.TotalCount = len(unsuspensionOps)
-	dto.Status.Unsuspension.Count = len(unsuspensionOps)
-
-	for _, o := range unsuspensionOps {
+	for _, o := range oprs {
 		op := pkg.Operation{}
 		c.applyOperation(&o.Operation, &op)
 		dto.Status.Unsuspension.Data = append(dto.Status.Unsuspension.Data, op)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-981"
     kyma_environment_broker:
       dir:
-      version: "PR-1035"
+      version: "PR-1042"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-938"

--- a/tools/cli/go.mod
+++ b/tools/cli/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/int128/kubelogin v1.22.0
 	github.com/kyma-project/control-plane/components/kubeconfig-service v0.0.0-20201211152036-9bdabffd55fb
-	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20211018121130-0215158aec4f
+	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0
 	github.com/kyma-project/control-plane/components/reconciler v0.0.0
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de
 	github.com/pkg/errors v0.9.1
@@ -26,6 +26,7 @@ replace (
 	github.com/census-instrumentation/opencensus-proto v0.1.0-0.20181214143942-ba49f56771b8 => github.com/census-instrumentation/opencensus-proto v0.0.3-0.20181214143942-ba49f56771b8
 	github.com/gardener/gardener => github.com/gardener/gardener v1.24.0
 	github.com/kyma-incubator/compass/components/director => github.com/kyma-incubator/compass/components/director v0.0.0-20210329081251-209fb6d91e72
+	github.com/kyma-project/control-plane/components/kyma-environment-broker => ../../components/kyma-environment-broker
 	github.com/kyma-project/control-plane/components/reconciler => ../../components/reconciler
 	k8s.io/api => k8s.io/api v0.19.12
 	k8s.io/apimachinery => k8s.io/apimachinery v0.20.0

--- a/tools/cli/go.sum
+++ b/tools/cli/go.sum
@@ -760,6 +760,7 @@ github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7V
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/jung-kurt/gofpdf v1.0.3-0.20190309125859-24315acbbda5/go.mod h1:7Id9E/uU8ce6rXgefFLlgrJj/GYY22cpxn+r32jIOes=
 github.com/k0kubun/colorstring v0.0.0-20150214042306-9440f1994b88/go.mod h1:3w7q1U84EfirKl04SVQ/s7nPm1ZPhiXd34z40TNz36k=
+github.com/kennygrant/sanitize v1.2.4/go.mod h1:LGsjYYtgxbetdg5owWB2mpgUL6e2nfw2eObZ0u0qvak=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
@@ -802,8 +803,6 @@ github.com/kyma-incubator/hydroform/install v0.0.0-20200629120139-6648400a8188/g
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-project/control-plane/components/kubeconfig-service v0.0.0-20201211152036-9bdabffd55fb h1:PU13re+51gRHXDMgQcLVfBzPWCw810/2klnyFh8xflc=
 github.com/kyma-project/control-plane/components/kubeconfig-service v0.0.0-20201211152036-9bdabffd55fb/go.mod h1:PDFrNKcvGvi8T7l15Eh40Gy6+/tzlARJCluVwK8j9bI=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20211018121130-0215158aec4f h1:s+rVNs1d5SN8a+TxztQ7hyZQf0zxAfchrFavlG/DtxY=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20211018121130-0215158aec4f/go.mod h1:ZCtO5tLlAy6hj7w/RLXS8nzAIPnXI9qd4O97eQses8E=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20200702142454-d5c043eb0dbe/go.mod h1:kej5mA0lXpMuwh8iFu48vqaXyVByulBFZlXUmaFvIgk=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20210908123350-912a714ae675 h1:+vZWvVqlXSSYAfUgP3NBJJskx/aEIkpnmb7DjKX4mbo=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20210908123350-912a714ae675/go.mod h1:WeQmbtBLbkjMbg4npPKPqTz2JFij2emvZwalK1fRiMg=


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- [BUGFIX]: KEB: Allow runtime `converter.ApplySuspensionOperations()` to work without initial provision operation (i.e. full list of provision operations). This is needed for runtime handler's `setRuntimeLastOperation()` function to work properly. Adjust all users of `converter.ApplySuspensionOperations()` according to the new contract.
- [BUGFIX]: KEB: populate `AVSInternalEvaluationID` from the last provisioning operation (unsuspension) instead of the first. The current behavior returns obsolete, deleted AVS IDs. 
- [ENHANCEMENT]: CLI: `kcp runtimes` command queries only the last operation now by default. Add `--ops` parameter to query all operations.
- [ENHANCEMENT]: CLI: `kcp runtimes` command table output now displays the state based on runtime state attribute coming from KEB. 
- [ENHANCEMENT]: CLI: Add `kcp runtimes --kyma-config`  option to query and display the Kyma configuration in the JSON output.
- [ENHANCEMENT]: CLI: Add `kcp runtimes --cluster-config`  option to query and display the (Gardener shoot) cluster configuration in the JSON output.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
