### PR TITLE
Encrypt BTP Operator ERS credentials

### DIFF
--- a/components/kyma-environment-broker/internal/storage/driver/postsql/ext.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/ext.go
@@ -7,6 +7,6 @@ type Cipher interface {
 	Decrypt(text []byte) ([]byte, error)
 
 	// methods used to encrypt/decrypt SM credentials
-	EncryptBasicAuth(pp *internal.ProvisioningParameters) error
-	DecryptBasicAuth(pp *internal.ProvisioningParameters) error
+	EncryptSMCreds(pp *internal.ProvisioningParameters) error
+	DecryptSMCreds(pp *internal.ProvisioningParameters) error
 }

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
@@ -340,7 +340,7 @@ func (s *Instance) toInstance(dto dbmodel.InstanceDTO) (internal.Instance, error
 	if err != nil {
 		return internal.Instance{}, errors.Wrap(err, "while unmarshal parameters")
 	}
-	err = s.cipher.DecryptBasicAuth(&params)
+	err = s.cipher.DecryptSMCreds(&params)
 	if err != nil {
 		return internal.Instance{}, errors.Wrap(err, "while decrypting parameters")
 	}
@@ -424,7 +424,7 @@ func (s *Instance) Update(instance internal.Instance) (*internal.Instance, error
 }
 
 func (s *Instance) toInstanceDTO(instance internal.Instance) (dbmodel.InstanceDTO, error) {
-	err := s.cipher.EncryptBasicAuth(&instance.Parameters)
+	err := s.cipher.EncryptSMCreds(&instance.Parameters)
 	if err != nil {
 		return dbmodel.InstanceDTO{}, errors.Wrap(err, "while encrypting parameters")
 	}

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/operation.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/operation.go
@@ -895,7 +895,7 @@ func (s *operations) ListUpgradeClusterOperationsByOrchestrationID(orchestration
 }
 
 func (s *operations) operationToDB(op internal.Operation) (dbmodel.OperationDTO, error) {
-	err := s.cipher.EncryptBasicAuth(&op.ProvisioningParameters)
+	err := s.cipher.EncryptSMCreds(&op.ProvisioningParameters)
 	if err != nil {
 		return dbmodel.OperationDTO{}, errors.Wrap(err, "while encrypting basic auth")
 	}
@@ -932,7 +932,7 @@ func (s *operations) toOperation(op *dbmodel.OperationDTO, instanceDetails inter
 			return internal.Operation{}, errors.Wrap(err, "while unmarshal provisioning parameters")
 		}
 	}
-	err := s.cipher.DecryptBasicAuth(&pp)
+	err := s.cipher.DecryptSMCreds(&pp)
 	if err != nil {
 		return internal.Operation{}, errors.Wrap(err, "while decrypting basic auth")
 	}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1207"
+      version: "PR-1184"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

https://github.com/kyma-project/control-plane/pull/980 has introduced `SMOperatorCredentials` in the `ERSContext`. The encryption implemented for each operation and instance would drop the `SMOperatorCredentials` and not store them in database.

This enhances the work by storing encrypted credentials in `SMOperatorCredentials` struct for each operation and instance.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/control-plane/issues/1163