### PR TITLE
Make KEB upgrade kyma queue aware of BTP Operator credentials

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -493,6 +493,38 @@ func (s *BrokerSuiteTest) FinishUpdatingOperationByReconciler(operationID string
 	assert.NoError(s.t, err)
 }
 
+func (s *BrokerSuiteTest) FinishUpdatingOperationByReconcilerBoth(operationID string) {
+	var updatingOp *internal.UpdatingOperation
+	err := wait.Poll(pollingInterval, 2*time.Second, func() (bool, error) {
+		op, err := s.db.Operations().GetUpdatingOperationByID(operationID)
+		if err != nil {
+			return false, nil
+		}
+		if op.ProvisionerOperationID != "" {
+			updatingOp = op
+			return true, nil
+		}
+		return false, nil
+	})
+	assert.NoError(s.t, err)
+
+	var state *reconciler.State
+	for ccv := updatingOp.ClusterConfigurationVersion; ccv <= updatingOp.ClusterConfigurationVersion+1; ccv++ {
+		err = wait.Poll(pollingInterval, 2*time.Second, func() (bool, error) {
+			state, err = s.reconcilerClient.GetCluster(updatingOp.RuntimeID, ccv)
+			if err != nil {
+				return false, err
+			}
+			if state.Cluster != "" {
+				s.reconcilerClient.ChangeClusterState(updatingOp.RuntimeID, ccv, reconciler.ReadyStatus)
+				return true, nil
+			}
+			return false, nil
+		})
+		assert.NoError(s.t, err)
+	}
+}
+
 func (s *BrokerSuiteTest) AssertProvisionerStartedProvisioning(operationID string) {
 	// wait until ProvisioningOperation reaches CreateRuntime step
 	var provisioningOp *internal.ProvisioningOperation
@@ -582,21 +614,20 @@ func (s *BrokerSuiteTest) AssertReconcilerStartedReconcilingWhenUpgrading(instan
 	// wait until UpgradeOperation reaches Apply_Cluster_Configuration step
 	var upgradeKymaOp *internal.UpgradeKymaOperation
 	err := wait.Poll(pollingInterval, 2*time.Second, func() (bool, error) {
-		op, err := s.db.Operations().GetUpgradeKymaOperationByInstanceID(instanceID)
-		if err != nil {
-			return false, nil
-		}
-		if op.InstanceDetails.ClusterConfigurationVersion != 0 {
-			upgradeKymaOp = op
+		upgradeKymaOp, _ = s.db.Operations().GetUpgradeKymaOperationByInstanceID(instanceID)
+		if upgradeKymaOp.InstanceDetails.ClusterConfigurationVersion != 0 {
 			return true, nil
 		}
 		return false, nil
 	})
 	assert.NoError(s.t, err)
-
+	assert.NotNil(s.t, upgradeKymaOp)
 	var state *reconcilerApi.HTTPClusterResponse
 	err = wait.Poll(pollingInterval, 2*time.Second, func() (bool, error) {
 		state, err = s.reconcilerClient.GetCluster(upgradeKymaOp.InstanceDetails.RuntimeID, upgradeKymaOp.InstanceDetails.ClusterConfigurationVersion)
+		if err != nil {
+			return false, err
+		}
 		if state.Cluster != "" {
 			return true, nil
 		}

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -879,11 +879,6 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 		cnd      upgrade_kyma.StepCondition
 	}{
 		{
-			weight: 2,
-			step:   upgrade_kyma.NewCheckClusterConfigurationStep(db.Operations(), reconcilerClient, 15*time.Minute),
-			cnd:    upgrade_kyma.ForKyma2,
-		},
-		{
 			weight: 3,
 			cnd:    upgrade_kyma.WhenBTPOperatorCredentialsNotProvided,
 			step:   upgrade_kyma.NewServiceManagerOverridesStep(db.Operations()),
@@ -923,6 +918,11 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 		{
 			weight: 10,
 			step:   upgrade_kyma.NewApplyClusterConfigurationStep(db.Operations(), db.RuntimeStates(), reconcilerClient),
+			cnd:    upgrade_kyma.ForKyma2,
+		},
+		{
+			weight: 11,
+			step:   upgrade_kyma.NewCheckClusterConfigurationStep(db.Operations(), reconcilerClient, 15*time.Minute),
 			cnd:    upgrade_kyma.ForKyma2,
 		},
 	}

--- a/components/kyma-environment-broker/cmd/broker/suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/suite_test.go
@@ -440,6 +440,7 @@ func fixK8sResources(defaultKymaVersion string, additionalKymaVersions []string)
 				"overrides-plan-aws_ha":       "true",
 				"overrides-plan-preview":      "true",
 				"overrides-version-2.0.0-rc4": "true",
+				"overrides-version-2.0.0":     "true",
 			},
 		},
 		Data: map[string]string{
@@ -461,6 +462,7 @@ func fixK8sResources(defaultKymaVersion string, additionalKymaVersions []string)
 				"overrides-plan-aws_ha":       "true",
 				"overrides-plan-preview":      "true",
 				"overrides-version-2.0.0-rc4": "true",
+				"overrides-version-2.0.0":     "true",
 				"component":                   "service-catalog2",
 			},
 		},

--- a/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
+++ b/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/google/uuid"
 	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/reconciler"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +88,126 @@ func TestKymaUpgrade_UpgradeTo2(t *testing.T) {
 	require.NoError(t, err)
 	found := suite.provisionerClient.IsRuntimeUpgraded(upgradeOp.InstanceDetails.RuntimeID, "2.0.0-rc4")
 	assert.False(t, found)
+}
+
+func TestKymaUpgrade_UpgradeAfterMigration(t *testing.T) {
+	// given
+	suite := NewBrokerSuiteTest(t)
+	mockBTPOperatorClusterID()
+	defer suite.TearDown()
+	id := "InstanceID-UpgradeAfterMigration"
+
+	// provision Kyma 2.0
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id), `
+{
+	"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+	"plan_id": "4deee563-e5ec-4731-b9b1-53b42d855f0c",
+	"context": {
+		"sm_platform_credentials": {
+			"url": "https://sm.url",
+			"credentials": {
+			"basic": {
+					"username":"smUsername",
+					"password":"smPassword"
+	  			}
+			}
+		},
+		"globalaccount_id": "g-account-id",
+		"subaccount_id": "sub-id",
+		"user_id": "john.smith@email.com"
+	},
+	"parameters": {
+		"name": "testing-cluster",
+		"kymaVersion": "2.0.0-rc4"
+	}
+}`)
+	opID := suite.DecodeOperationID(resp)
+	suite.processReconcilingByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
+
+	// migrate svcat
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id), `
+{
+	"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+	"context": {
+		"globalaccount_id": "g-account-id",
+		"subaccount_id": "sub-id",
+		"user_id": "john.smith@email.com",
+		"sm_operator_credentials": {
+			"clientid": "testClientID",
+			"clientsecret": "testClientSecret",
+			"sm_url": "https://service-manager.kyma.com",
+			"url": "https://test.auth.com",
+			"xsappname": "testXsappname"
+		},
+		"isMigration": true
+	}
+}`)
+
+	// make sure migration finished
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	updateOperationID := suite.DecodeOperationID(resp)
+	suite.FinishUpdatingOperationByProvisioner(updateOperationID)
+	suite.FinishUpdatingOperationByReconcilerBoth(updateOperationID)
+	suite.WaitForOperationState(updateOperationID, domain.Succeeded)
+
+	// run upgrade
+	orchestrationResp := suite.CallAPI("POST", "upgrade/kyma", `
+{
+	"strategy": {
+		"type": "parallel",
+		"schedule": "immediate",
+		"parallel": {
+			"workers": 1
+		}
+	},
+	"dryRun": false,
+	"targets": {
+		"include": [
+			{
+				"subAccount": "sub-id"
+			}
+		]
+	},
+	"kyma": {
+		"kymaVersion": "2.0.0"
+	}
+}`)
+	oID := suite.DecodeOrchestrationID(orchestrationResp)
+	suite.AssertReconcilerStartedReconcilingWhenUpgrading(id)
+	opResponse := suite.CallAPI("GET", fmt.Sprintf("orchestrations/%s/operations", oID), "")
+	upgradeKymaOperationID, err := suite.DecodeLastUpgradeKymaOperationIDFromOrchestration(opResponse)
+	require.NoError(t, err)
+
+	suite.FinishUpgradeKymaOperationByReconciler(upgradeKymaOperationID)
+	suite.AssertClusterKymaConfig(opID, reconciler.KymaConfig{
+		Version:        "2.0.0",
+		Profile:        "Production",
+		Administrators: []string{"john.smith@email.com"},
+		Components:     suite.fixExpectedComponentListWithSMProxy(opID),
+	})
+	suite.AssertClusterConfigWithKubeconfig(opID)
+
+	_, err = suite.db.Operations().GetUpgradeKymaOperationByID(upgradeKymaOperationID)
+	require.NoError(t, err)
+
+	// ensure component list after update is correct
+	i, err := suite.db.Instances().GetByID(id)
+	assert.NoError(t, err, "getting instance after update")
+	assert.True(t, i.InstanceDetails.SCMigrationTriggered, "instance SCMigrationTriggered after update")
+	rsu1, err := suite.db.RuntimeStates().GetLatestWithReconcilerInputByRuntimeID(i.RuntimeID)
+	assert.NoError(t, err, "getting runtime after update")
+	assert.NotEqual(t, rsu1.ID, rsu1.ID, "runtime_state ID from update should differ runtime_state ID from update")
+	assert.Equal(t, updateOperationID, rsu1.OperationID, "runtime state update operation ID")
+	assert.ElementsMatch(t, componentNames(rsu1.ClusterSetup.KymaConfig.Components), []string{"ory", "monitoring", "btp-operator"})
+
+	// ensure component list after upgrade didn't get changed
+	i, err = suite.db.Instances().GetByID(id)
+	assert.NoError(t, err, "getting instance after upgrade")
+	assert.True(t, i.InstanceDetails.SCMigrationTriggered, "instance SCMigrationTriggered after upgrade")
+	rsu2, err := suite.db.RuntimeStates().GetLatestWithReconcilerInputByRuntimeID(i.RuntimeID)
+	assert.NoError(t, err, "getting runtime after upgrade")
+	assert.NotEqual(t, rsu1.ID, rsu2.ID, "runtime_state ID from update should differ runtime_state ID from upgrade")
+	assert.Equal(t, updateOperationID, rsu2.OperationID, "runtime state upgrade operation ID")
+	assert.ElementsMatch(t, componentNames(rsu2.ClusterSetup.KymaConfig.Components), []string{"ory", "monitoring", "btp-operator"})
 }

