### PR TITLE
Preserve pod-preset certs via custom reconciler

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -4,10 +4,10 @@ global:
     cloudsql_proxy_image: eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.25.0-alpine-ef998682
     mothership_reconciler:
       path: eu.gcr.io/kyma-project/incubator/reconciler/mothership
-      tag: "2c7e77ec"
+      tag: "4d3d737e"
     component_reconciler:
       path: eu.gcr.io/kyma-project/incubator/reconciler/component
-      tag: "2c7e77ec"
+      tag: "4d3d737e"
     containerRegistry:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:
@@ -59,6 +59,7 @@ global:
     - rafter
     - eventing
     - serverless
+    - cluster-essentials
 
   auditlog:
     configMapName: "kcp-auditlog-config"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bump reconciler images to include [custom reconciler for cluster essentials](https://github.com/kyma-incubator/reconciler/pull/354) and [allow the definition of a URL for a component](https://github.com/kyma-incubator/reconciler/pull/335)
- include `cluster-essentials` in templating of custom reconcilers


**Related issue(s)**
Fixes https://github.com/kyma-project/kyma/issues/12531
Fixes https://github.com/kyma-incubator/reconciler/issues/285