### PR TITLE
Kcp reconciliations commands lists items in historical order

### DIFF
--- a/tools/cli/pkg/command/reconciliations.go
+++ b/tools/cli/pkg/command/reconciliations.go
@@ -46,8 +46,6 @@ type ReconciliationCommand struct {
 	provideMshipClient mothershipClientProvider
 }
 
-type timeSlice []mothership.HTTPReconciliationInfo
-
 func toReconciliationStatuses(rawStates []string) ([]mothership.Status, error) {
 	statuses := []mothership.Status{}
 	if rawStates == nil {

--- a/tools/cli/pkg/command/reconciliations.go
+++ b/tools/cli/pkg/command/reconciliations.go
@@ -206,7 +206,7 @@ func (cmd *ReconciliationCommand) Run() error {
 		return errors.WithStack(ErrMothershipResponse)
 	}
 
-	sort.Slice(result)
+	sortSlice(result)
 
 	err = cmd.printReconciliation(result)
 	if err != nil {

--- a/tools/cli/pkg/command/reconciliations.go
+++ b/tools/cli/pkg/command/reconciliations.go
@@ -206,7 +206,7 @@ func (cmd *ReconciliationCommand) Run() error {
 		return errors.WithStack(ErrMothershipResponse)
 	}
 
-	sort(result)
+	sort.Slice(result)
 
 	err = cmd.printReconciliation(result)
 	if err != nil {
@@ -216,7 +216,7 @@ func (cmd *ReconciliationCommand) Run() error {
 	return nil
 }
 
-func sort(s []mothership.HTTPReconciliationInfo) {
+func sortSlice(s []mothership.HTTPReconciliationInfo) {
 	sort.SliceStable(s, func(i, j int) bool {
 		return s[i].Created.Before(s[j].Created)
 	})

--- a/tools/cli/pkg/command/reconciliations.go
+++ b/tools/cli/pkg/command/reconciliations.go
@@ -206,7 +206,7 @@ func (cmd *ReconciliationCommand) Run() error {
 		return errors.WithStack(ErrMothershipResponse)
 	}
 
-	sorting(result)
+	sort(result)
 
 	err = cmd.printReconciliation(result)
 	if err != nil {
@@ -216,7 +216,7 @@ func (cmd *ReconciliationCommand) Run() error {
 	return nil
 }
 
-func sorting(s []mothership.HTTPReconciliationInfo) {
+func sort(s []mothership.HTTPReconciliationInfo) {
 	sort.SliceStable(s, func(i, j int) bool {
 		return s[i].Created.Before(s[j].Created)
 	})

--- a/tools/cli/pkg/command/reconciliations_test.go
+++ b/tools/cli/pkg/command/reconciliations_test.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"sort"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/runtime"
@@ -269,6 +271,64 @@ func TestReconciliationCommand_Run(t *testing.T) {
 			}
 			if err := cmd.Run(); (err != nil) != tt.wantErr {
 				t.Errorf("ReconciliationCommand.Run() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_sorting(t *testing.T) {
+	type args struct {
+		s []mothership.HTTPReconciliationInfo
+	}
+	tests := []struct {
+		name       string
+		args       args
+		wantSorted bool
+	}{
+		{
+			name: "Happy path",
+			args: args{
+				s: []mothership.HTTPReconciliationInfo{
+					{
+						Created: time.Now().Add(10 * time.Hour),
+					},
+					{
+						Created: time.Now(),
+					},
+					{
+						Created: time.Now().Add(20 * time.Hour),
+					},
+				},
+			},
+			wantSorted: true,
+		},
+		{
+			name: "No data",
+			args: args{
+				s: []mothership.HTTPReconciliationInfo{},
+			},
+			wantSorted: true,
+		},
+		{
+			name: "One argument",
+			args: args{
+				s: []mothership.HTTPReconciliationInfo{
+					{
+						Created: time.Now(),
+					},
+				},
+			},
+			wantSorted: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sorting(tt.args.s)
+			checkIfSorted := sort.SliceIsSorted(tt.args.s, func(i, j int) bool {
+				return tt.args.s[i].Created.Before(tt.args.s[j].Created)
+			})
+			if checkIfSorted != tt.wantSorted {
+				t.Errorf("sorting() got = %v, wanted %v", checkIfSorted, tt.wantSorted)
 			}
 		})
 	}

--- a/tools/cli/pkg/command/reconciliations_test.go
+++ b/tools/cli/pkg/command/reconciliations_test.go
@@ -298,6 +298,12 @@ func Test_sorting(t *testing.T) {
 					{
 						Created: time.Now().Add(20 * time.Hour),
 					},
+					{
+						Created: time.Now().Add(-30 * time.Hour),
+					},
+					{
+						Created: time.Now().Add(50 * time.Hour),
+					},
 				},
 			},
 			wantSorted: true,
@@ -323,7 +329,7 @@ func Test_sorting(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sorting(tt.args.s)
+			sort(tt.args.s)
 			checkIfSorted := sort.SliceIsSorted(tt.args.s, func(i, j int) bool {
 				return tt.args.s[i].Created.Before(tt.args.s[j].Created)
 			})

--- a/tools/cli/pkg/command/reconciliations_test.go
+++ b/tools/cli/pkg/command/reconciliations_test.go
@@ -329,7 +329,7 @@ func Test_sorting(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			sort(tt.args.s)
+			sortSlice(tt.args.s)
 			checkIfSorted := sort.SliceIsSorted(tt.args.s, func(i, j int) bool {
 				return tt.args.s[i].Created.Before(tt.args.s[j].Created)
 			})


### PR DESCRIPTION
**Description**
Using the kcp command
```
kcp rc -c <shoot_name>
```
sorts the entries by date in "Created at" column
Changes proposed in this pull request:

- Added sorting functionality
- Added unit tests for sorting

**Related issue(s)**
See also https://github.com/kyma-incubator/reconciler/issues/454