### PR TITLE
Configurable deployment strategy for mothership-reconciler

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
@@ -9,6 +9,10 @@ spec:
   selector:
     matchLabels:
     {{- include "mothership-reconciler.labels" . | nindent 6 }}
+  {{- with .Values.deployment.strategy }}
+  strategy:
+{{ toYaml . | indent 4 }}
+  {{- end }}
   replicas: {{ .Values.deployment.replicasCount }}
   template:
     metadata:
@@ -141,7 +145,7 @@ spec:
         - name: audit-log
           mountPath: {{ .Values.global.mothership_reconciler.auditlog.logPath }}
         - name: fluentbit-config
-          mountPath: /fluent-bit/etc/    
+          mountPath: /fluent-bit/etc/
       {{- end }}
       volumes:
       {{- if eq .Values.global.database.embedded.enabled false }}

--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -33,6 +33,13 @@ deployment:
 
   replicasCount: 1
 
+  # Don't use surge pods during rolling update by default as mothership_reconciler.auditlog.persistence.enabled=true
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
   imagePullSecrets: []
 
   serviceAccount:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add possibility to configure deployment strategy of mothership-reconciler
- Set rollingUpdate strategy with `maxSurge` = 0, `maxUnavailable` = 1 because PV with ReadWriteOnce is used by default, which could fail to be attached properly during rolling update. 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
