### PR TITLE
Changing TestDefinitions to Jobs in e2e tests

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-aws.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-aws
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.aws.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
+              value: "false"
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on AWS. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-aws-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.aws.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
+              value: "false"
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on AWS. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-aws.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-aws
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -88,16 +88,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-provisioning test on AWS. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-aws-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-azure.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-azure
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -86,16 +86,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-provisioning test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-azure-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-azure.yaml
@@ -1,0 +1,170 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-azure
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.azure.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.azure.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-azure-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.azure.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.azure.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-free-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-free-aws.yaml
@@ -138,7 +138,7 @@ spec:
             - name: APP_PROVISIONER_URL
               value: "{{ .Values.provisioner.URL }}"
             - name: APP_CONFIG_NAME
-              value: "{{ .Values.e2e.azure.configName }}"
+              value: "{{ .Values.e2e.free_aws.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-free-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-free-aws.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-free-aws
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -88,16 +88,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-provisioning test on AWS (free plan). Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-free-aws-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-free-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-free-aws.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-free-aws
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.free_aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_BROKER_REGION
+              value: "cf-eu10"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.free_aws.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on AWS (free plan). Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-free-aws-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.free_aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_BROKER_REGION
+              value: "cf-eu10"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.azure.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on AWS (free plan). Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-gcp.yaml
@@ -1,0 +1,169 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-gcp
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.gcp.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.gcp.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on GCP. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-gcp-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.gcp.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.gcp.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on GCP. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+      {{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-gcp.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-gcp.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-gcp
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -85,16 +85,16 @@ spec:
           command: ["/bin/sh"]
           args: ["-c", "echo 'Starting e2e-provisioning test on GCP. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-gcp-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-ha-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-ha-aws.yaml
@@ -138,7 +138,7 @@ spec:
             - name: APP_PROVISIONER_URL
               value: "{{ .Values.provisioner.URL }}"
             - name: APP_CONFIG_NAME
-              value: "{{ .Values.e2e.azure.configName }}"
+              value: "{{ .Values.e2e.ha_aws.configName }}"
             - name: APP_DEPLOY_NAMESPACE
               value: "kcp-system"
             - name: APP_DIRECTOR_URL

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-ha-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-ha-aws.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-ha-aws
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.ha_aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_BROKER_REGION
+              value: "cf-eu10"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.ha_aws.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on AWS (HA plan). Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-ha-aws-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.ha_aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_BROKER_REGION
+              value: "cf-eu10"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.azure.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on AWS (HA plan). Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-ha-aws.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-ha-aws.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-ha-aws
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -88,16 +88,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-provisioning test on AWS (HA plan). Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-ha-aws-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-skr.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-skr.yaml
@@ -1,0 +1,170 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-provisioning-skr
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.skr.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.skr.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-provisioning-skr-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.skr.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.skr.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-provisioning cleanup test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-skr.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-skr.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-provisioning-skr
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -86,16 +86,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-provisioning test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Provisioning; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-provisioning-skr-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-suspension.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-suspension.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-trial
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -82,16 +82,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-suspension test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Suspension; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-trial-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-suspension.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-provisioning-suspension.yaml
@@ -1,0 +1,166 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-trial
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.trial.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.trial.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-suspension test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Suspension; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-trial-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.trial.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.trial.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "false"
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-suspension cleanup test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Suspension; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-upgrade-azure.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-upgrade-azure
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig
@@ -88,16 +88,16 @@ spec:
           args: ["-c", "echo 'Starting e2e-upgrade test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Upgrade; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: e2e-upgrade-azure-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       volumes:
         - name: gardener-kubeconfig

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-upgrade-azure.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/e2e-upgrade-azure.yaml
@@ -1,0 +1,174 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-upgrade-azure
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              # For now it is set to `true`, because if anyone set global.provisioning.enabled to `true`
+              # then this test will be executed on the pre-master-compass-integration job with the rest of the acceptance tests.
+              # With the Dummy test, we won't block the pipelines.
+              # In future we can make that test useful for pre-master jobs.
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.azure.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.upgrade.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "true"
+            - name: APP_UPGRADE_TIMEOUT
+              value: {{ .Values.e2e.upgrade.timeout }}
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-upgrade test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Upgrade; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: e2e-upgrade-azure-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      volumes:
+        - name: gardener-kubeconfig
+          secret:
+            defaultMode: 420
+            secretName: {{ .Values.gardener.secretName }}
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - mountPath: /gardener/kubeconfig
+              name: gardener-kubeconfig
+              readOnly: true
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.azure.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_CONFIG_NAME
+              value: "{{ .Values.e2e.upgrade.configName }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_UPGRADE_TEST
+              value: "true"
+            - name: APP_UPGRADE_TIMEOUT
+              value: {{ .Values.e2e.upgrade.timeout }}
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-upgrade cleanup test on Azure. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Upgrade; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/rbac.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/rbac.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: e2e-provisioning
+subjects:
+  - kind: ServiceAccount
+    name: e2e-provisioning
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-provisioning
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["secrets", "configmaps"]
+    verbs: ["get", "create", "update", "delete"]
+  - apiGroups: ["*"]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list"]
+  - apiGroups: ["testing.kyma-project.io"]
+    resources: ["clustertestsuites", "testdefinitions"]
+    verbs: ["*"]
+  - apiGroups: ["hydra.ory.sh"]
+    resources: ["oauth2clients"]
+    verbs: ["get"]
+  - apiGroups: ["core.gardener.cloud"]
+    resources: ["secretbindings"]
+    verbs: ["get", "list", "create", "update", "delete"]
+{{- end -}}

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/upg-tst-aws-prov.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/upg-tst-aws-prov.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.e2e.enabled }}
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: upg-tst-aws-prov
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       containers:
         - name: tests
@@ -82,16 +82,16 @@ spec:
           args: ["-c", "echo 'Starting e2e upgrade test on AWS. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Upgrade; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
 
 ---
-apiVersion: "testing.kyma-project.io/v1alpha1"
-kind: TestDefinition
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: upg-tst-aws-prov-cleanup
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
 spec:
-  disableConcurrency: false
   template:
     spec:
+      restartPolicy: Never
       serviceAccountName: e2e-provisioning
       containers:
         - name: tests

--- a/resources/kcp/charts/kyma-environment-broker/templates/tests-new/upg-tst-aws-prov.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/tests-new/upg-tst-aws-prov.yaml
@@ -1,0 +1,161 @@
+{{- if .Values.e2e.enabled }}
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: upg-tst-aws-prov
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "false"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_CONFIG_NAME
+              value: "upg-tst-aws-config"
+            - name: APP_PRE_UPGRADE_KYMA_VERSION
+              valueFrom:
+                configMapKeyRef:
+                  name: upg-tst-config
+                  key: BASE_VERSION
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
+              value: "false"
+            - name: APP_UPGRADE_TEST
+              value: "true"
+            - name: APP_UPGRADE_TIMEOUT
+              value: {{ .Values.e2e.upgrade.timeout }}
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e upgrade test on AWS. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Upgrade; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+
+---
+apiVersion: "testing.kyma-project.io/v1alpha1"
+kind: TestDefinition
+metadata:
+  name: upg-tst-aws-prov-cleanup
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  disableConcurrency: false
+  template:
+    spec:
+      serviceAccountName: e2e-provisioning
+      containers:
+        - name: tests
+          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.tests.e2e_provisioning.dir }}e2e-provisioning-test:{{ .Values.global.images.tests.e2e_provisioning.version }}
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: APP_PROVISION_TIMEOUT
+              value: "{{ .Values.e2e.provisioning.timeout }}"
+            - name: APP_DEPROVISION_TIMEOUT
+              value: "{{ .Values.e2e.deprovisioning.timeout }}"
+            - name: APP_SKIP_CERT_VERIFICATION
+              value: "true"
+            - name: APP_TENANT_ID
+              value: "{{ .Values.e2e.tenant.id }}"
+            - name: APP_DUMMY_TEST
+              value: "false"
+            - name: APP_CLEANUP_PHASE
+              value: "true"
+            - name: APP_BROKER_URL
+              value: 'https://{{ .Values.host }}.{{ .Values.global.ingress.domainName }}'
+            - name: APP_BROKER_PLAN_ID
+              value: "{{ .Values.e2e.aws.planID }}"
+            - name: APP_BROKER_CLIENT_NAME
+              value: {{ include "kyma-env-broker.fullname" . | quote }}
+            - name: APP_CONFIG_NAME
+              value: "upg-tst-aws-config"
+            - name: APP_BROKER_TOKEN_URL
+              value: "https://oauth2.{{ .Values.global.ingress.domainName }}/oauth2/token"
+            - name: APP_PROVISIONER_URL
+              value: "{{ .Values.provisioner.URL }}"
+            - name: APP_DEPLOY_NAMESPACE
+              value: "kcp-system"
+            - name: APP_DIRECTOR_URL
+              value: "https://{{ .Values.global.compass.tls.secure.oauth.host }}.{{ .Values.global.compass.domain | default .Values.global.ingress.domainName }}/director/graphql"
+            - name: APP_DIRECTOR_OAUTH_TOKEN_URL
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: tokens_endpoint
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_id
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ .Values.global.kyma_environment_broker.secrets.integrationSystemCredentials.name }}"
+                  key: client_secret
+                  optional: true
+            - name: APP_DIRECTOR_OAUTH_SCOPE
+              value: "{{ .Values.director.scope }}"
+            - name: APP_GARDENER_PROJECT
+              value: {{ .Values.gardener.project }}
+            - name: APP_GARDENER_KUBECONFIG_PATH
+              value: {{ .Values.gardener.kubeconfigPath }}
+            - name: APP_TEST_AZURE_EVENT_HUBS_ENABLED
+              value: "false"
+            - name: APP_UPGRADE_TEST
+              value: "true"
+            - name: APP_UPGRADE_TIMEOUT
+              value: {{ .Values.e2e.upgrade.timeout }}
+          command: ["/bin/sh"]
+          args: ["-c", "echo 'Starting e2e-upgrade cleanup test on AWS. Waiting 20s for api server...'; sleep 20; ./test.test -test.run Test_E2E_Upgrade; exit_code=$?; curl -XPOST http://127.0.0.1:15020/quitquitquit; sleep 4; exit $exit_code;"]
+{{- end -}}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Duplicating `tests` folder with name `tests-new`
- Changing `TestDefinitions` to `Jobs` (apiVersion, kind, +restartPolicy, -disableConcurrency)
- Changing config names in `ha-aws-cleanup` & `free-aws-cleanup`

**Related issue(s)**
See also #1043
