### PR TITLE
Configurable profiler for KEB

### DIFF
--- a/components/kyma-environment-broker/README.md
+++ b/components/kyma-environment-broker/README.md
@@ -61,3 +61,4 @@ KEB binary allows you to override some configuration parameters. You can specify
 | **APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID** | Specifies the **TagClassId** of the tag that contains Gardener cluster's shoot name. | None |
 | **APP_AVS_GARDENER_SEED_NAME_TAG_CLASS_ID** | Specifies the **TagClassId** of the tag that contains Gardener cluster's seed name. | None |
 | **APP_AVS_REGION_TAG_CLASS_ID** | Specifies the **TagClassId** of the tag that contains Gardener cluster's region. | None |
+| **APP_PROFILER_MEMORY** | Enables memory profiling every sampling period with the default location `/tmp/profiler`, backed by a persistent volume. | `false` |

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -42,6 +42,21 @@ spec:
       nodeSelector:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       containers:
+        {{- if .Values.broker.profiler.memory }}
+        - name: profiler
+          command:
+          - bash
+          - -c
+          - chmod 777 /tmp/profiler && sleep inf
+          securityContext:
+            runAsUser: 0
+          image: ubuntu:20.04
+          imagePullPolicy: Always
+          volumeMounts:
+            - name: keb-memory-profile
+              mountPath: /tmp/profiler
+              readOnly: false
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.kyma_environment_broker.dir }}kyma-environment-broker:{{ .Values.global.images.kyma_environment_broker.version }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
@@ -374,6 +389,8 @@ spec:
               value: "orchestration-config"
             - name: APP_NEW_ADDITIONAL_RUNTIME_COMPONENTS_YAML_FILE_PATH
               value: /config/newAdditionalRuntimeComponents.yaml
+            - name: APP_PROFILER_MEMORY
+              value: "{{ .Values.broker.profiler.memory }}"
           ports:
             - name: http
               containerPort: {{ .Values.broker.port }}
@@ -404,11 +421,16 @@ spec:
               name: swagger-volume
             - mountPath: /auditlog-script
               name: auditlog-script
-          {{if eq .Values.global.database.embedded.enabled false}}
+          {{- if eq .Values.global.database.embedded.enabled false}}
             - name: cloudsql-instance-credentials
               mountPath: /secrets/cloudsql-instance-credentials
               readOnly: true
-          {{ end }}
+          {{- end }}
+          {{- if .Values.broker.profiler.memory }}
+            - name: keb-memory-profile
+              mountPath: /tmp/profiler
+              readOnly: false
+          {{- end }}
 
         {{- if eq .Values.global.database.embedded.enabled false}}
         - name: cloudsql-proxy
@@ -443,3 +465,8 @@ spec:
       - name: auditlog-script
         configMap:
           name: {{ .Values.global.auditlog.script.configMapName }}
+      {{- if .Values.broker.profiler.memory }}
+      - name: keb-memory-profile
+        persistentVolumeClaim:
+          claimName: {{ include "kyma-env-broker.fullname" . }}-profiler
+      {{- end }}

--- a/resources/kcp/charts/kyma-environment-broker/templates/profiler-pvc.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/profiler-pvc.yaml
@@ -1,0 +1,15 @@
+{{ if .Values.broker.profiler.memory }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "kyma-env-broker.fullname" . }}-profiler
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: standard
+{{ end }}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -19,6 +19,8 @@ broker:
   statusPort: "8071"
   defaultRequestRegion: "cf-eu10"
   operationTimeout: "24h"
+  profiler:
+    memory: false
 
 service:
   type: ClusterIP

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1149"
+      version: "PR-1115"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1149"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

During debugging OOMKilled KEB https://github.com/kyma-project/control-plane/pull/1111, use for a configurable profiler was discovered. This PR introduces a switch for enabling memory profiler as well as enabling PVC for persisting the profiler traces in a PVC.

**Here is 5 minute 101 course on how to use this functionality**
1. enable profiler in helm chart switching this from `false` to `true`
https://github.com/kyma-project/control-plane/blob/2f7b1384dc59901c4b08cc09f53b71b84e33eda7/resources/kcp/charts/kyma-environment-broker/values.yaml#L23
2. copy the profiles from the running pod
```
$ mkdir -p /tmp/keb-profiles
$ k cp -c profiler kcp-kyma-environment-broker-jw-76548f646-rnclv:/tmp/profiler /tmp/keb-profiles
```
3. look at any profile
```
$ go tool pprof /tmp/keb-profiles/mem-1637917702.pprof
```
4. get any information you care about, for example top10 memory allocators
```
(pprof) top10
Showing nodes accounting for 143.53GB, 98.73% of 145.38GB total
Dropped 279 nodes (cum <= 0.73GB)
Showing top 10 nodes out of 20
      flat  flat%   sum%        cum   cum%
   46.86GB 32.23% 32.23%    84.81GB 58.34%  compress/flate.NewWriter
   23.24GB 15.99% 48.22%    37.95GB 26.11%  compress/flate.(*compressor).init
   22.37GB 15.39% 63.61%    22.37GB 15.39%  runtime/pprof.allFrames
   14.89GB 10.24% 73.85%   144.81GB 99.61%  runtime/pprof.writeHeapInternal
   14.43GB  9.92% 83.77%    14.43GB  9.92%  compress/flate.newDeflateFast (inline)
    8.44GB  5.81% 89.58%    39.65GB 27.27%  runtime/pprof.(*profileBuilder).emitLocation
    5.15GB  3.54% 93.12%     5.34GB  3.67%  runtime/pprof.(*protobuf).string (inline)
    4.32GB  2.97% 96.09%     4.32GB  2.97%  runtime/pprof.(*profileBuilder).stringIndex (inline)
    2.18GB  1.50% 97.59%   129.92GB 89.37%  runtime/pprof.writeHeapProto
    1.65GB  1.14% 98.73%     1.65GB  1.14%  runtime/pprof.(*protobuf).varint (inline)
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/control-plane/pull/1111, https://github.com/kyma-project/control-plane/pull/1112