### PR TITLE
Append overrides based on unique override key

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -124,7 +124,19 @@ func (r *RuntimeInput) AppendOverrides(component string, overrides []*gqlschema.
 	r.mutex.Lock("AppendOverrides")
 	defer r.mutex.Unlock("AppendOverrides")
 
-	r.overrides[component] = append(r.overrides[component], overrides...)
+	for _, o2 := range overrides {
+		found := false
+		for i, o1 := range r.overrides[component] {
+			if o1.Key == o2.Key {
+				found = true
+				r.overrides[component][i].Secret = o2.Secret
+				r.overrides[component][i].Value = o2.Value
+			}
+		}
+		if !found {
+			r.overrides[component] = append(r.overrides[component], o2)
+		}
+	}
 	return r
 }
 
@@ -133,7 +145,19 @@ func (r *RuntimeInput) AppendGlobalOverrides(overrides []*gqlschema.ConfigEntryI
 	r.mutex.Lock("AppendGlobalOverrides")
 	defer r.mutex.Unlock("AppendGlobalOverrides")
 
-	r.globalOverrides = append(r.globalOverrides, overrides...)
+	for _, o2 := range overrides {
+		found := false
+		for i, o1 := range r.globalOverrides[component] {
+			if o1.Key == o2.Key {
+				found = true
+				r.globalOverrides[component][i].Secret = o2.Secret
+				r.globalOverrides[component][i].Value = o2.Value
+			}
+		}
+		if !found {
+			r.globalOverrides[component] = append(r.globalOverrides[component], o2)
+		}
+	}
 	return r
 }
 

--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -147,15 +147,15 @@ func (r *RuntimeInput) AppendGlobalOverrides(overrides []*gqlschema.ConfigEntryI
 
 	for _, o2 := range overrides {
 		found := false
-		for i, o1 := range r.globalOverrides[component] {
+		for i, o1 := range r.globalOverrides {
 			if o1.Key == o2.Key {
 				found = true
-				r.globalOverrides[component][i].Secret = o2.Secret
-				r.globalOverrides[component][i].Value = o2.Value
+				r.globalOverrides[i].Secret = o2.Secret
+				r.globalOverrides[i].Value = o2.Value
 			}
 		}
 		if !found {
-			r.globalOverrides[component] = append(r.globalOverrides[component], o2)
+			r.globalOverrides = append(r.globalOverrides, o2)
 		}
 	}
 	return r

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-1030"
     kyma_environment_broker:
       dir:
-      version: "PR-1109"
+      version: "PR-1112"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1103"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
During investigation of an OOMKill KEB https://github.com/kyma-project/control-plane/pull/1111/files, we found a memory leak

```
(pprof) top10
Showing nodes accounting for 5877.13MB, 99.19% of 5925.21MB total
Dropped 124 nodes (cum <= 29.63MB)
Showing top 10 nodes out of 57
      flat  flat%   sum%        cum   cum%
 3817.15MB 64.42% 64.42%  3817.15MB 64.42%  github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/input.(*RuntimeInput).AppendOverrides
  676.34MB 11.41% 75.84%   676.34MB 11.41%  encoding/base64.(*Encoding).DecodeString
  386.48MB  6.52% 82.36%  1062.81MB 17.94%  github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage.(*Encrypter).Decrypt
  224.34MB  3.79% 86.15%   224.34MB  3.79%  github.com/lib/pq.textDecode
  220.84MB  3.73% 89.87%  1606.89MB 27.12%  github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/driver/postsql.(*runtimeState).toRuntimeState
  220.84MB  3.73% 93.60%   220.84MB  3.73%  github.com/lib/pq.(*conn).recvMessage
  212.84MB  3.59% 97.19%   212.84MB  3.59%  reflect.unsafe_NewArray
  100.01MB  1.69% 98.88%   117.02MB  1.97%  encoding/json.(*decodeState).literalStore
   16.75MB  0.28% 99.16%    31.28MB  0.53%  compress/flate.NewWriter
    1.54MB 0.026% 99.19%  5869.26MB 99.06%  github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/upgrade_kyma.(*CreateClusterConfigurationStep).Run
```
The overrides were getting infinitely appended until OOMKill.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
