### PR TITLE
Fix determining current Kyma version by operations

### DIFF
--- a/components/kyma-environment-broker/internal/runtime/handler.go
+++ b/components/kyma-environment-broker/internal/runtime/handler.go
@@ -319,7 +319,7 @@ func determineKymaVersion(pOprs []internal.ProvisioningOperation, uOprs []intern
 	//   - is not dry-run
 	//   - is created after the last provisioning operation
 	//   - has the kyma version set
-	//   - the has been processed, i.e. not pending, canceling or canceled
+	//   - has been processed, i.e. not pending, canceling or canceled
 	// Use the last provisioning kyma version if no such upgrade operation was found, or the processed upgrade happened before the last provisioning operation.
 	for _, u := range uOprs {
 		if !u.DryRun && u.CreatedAt.After(kymaVersionSetAt) && u.RuntimeVersion.Version != "" && u.State != orchestration.Pending && u.State != orchestration.Canceling && u.State != orchestration.Canceled {

--- a/components/kyma-environment-broker/internal/runtime/handler.go
+++ b/components/kyma-environment-broker/internal/runtime/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/pagination"
 	pkg "github.com/kyma-project/control-plane/components/kyma-environment-broker/common/runtime"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -160,8 +161,6 @@ func setRuntimeStateByOperationState(dto *pkg.RuntimeDTO) {
 }
 
 func (h *Handler) setRuntimeAllOperations(instance internal.Instance, dto *pkg.RuntimeDTO) error {
-	kymaVersion := ""
-	kymaVersionSetAt := time.Time{}
 	provOprs, err := h.operationsDb.ListProvisioningOperationsByInstanceID(instance.InstanceID)
 	if err != nil && !dberr.IsNotFound(err) {
 		return errors.Wrap(err, "while fetching provisioning operations list for instance")
@@ -175,9 +174,6 @@ func (h *Handler) setRuntimeAllOperations(instance internal.Instance, dto *pkg.R
 		if len(provOprs) > 1 {
 			h.converter.ApplyUnsuspensionOperations(dto, provOprs[:len(provOprs)-1])
 		}
-		// Set kyma version from the last provisioning operation
-		kymaVersion = lastProvOp.RuntimeVersion.Version
-		kymaVersionSetAt = lastProvOp.CreatedAt
 	}
 
 	deprovOprs, err := h.operationsDb.ListDeprovisioningOperationsByInstanceID(instance.InstanceID)
@@ -200,11 +196,9 @@ func (h *Handler) setRuntimeAllOperations(instance internal.Instance, dto *pkg.R
 	if err != nil && !dberr.IsNotFound(err) {
 		return errors.Wrap(err, "while fetching upgrade kyma operation for instance")
 	}
+	dto.KymaVersion = determineKymaVersion(provOprs, ukOprs)
 	ukOprs, totalCount := h.takeLastNonDryRunOperations(ukOprs)
 	h.converter.ApplyUpgradingKymaOperations(dto, ukOprs, totalCount)
-	if len(ukOprs) > 0 && ukOprs[0].CreatedAt.After(kymaVersionSetAt) {
-		kymaVersion = ukOprs[0].RuntimeVersion.Version
-	}
 
 	ucOprs, err := h.operationsDb.ListUpgradeClusterOperationsByInstanceID(instance.InstanceID)
 	if err != nil && !dberr.IsNotFound(err) {
@@ -222,8 +216,6 @@ func (h *Handler) setRuntimeAllOperations(instance internal.Instance, dto *pkg.R
 		uOprs = uOprs[0:numberOfUpgradeOperationsToReturn]
 	}
 	h.converter.ApplyUpdateOperations(dto, uOprs, totalCount)
-
-	dto.KymaVersion = kymaVersion
 
 	return nil
 }
@@ -311,6 +303,34 @@ func (h *Handler) setRuntimeOptionalAttributes(instance internal.Instance, dto *
 	}
 
 	return nil
+}
+
+func determineKymaVersion(pOprs []internal.ProvisioningOperation, uOprs []internal.UpgradeKymaOperation) string {
+	kymaVersion := ""
+	kymaVersionSetAt := time.Time{}
+
+	// Set kyma version from the last provisioning operation
+	if len(pOprs) != 0 {
+		kymaVersion = pOprs[0].RuntimeVersion.Version
+		kymaVersionSetAt = pOprs[0].CreatedAt
+	}
+
+	// Take the last upgrade kyma operation which
+	//   - is not dry-run
+	//   - is created after the last provisioning operation
+	//   - has the kyma version set
+	//   - the has been processed, i.e. not pending, canceling or canceled
+	// Use the last provisioning kyma version if no such upgrade operation was found, or the processed upgrade happened before the last provisioning operation.
+	for _, u := range uOprs {
+		if !u.DryRun && u.CreatedAt.After(kymaVersionSetAt) && u.RuntimeVersion.Version != "" && u.State != orchestration.Pending && u.State != orchestration.Canceling && u.State != orchestration.Canceled {
+			kymaVersion = u.RuntimeVersion.Version
+			break
+		} else if u.CreatedAt.Before(kymaVersionSetAt) {
+			break
+		}
+	}
+
+	return kymaVersion
 }
 
 func (h *Handler) getFilters(req *http.Request) dbmodel.InstanceFilter {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1190"
+      version: "PR-1202"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
**Description**

The previous [PR about exposing current Kyma version on /runtimes endpoint](https://github.com/kyma-project/control-plane/pull/1190) has multiple flaws, e.g. it doesn't take into account whether upgrade operations has been processed or not.
This PR fixes these issues.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
