### PR TITLE
Add liveness and readiness probes to rma-reconciler

### DIFF
--- a/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma-component-reconciler/templates/deployment.yaml
@@ -37,6 +37,14 @@ spec:
         - name: http
           containerPort: 8080
           protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /health/live
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /health/ready
+            port: http
         resources: {{- toYaml .Values.resources | nindent 10 }}
         volumeMounts:
         - mountPath: /tmp


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added liveness and readiness probes to rma reconciler. As SRE, we need the liveness probe defined in deployment.yaml so that istio can overwrite it. As a result, avs will be able to monitor this component. 

