### PR TITLE
Check reconciler status in update queue only when required

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -767,7 +767,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *update.Manager, work
 		{
 			stage:     "runtime",
 			step:      update.NewCheckReconcilerState(db.Operations(), reconcilerClient),
-			condition: ifBTPMigrationEnabled(update.ForContainsReconcilerClusterConfigVersion),
+			condition: ifBTPMigrationEnabled(update.CheckReconcilerStatus),
 		},
 		{
 			stage:     "runtime",
@@ -782,7 +782,7 @@ func NewUpdateProcessingQueue(ctx context.Context, manager *update.Manager, work
 		{
 			stage:     "runtime",
 			step:      update.NewCheckReconcilerState(db.Operations(), reconcilerClient),
-			condition: ifBTPMigrationEnabled(update.ForContainsReconcilerClusterConfigVersion),
+			condition: ifBTPMigrationEnabled(update.CheckReconcilerStatus),
 		},
 		{
 			stage: "check",

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -341,8 +341,9 @@ type DeprovisioningOperation struct {
 type UpdatingOperation struct {
 	Operation
 
-	RuntimeVersion     RuntimeVersionData    `json:"runtime_version"`
-	UpdatingParameters UpdatingParametersDTO `json:"updating_parameters"`
+	RuntimeVersion        RuntimeVersionData    `json:"runtime_version"`
+	UpdatingParameters    UpdatingParametersDTO `json:"updating_parameters"`
+	CheckReconcilerStatus bool                  `json:"check_reconciler_status"`
 
 	// following fields are not stored in the storage
 	InputCreator ProvisionerInputCreator `json:"-"`

--- a/components/kyma-environment-broker/internal/process/update/apply_reconciler_configuration.go
+++ b/components/kyma-environment-broker/internal/process/update/apply_reconciler_configuration.go
@@ -53,6 +53,7 @@ func (s *ApplyReconcilerConfigurationStep) Run(operation internal.UpdatingOperat
 	log.Infof("Reconciler configuration version %d", state.ConfigurationVersion)
 	updatedOperation, repeat := s.operationManager.UpdateOperation(operation, func(op *internal.UpdatingOperation) {
 		op.ClusterConfigurationVersion = state.ConfigurationVersion
+		op.CheckReconcilerStatus = true
 	}, log)
 	if repeat != 0 {
 		log.Errorf("cannot save cluster configuration version")

--- a/components/kyma-environment-broker/internal/process/update/conditions.go
+++ b/components/kyma-environment-broker/internal/process/update/conditions.go
@@ -33,6 +33,6 @@ func ForMigration(op internal.UpdatingOperation) bool {
 	return op.InstanceDetails.SCMigrationTriggered && op.RuntimeVersion.MajorVersion == 2
 }
 
-func ForContainsReconcilerClusterConfigVersion(op internal.UpdatingOperation) bool {
-	return op.ClusterConfigurationVersion != 0
+func CheckReconcilerStatus(op internal.UpdatingOperation) bool {
+	return op.CheckReconcilerStatus
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1206"
+      version: "PR-1207"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
In #825, I introduced interactions with reconciler. The algorithm would execute reconciler  checks when operation contained `ClusterConfigurationVersion` populated from status of the last apply changes in reconciler. This number is inherited from previous operations and essentially meant that every update on kyma 2.0 would execute this check. An update to gardener could fail the operation if reconciler is having troubles. But we don't need to check status of the reconciler for purely gardener update operations.

This PR changes the check from looking at `ClusterConfigurationVersion` to explicit flag on an operation, that is set when certain step really talks to the reconciler and we need to wait for the processing to move forward to the next step.

**Related issue(s)**
https://github.com/kyma-project/control-plane/issues/1122