### PR TITLE
Add custom subchart for rma reconciler. Set new metadata attrs in KEB

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -336,8 +336,10 @@ func (r *RuntimeInput) CreateClusterConfiguration() (reconciler.Cluster, error) 
 			SubAccountID:    r.provisioningParameters.ErsContext.SubAccountID,
 			ServiceID:       r.provisioningParameters.ServiceID,
 			ServicePlanID:   r.provisioningParameters.PlanID,
+			ServicePlanName: broker.PlanNamesMapping[r.provisioningParameters.PlanID],
 			ShootName:       *r.shootName,
 			InstanceID:      r.instanceID,
+			Region:          r.provisionRuntimeInput.ClusterConfig.GardenerConfig.Region,
 		},
 		Kubeconfig: r.kubeconfig,
 	}

--- a/components/kyma-environment-broker/internal/reconciler/contract.go
+++ b/components/kyma-environment-broker/internal/reconciler/contract.go
@@ -52,8 +52,10 @@ type Metadata struct {
 	SubAccountID    string `json:"subAccountID"`
 	ServiceID       string `json:"serviceID"`
 	ServicePlanID   string `json:"servicePlanID"`
+	ServicePlanName string `json:"servicePlanName"`
 	ShootName       string `json:"shootName"`
 	InstanceID      string `json:"instanceID"`
+	Region          string `json:"region"`
 }
 
 // reconciling statuses

--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/Chart.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: rma-component-reconciler
+description: A Helm chart for runtime-monitoring-agent (rma) component reconciler
+type: application
+version: 0.1.0

--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/authorization.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/authorization.yaml
@@ -1,0 +1,17 @@
+{{ if .Values.global.component_reconcilers.authentication }}
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+  name: rma-reconciler
+  namespace: {{ .Release.Namespace }}
+spec:
+  action: ALLOW
+  selector:
+    matchLabels:
+      kyma-project.io/component-reconciler: ""
+      component: rma
+  rules:
+  - from:
+    - source:
+        principals: ["cluster.local/ns/{{ .Release.Namespace }}/sa/{{ .Values.global.mothership_reconciler.serviceAccountName }}"]
+{{- end }}

--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    kyma-project.io/component-reconciler: ""
+    component: rma
+  name: rma-reconciler
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      kyma-project.io/component-reconciler: ""
+      component: rma
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        kyma-project.io/component-reconciler: ""
+        component: rma
+    spec:
+      serviceAccountName: component-reconcilers-rma
+      containers:
+      - image: "{{ .Values.global.images.component_reconciler.path }}:{{ .Values.global.images.component_reconciler.tag }}"
+        imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+        args:
+          - reconciler
+          - start
+          - rma
+          - --workspace=/tmp/reconciler
+          - --verbose
+          - --worker-count={{ .Values.config.workerCount }}
+          - --worker-timeout={{ .Values.config.workerTimeout }}
+          - --retries-max={{ .Values.config.retriesMax }}
+          - --retries-delay={{ .Values.config.retriesDelay }}
+        name: reconciler
+        ports:
+        - name: http
+          containerPort: 8080
+          protocol: TCP
+        resources: {{- toYaml .Values.resources | nindent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: workspace
+      securityContext:
+        runAsUser: 2000
+      volumes:
+      - emptyDir: {}
+        name: workspace

--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/rbac.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/rbac.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: component-reconcilers-rma
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app: component-reconcilers-rma
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: component-reconcilers-rma
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["*"]
+  - apiGroups: ["operator.victoriametrics.com"]
+    resources: ["vmrules"]
+    verbs: ["*"]
+  - apiGroups: ["operator.victoriametrics.com"]
+    resources: ["vmusers"]
+    verbs: ["*"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: component-reconcilers-rma
+subjects:
+  - kind: ServiceAccount
+    name: component-reconcilers-rma
+    namespace:  {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: component-reconcilers-rma

--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/service.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rma-reconciler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    kyma-project.io/component-reconciler: ""
+    component: rma
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    kyma-project.io/component-reconciler: ""
+    component: rma

--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/values.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/values.yaml
@@ -1,0 +1,19 @@
+# Default values for rma reconciler.
+
+nameOverride: ""
+fullnameOverride: ""
+
+deployment:
+  imagePullPolicy: "IfNotPresent"
+
+service:
+  type: ClusterIP
+  port: 8080
+
+config:
+  workerCount: 16
+  workerTimeout: 10m
+  retriesMax: 10
+  retriesDelay: 60s
+
+resources: {}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -4,10 +4,10 @@ global:
     cloudsql_proxy_image: eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.27.0-alpine-7c52185c
     mothership_reconciler:
       path: eu.gcr.io/kyma-project/incubator/reconciler/mothership
-      tag: "a3fbfa81"
+      tag: "41af9d37"
     component_reconciler:
       path: eu.gcr.io/kyma-project/incubator/reconciler/component
-      tag: "a3fbfa81"
+      tag: "41af9d37"
     containerRegistry:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:
@@ -60,6 +60,7 @@ global:
     - eventing
     - serverless
     - cluster-essentials
+    - rma
 
   auditlog:
     configMapName: "kcp-auditlog-config"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add custom subchart for rma reconciler. Needed to configure custom RBAC for the integration actions, as well as to enable configurable options and resource settings.
- KEB: set the new ServicePlanName and Region attributes in Metadata API.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
