### PR TITLE
Hiding kubeconfig information in json output

### DIFF
--- a/tools/cli/pkg/command/reconciliation_info.go
+++ b/tools/cli/pkg/command/reconciliation_info.go
@@ -145,7 +145,7 @@ func (cmd *ReconciliationOperationInfoCommand) Run() error {
 		return errors.WithStack(ErrMothershipResponse)
 	}
 
-	// We are overwriting the kubeconfig field in order to not display it in log
+	// We are overwriting the kubeconfig field in order to not display it in output
 	result.Cluster.Kubeconfig = "<SENSITIVE_INFORMATION>"
 
 	err = cmd.printReconciliation(result)

--- a/tools/cli/pkg/command/reconciliation_info.go
+++ b/tools/cli/pkg/command/reconciliation_info.go
@@ -145,6 +145,9 @@ func (cmd *ReconciliationOperationInfoCommand) Run() error {
 		return errors.WithStack(ErrMothershipResponse)
 	}
 
+	// We are overwriting the kubeconfig field in order to not display it in log
+	result.Cluster.Kubeconfig = "<SENSITIVE_INFORMATION>"
+
 	err = cmd.printReconciliation(result)
 	if err != nil {
 		return errors.Wrap(err, "while printing runtimes")


### PR DESCRIPTION
**Description**
We shouldn't show kubeconfig information when using `kcp reconciliations info -i <shoot-name> -o json`

**Related issue(s)**
Fixes https://github.com/kyma-project/control-plane/issues/1083
