### PR TITLE
Adjust AWS plans' machine types

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -276,7 +276,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 			expectedProfile:                     gqlschema.KymaProfileEvaluation,
 			expectedProvider:                    "aws",
 			expectedSharedSubscription:          false,
-			expectedMachineType:                 "m5.xlarge",
+			expectedMachineType:                 "m6i.xlarge",
 			expectedSubscriptionHyperscalerType: hyperscaler.AWS,
 		},
 		"Freemium azure": {

--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -330,7 +330,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:        2,
 			expectedMaximumNumberOfNodes:        10,
-			expectedMachineType:                 "m5.2xlarge",
+			expectedMachineType:                 "m6i.2xlarge",
 			expectedProfile:                     gqlschema.KymaProfileProduction,
 			expectedProvider:                    "aws",
 			expectedSharedSubscription:          false,
@@ -343,7 +343,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:        1,
 			expectedMaximumNumberOfNodes:        10,
-			expectedMachineType:                 "m5.2xlarge",
+			expectedMachineType:                 "m6i.2xlarge",
 			expectedProfile:                     gqlschema.KymaProfileProduction,
 			expectedProvider:                    "aws",
 			expectedSharedSubscription:          false,
@@ -355,7 +355,7 @@ func TestProvisioning_ClusterParameters(t *testing.T) {
 
 			expectedMinimalNumberOfNodes:        1,
 			expectedMaximumNumberOfNodes:        10,
-			expectedMachineType:                 "m5.2xlarge",
+			expectedMachineType:                 "m6i.2xlarge",
 			expectedProfile:                     gqlschema.KymaProfileProduction,
 			expectedProvider:                    "aws",
 			expectedSharedSubscription:          false,

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -262,7 +262,7 @@ type Plan struct {
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
 func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool) map[string]Plan {
-	awsSchema := AWSSchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
+	awsSchema := AWSSchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
 	awsHASchema := AWSHASchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
 	gcpSchema := GCPSchema([]string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"})
 	openstackSchema := OpenStackSchema([]string{"m2.xlarge", "m1.2xlarge"})

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -262,8 +262,8 @@ type Plan struct {
 // Plans is designed to hold plan defaulting logic
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
 func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool) map[string]Plan {
-	awsSchema := AWSSchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"})
-	awsHASchema := AWSHASchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"})
+	awsSchema := AWSSchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
+	awsHASchema := AWSHASchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
 	gcpSchema := GCPSchema([]string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"})
 	openstackSchema := OpenStackSchema([]string{"m2.xlarge", "m1.2xlarge"})
 	azureSchema := AzureSchema([]string{"Standard_D8_v3"})

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -267,7 +267,7 @@ type Plan struct {
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
 func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool) map[string]Plan {
 	awsSchema := AWSSchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
-	awsHASchema := AWSHASchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
+	awsHASchema := AWSHASchema([]string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
 	gcpSchema := GCPSchema([]string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"})
 	openstackSchema := OpenStackSchema([]string{"m2.xlarge", "m1.2xlarge"})
 	azureSchema := AzureSchema([]string{"Standard_D8_v3"})

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -279,14 +279,14 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	// Schemas exposed on v2/catalog endpoint - different than provisioningRawSchema to allow backwards compatibility
 	// when a machine type switch is introduced
 	awsCatalogSchema := AWSSchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
-	awsCatalogHASchema := AWSHASchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
+	awsHACatalogSchema := AWSHASchema([]string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"})
 
 	if includeAdditionalParamsInSchema {
 		schemas := []*RootSchema{
 			&awsSchema,
 			&awsCatalogSchema,
 			&awsHASchema,
-			&awsCatalogHASchema,
+			&awsHACatalogSchema,
 			&gcpSchema,
 			&openstackSchema,
 			&azureSchema,
@@ -355,7 +355,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 					},
 				},
 			},
-			catalogRawSchema:      marshalSchema(awsCatalogHASchema),
+			catalogRawSchema:      marshalSchema(awsHACatalogSchema),
 			provisioningRawSchema: marshalSchema(awsHASchema),
 			updateRawSchema:       schemaForUpdate(awsHASchema),
 		},

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -26,7 +26,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:           "AWS schema is correct",
 			generator:      AWSSchema,
-			machineTypes:   []string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
+			machineTypes:   []string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"},
 			file:           "aws-schema.json",
 			updateFile:     "update-aws-schema.json",
 			fileOIDC:       "aws-schema-additional-params.json",
@@ -35,7 +35,7 @@ func TestSchemaGenerator(t *testing.T) {
 		{
 			name:           "AWS HA schema is correct",
 			generator:      AWSHASchema,
-			machineTypes:   []string{"m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"},
+			machineTypes:   []string{"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"},
 			file:           "aws-ha-schema.json",
 			updateFile:     "update-aws-ha-schema.json",
 			fileOIDC:       "aws-ha-schema-additional-params.json",

--- a/components/kyma-environment-broker/internal/broker/services.go
+++ b/components/kyma-environment-broker/internal/broker/services.go
@@ -52,11 +52,22 @@ func (b *ServicesEndpoint) Services(ctx context.Context) ([]domain.Service, erro
 			continue
 		}
 		p := plan.PlanDefinition
+
 		err := json.Unmarshal(plan.provisioningRawSchema, &p.Schemas.Instance.Create.Parameters)
 		if err != nil {
 			b.log.Errorf("while unmarshal provisioning schema: %s", err)
 			return nil, err
 		}
+
+		if len(plan.catalogRawSchema) > 0 {
+			// overwrite provisioning parameters schema if Plan.catalogRawSchema is provided
+			err := json.Unmarshal(plan.catalogRawSchema, &p.Schemas.Instance.Create.Parameters)
+			if err != nil {
+				b.log.Errorf("while unmarshal provisioning schema: %s", err)
+				return nil, err
+			}
+		}
+
 		if len(plan.updateRawSchema) > 0 {
 			err = json.Unmarshal(plan.updateRawSchema, &p.Schemas.Instance.Update.Parameters)
 			if err != nil {

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema-additional-params.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema-additional-params.json
@@ -20,7 +20,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
+      "enum": ["m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-ha-schema.json
@@ -20,7 +20,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
+      "enum": ["m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-schema-additional-params.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-schema-additional-params.json
@@ -20,7 +20,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
+      "enum": ["m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/broker/testdata/aws-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/aws-schema.json
@@ -20,7 +20,7 @@
     },
     "machineType": {
       "type": "string",
-      "enum": ["m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"]
+      "enum": ["m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"]
     },
     "autoScalerMin": {
       "type": "integer",

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -213,7 +213,7 @@ func awsLiteDefaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m5.xlarge",
+			MachineType:    "m6i.xlarge",
 			Region:         DefaultAWSTrialRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",
@@ -273,7 +273,6 @@ func (p *AWSTrialInput) Provider() internal.CloudProvider {
 func (p *AWSFreemiumInput) Defaults() *gqlschema.ClusterConfigInput {
 	defaults := awsLiteDefaults()
 
-	defaults.GardenerConfig.MachineType = "m6i.xlarge"
 	// Lite (freemium) must have the same defaults as Trial plan, but there was a requirement to change a region only for Trial.
 	defaults.GardenerConfig.Region = DefaultAWSRegion
 	return defaults

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -42,7 +42,7 @@ func (p *AWSInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m5.2xlarge",
+			MachineType:    "m6i.2xlarge",
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",
@@ -168,7 +168,7 @@ func (p *AWSHAInput) Defaults() *gqlschema.ClusterConfigInput {
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
-			MachineType:    "m5.2xlarge",
+			MachineType:    "m6i.2xlarge",
 			Region:         DefaultAWSRegion,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",
@@ -272,7 +272,7 @@ func (p *AWSTrialInput) Provider() internal.CloudProvider {
 
 func (p *AWSFreemiumInput) Defaults() *gqlschema.ClusterConfigInput {
 	defaults := awsLitelDefaults()
-	// Lite (freemium) must hafve the same defaults as Trial plan, but there was a requirement to change a region only for Trial.
+	// Lite (freemium) must have the same defaults as Trial plan, but there was a requirement to change a region only for Trial.
 	defaults.GardenerConfig.Region = DefaultAWSRegion
 	return defaults
 }

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -205,10 +205,10 @@ func (p *AWSInput) Provider() internal.CloudProvider {
 }
 
 func (p *AWSTrialInput) Defaults() *gqlschema.ClusterConfigInput {
-	return awsLitelDefaults()
+	return awsLiteDefaults()
 }
 
-func awsLitelDefaults() *gqlschema.ClusterConfigInput {
+func awsLiteDefaults() *gqlschema.ClusterConfigInput {
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
@@ -271,7 +271,9 @@ func (p *AWSTrialInput) Provider() internal.CloudProvider {
 }
 
 func (p *AWSFreemiumInput) Defaults() *gqlschema.ClusterConfigInput {
-	defaults := awsLitelDefaults()
+	defaults := awsLiteDefaults()
+
+	defaults.GardenerConfig.MachineType = "m6i.xlarge"
 	// Lite (freemium) must have the same defaults as Trial plan, but there was a requirement to change a region only for Trial.
 	defaults.GardenerConfig.Region = DefaultAWSRegion
 	return defaults

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -123,7 +123,7 @@ These are the provisioning parameters for AWS that you can configure:
 
 | Parameter name | Type | Description | Required | Default value |
 | ---------------|-------|-------------|:----------:|---------------|
-| **machineType** | string | Specifies the provider-specific virtual machine type. | No | `m5.2xlarge` |
+| **machineType** | string | Specifies the provider-specific virtual machine type. | No | `m6i.2xlarge` |
 | **volumeSizeGb** | int | Specifies the size of the root volume. | No | `50` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |
@@ -140,7 +140,7 @@ These are the provisioning parameters for AWS that you can configure:
 
 | Parameter name | Type | Description | Required | Default value |
 | ---------------|-------|-------------|:----------:|---------------|
-| **machineType** | string | Specifies the provider-specific virtual machine type. | No | `m5d.xlarge` |
+| **machineType** | string | Specifies the provider-specific virtual machine type. | No | `m6i.2xlarge` |
 | **volumeSizeGb** | int | Specifies the size of the root volume. | No | `50` |
 | **region** | string | Defines the cluster region. | No | `westeurope` |
 | **zones** | string | Defines the list of zones in which Runtime Provisioner creates a cluster. | No | `["1"]` |

--- a/resources/kcp/charts/kyma-metrics-collector/templates/public-cloud-info-config-map.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/public-cloud-info-config-map.yaml
@@ -297,7 +297,27 @@ data:
         "m5d.metal": {
             "cpu_cores": 96,
             "memory": 384
-        }
+        },
+        "m6i.xlarge": {
+            "cpu_cores": 4,
+            "memory": 16
+        },
+        "m6i.2xlarge": {
+            "cpu_cores": 8,
+            "memory": 32
+        },
+        "m6i.4xlarge": {
+            "cpu_cores": 16,
+            "memory": 64
+        },
+        "m6i.8xlarge": {
+            "cpu_cores": 32,
+            "memory": 128
+        },
+        "m6i.12xlarge": {
+            "cpu_cores": 48,
+            "memory": 192
+        },
       },
       "gcp": {
        "n1-standard-4": {

--- a/resources/kcp/charts/kyma-metrics-collector/templates/public-cloud-info-config-map.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/public-cloud-info-config-map.yaml
@@ -317,7 +317,7 @@ data:
         "m6i.12xlarge": {
             "cpu_cores": 48,
             "memory": 192
-        },
+        }
       },
       "gcp": {
        "n1-standard-4": {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -18,7 +18,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1115"
+      version: "PR-1152"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1149"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- machine types available for plans `aws` and `aws_ha` extended with `"m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"`
- [default machine type](https://github.com/kyma-project/control-plane/pull/1152/files#diff-50bac063fd6efced9ab53ac5e58a250131a3d60e540159e417e33063023272c8R216) for freemium and trial plans  (`aws` provider) changed to `m6i.xlarge`)
- Introduced `catalogRawSchema` which, if provided, overwrites the schema rendered by Services endpoint at `GET v2/catalog` - user's provisioning input is still validated using `provisioningRawSchema` field. This implementation allows backwards compatibility until the consumer updates the schema - new deployment will serve schema with `m6-*` machines for `aws` and `aws_ha` plans and use the default `"m6i.2xlarge"`, but will still allow to provision `aws` plan with parameter `"machineType": m5-*" so consumers which did not update the schema could still use the provisioning service
**Related issue(s)**
https://github.com/kyma-project/control-plane/issues/1002
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
