### PR TITLE
KEB runtimes state: set to succeeded by default when operation state doesn't match

### DIFF
--- a/components/kyma-environment-broker/internal/runtime/handler.go
+++ b/components/kyma-environment-broker/internal/runtime/handler.go
@@ -153,6 +153,8 @@ func setRuntimeStateByOperationState(dto *pkg.RuntimeDTO) {
 		case pkg.Update:
 			dto.Status.State = pkg.StateUpdating
 		}
+	default:
+		dto.Status.State = pkg.StateSucceeded
 	}
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-1030"
     kyma_environment_broker:
       dir:
-      version: "PR-1113"
+      version: "PR-1124"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1103"


### PR DESCRIPTION
**Description**

This changes is to capture cases when the runtime state cannot be reliably determined from the state of the last operation. One example is when the last operation was `upgradeKyma` type, which was `canceled`. In these cases fall back by default to assume the runtime is in an active "succeeded" state.

