### PR TITLE
Adjust azure_lite autoScalerMax settings

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -155,8 +155,8 @@ func AzureSchema(machineTypes []string) RootSchema {
 
 func AzureLiteSchema(machineTypes []string) RootSchema {
 	properties := NewProvisioningProperties(machineTypes, AzureRegions())
-	properties.AutoScalerMax.Maximum = 4
-	properties.AutoScalerMax.Default = 2
+	properties.AutoScalerMax.Maximum = 40
+	properties.AutoScalerMax.Default = 10
 
 	return NewSchema(properties, DefaultControlsOrder())
 }

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema-additional-params.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema-additional-params.json
@@ -31,8 +31,8 @@
       "type": "integer",
       "description": "Specifies the maximum number of virtual machines to create",
       "minimum": 2,
-      "maximum": 4,
-      "default": 2
+      "maximum": 40,
+      "default": 10
     },
     "oidc": {
       "type": "object",

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema.json
@@ -31,8 +31,8 @@
       "type": "integer",
       "description": "Specifies the maximum number of virtual machines to create",
       "minimum": 2,
-      "maximum": 4,
-      "default": 2
+      "maximum": 40,
+      "default": 10
     }},
   "required": [
     "name"

--- a/components/kyma-environment-broker/internal/broker/testdata/update-azure-lite-schema-additional-params.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/update-azure-lite-schema-additional-params.json
@@ -11,7 +11,7 @@
       "type": "integer",
       "description": "Specifies the maximum number of virtual machines to create",
       "minimum": 2,
-      "maximum": 4
+      "maximum": 40
     },
     "oidc": {
       "type": "object",

--- a/components/kyma-environment-broker/internal/broker/testdata/update-azure-lite-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/update-azure-lite-schema.json
@@ -11,7 +11,7 @@
       "type": "integer",
       "description": "Specifies the maximum number of virtual machines to create",
       "minimum": 2,
-      "maximum": 4
+      "maximum": 40
     }
   },
   "required": [],

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -78,8 +78,8 @@ func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
 			Region:         DefaultAzureRegion,
 			Provider:       "azure",
 			WorkerCidr:     "10.250.0.0/19",
-			AutoScalerMin:  3,
-			AutoScalerMax:  4,
+			AutoScalerMin:  2,
+			AutoScalerMax:  10,
 			MaxSurge:       4,
 			MaxUnavailable: 1,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -88,7 +88,7 @@ These are the provisioning parameters for Azure that you can configure:
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
 | **autoScalerMin[<sup>1</sup>](#update)** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
-| **autoScalerMax[<sup>1</sup>](#update)** | int | Specifies the maximum number of virtual machines to create. | No | `40` |
+| **autoScalerMax[<sup>1</sup>](#update)** | int | Specifies the maximum number of virtual machines to create, up to `40` allowed. | No | `10` |
 | **maxSurge[<sup>1</sup>](#update)** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable[<sup>1</sup>](#update)** | int | Specifies the maximum number of VMs that can be unavailable during an update. | No | `1` |
 

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -87,8 +87,8 @@ These are the provisioning parameters for Azure that you can configure:
 | **volumeSizeGb** | int | Specifies the size of the root volume. | No | `50` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
-| **autoScalerMin[<sup>1</sup>](#update)** | int | Specifies the minimum number of virtual machines to create. | No | `3` |
-| **autoScalerMax[<sup>1</sup>](#update)** | int | Specifies the maximum number of virtual machines to create. | No | `4` |
+| **autoScalerMin[<sup>1</sup>](#update)** | int | Specifies the minimum number of virtual machines to create. | No | `2` |
+| **autoScalerMax[<sup>1</sup>](#update)** | int | Specifies the maximum number of virtual machines to create. | No | `40` |
 | **maxSurge[<sup>1</sup>](#update)** | int | Specifies the maximum number of virtual machines that are created during an update. | No | `4` |
 | **maxUnavailable[<sup>1</sup>](#update)** | int | Specifies the maximum number of VMs that can be unavailable during an update. | No | `1` |
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-1131"
     kyma_environment_broker:
       dir:
-      version: "PR-1140"
+      version: "PR-1126"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1103"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adjust autoScalerMax for create and update on azure_lite plan to:
```
 "properties": {
                    "autoScalerMax": {
                      "default": 10,
                      "description": "Specifies the maximum number of virtual machines to create",
                      "maximum": 40,
                      "minimum": 2,
                      "type": "integer"
                    }
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- #1072