--- a/components/kyma-environment-broker/internal/process/update/sc_migration_check_step.go
+++ b/components/kyma-environment-broker/internal/process/update/sc_migration_check_step.go
@@ -40,7 +40,7 @@ func (s *CheckReconcilerState) Run(operation internal.UpdatingOperation, log log
 	}
 	switch state.Status {
 	case reconcilerApi.StatusReconciling, reconcilerApi.StatusReconcilePending:
-		log.Info("Reconciler status %v", state.Status)
+		log.Infof("Reconciler status %v", state.Status)
 		return operation, 30 * time.Second, nil
 	case reconcilerApi.StatusReconcileErrorRetryable:
 		log.Infof("Reconciler failed with retryable, rechecking in 10 minutes.")

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/get_kubeconfig_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/get_kubeconfig_step.go
@@ -33,6 +33,7 @@ func (s *GetKubeconfigStep) Name() string {
 
 func (s *GetKubeconfigStep) Run(operation internal.UpgradeKymaOperation, log logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
 	if operation.Kubeconfig != "" {
+		operation.InputCreator.SetKubeconfig(operation.Kubeconfig)
 		return operation, 0, nil
 	}
 	if operation.Runtime.RuntimeID == "" {
@@ -46,7 +47,7 @@ func (s *GetKubeconfigStep) Run(operation internal.UpgradeKymaOperation, log log
 		return operation, 1 * time.Minute, nil
 	}
 
-	if status.RuntimeConfiguration.Kubeconfig == nil {
+	if status.RuntimeConfiguration.Kubeconfig == nil || *status.RuntimeConfiguration.Kubeconfig == "" {
 		log.Errorf("kubeconfig is not provided")
 		return operation, 1 * time.Minute, nil
 	}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go
@@ -120,7 +120,6 @@ func (s *InitialisationStep) Run(operation internal.UpgradeKymaOperation, log lo
 				op.ProvisioningParameters.ErsContext.SMOperatorCredentials = lastOp.ProvisioningParameters.ErsContext.SMOperatorCredentials
 			}
 			op.State = domain.InProgress
-			op.ClusterConfigurationVersion = 0
 		}, log)
 		if delay != 0 {
 			return operation, delay, nil

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go
@@ -116,6 +116,9 @@ func (s *InitialisationStep) Run(operation internal.UpgradeKymaOperation, log lo
 		}
 		op, delay := s.operationManager.UpdateOperation(operation, func(op *internal.UpgradeKymaOperation) {
 			op.ProvisioningParameters = provisioningOperation.ProvisioningParameters
+			if op.ProvisioningParameters.ErsContext.SMOperatorCredentials == nil && lastOp.ProvisioningParameters.ErsContext.SMOperatorCredentials != nil {
+				op.ProvisioningParameters.ErsContext.SMOperatorCredentials = lastOp.ProvisioningParameters.ErsContext.SMOperatorCredentials
+			}
 			op.State = domain.InProgress
 			op.ClusterConfigurationVersion = 0
 		}, log)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1198"
     kyma_environment_broker:
       dir:
-      version: "PR-1204"
+      version: "PR-1201"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Upgrade kyma queue currently ignores the fact ERS call could have updated ERSContext with new BTP operator credentials and would always install service catalog. This ensures KEB picks up the up to date ERSContext.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
closes: https://github.com/kyma-project/control-plane/issues/1163
depends on:
- [x] https://github.com/kyma-project/control-plane/pull/1184