### PR TITLE
Explicitly fail KEB update operations on irrecoverable errors

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -751,12 +751,12 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *update.Manager, work
 		},
 		{
 			stage:     "runtime",
-			step:      update.NewBTPOperatorOverridesStep(runtimeProvider),
+			step:      update.NewBTPOperatorOverridesStep(db.Operations(), runtimeProvider),
 			condition: ifBTPMigrationEnabled(update.ForBTPOperatorCredentialsProvided),
 		},
 		{
 			stage:     "runtime",
-			step:      update.NewSCMigrationStep(runtimeProvider),
+			step:      update.NewSCMigrationStep(db.Operations(), runtimeProvider),
 			condition: ifBTPMigrationEnabled(update.ForMigration),
 		},
 		{
@@ -766,7 +766,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *update.Manager, work
 		},
 		{
 			stage:     "runtime",
-			step:      update.NewCheckReconcilerState(reconcilerClient),
+			step:      update.NewCheckReconcilerState(db.Operations(), reconcilerClient),
 			condition: ifBTPMigrationEnabled(update.ForContainsReconcilerClusterConfigVersion),
 		},
 		{
@@ -781,7 +781,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *update.Manager, work
 		},
 		{
 			stage:     "runtime",
-			step:      update.NewCheckReconcilerState(reconcilerClient),
+			step:      update.NewCheckReconcilerState(db.Operations(), reconcilerClient),
 			condition: ifBTPMigrationEnabled(update.ForContainsReconcilerClusterConfigVersion),
 		},
 		{

--- a/components/kyma-environment-broker/internal/process/update/apply_reconciler_configuration.go
+++ b/components/kyma-environment-broker/internal/process/update/apply_reconciler_configuration.go
@@ -47,9 +47,7 @@ func (s *ApplyReconcilerConfigurationStep) Run(operation internal.UpdatingOperat
 		log.Error(msg)
 		return operation, 5 * time.Second, nil
 	case err != nil:
-		msg := fmt.Sprintf("Request to Reconciler failed: %s", err.Error())
-		log.Error(msg)
-		return operation, 0, err
+		return s.operationManager.OperationFailed(operation, err.Error(), log)
 	}
 
 	log.Infof("Reconciler configuration version %d", state.ConfigurationVersion)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1202"
+      version: "PR-1206"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In #825, I have introduced an error in update queue where irrecoverable errors from reconciler are silently ignored. This ensures that non-retryable errors related to reconciler are failing the operation as well.

**Related issue(s)**
related to recent debugging in https://github.com/kyma-project/control-plane/issues/1122
