### PR TITLE
KEB takes updateAt/modifiedAt field for runtime status from last operation

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -460,7 +460,7 @@ func createAPI(router *mux.Router, servicesConfig broker.ServicesConfig, planVal
 	}
 
 	respWriter := httputil.NewResponseWriter(logs, cfg.DevelopmentMode)
-	runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(db.Instances(), defaultPlansConfig, cfg.DefaultRequestRegion, respWriter)
+	runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(db.Instances(), db.Operations(), defaultPlansConfig, cfg.DefaultRequestRegion, respWriter)
 	router.Handle("/info/runtimes", runtimesInfoHandler)
 }
 

--- a/components/kyma-environment-broker/internal/appinfo/runtime_info_test.go
+++ b/components/kyma-environment-broker/internal/appinfo/runtime_info_test.go
@@ -97,7 +97,7 @@ func TestRuntimeInfoHandlerSuccess(t *testing.T) {
 				memStorage = newInMemoryStorage(t, tc.instances, tc.provisionOp, tc.deprovisionOp)
 			)
 
-			handler := appinfo.NewRuntimeInfoHandler(memStorage.Instances(), broker.PlansConfig{}, "default-region", writer)
+			handler := appinfo.NewRuntimeInfoHandler(memStorage.Instances(), memStorage.Operations(), broker.PlansConfig{}, "default-region", writer)
 
 			// when
 			handler.ServeHTTP(respSpy, fixReq)
@@ -128,7 +128,7 @@ func TestRuntimeInfoHandlerFailures(t *testing.T) {
 	storageMock := &automock.InstanceFinder{}
 	defer storageMock.AssertExpectations(t)
 	storageMock.On("FindAllJoinedWithOperations", mock.Anything).Return(nil, errors.New("ups.. internal info"))
-	handler := appinfo.NewRuntimeInfoHandler(storageMock, broker.PlansConfig{}, "", writer)
+	handler := appinfo.NewRuntimeInfoHandler(storageMock, nil, broker.PlansConfig{}, "", writer)
 
 	// when
 	handler.ServeHTTP(respSpy, fixReq)
@@ -223,7 +223,7 @@ func TestRuntimeInfoHandlerOperationRecognition(t *testing.T) {
 		require.NoError(t, err)
 
 		responseWriter := httputil.NewResponseWriter(logger.NewLogDummy(), true)
-		runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(instances, broker.PlansConfig{}, "", responseWriter)
+		runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(instances, operations, broker.PlansConfig{}, "", responseWriter)
 
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()
@@ -332,7 +332,7 @@ func TestRuntimeInfoHandlerOperationRecognition(t *testing.T) {
 		require.NoError(t, err)
 
 		responseWriter := httputil.NewResponseWriter(logger.NewLogDummy(), true)
-		runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(instances, broker.PlansConfig{}, "", responseWriter)
+		runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(instances, operations, broker.PlansConfig{}, "", responseWriter)
 
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()
@@ -470,7 +470,7 @@ func TestRuntimeInfoHandlerOperationRecognition(t *testing.T) {
 		require.NoError(t, err)
 
 		responseWriter := httputil.NewResponseWriter(logger.NewLogDummy(), true)
-		runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(instances, broker.PlansConfig{}, "", responseWriter)
+		runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(instances, operations, broker.PlansConfig{}, "", responseWriter)
 
 		rr := httptest.NewRecorder()
 		router := mux.NewRouter()

--- a/components/kyma-environment-broker/internal/appinfo/testdata/TestRuntimeInfoHandlerSuccess/instances_with_deprovision_operation.golden.json
+++ b/components/kyma-environment-broker/internal/appinfo/testdata/TestRuntimeInfoHandlerSuccess/instances_with_deprovision_operation.golden.json
@@ -14,7 +14,7 @@
         "description": "esc for succeeded op.. IDX: 1",
         "state": "succeeded"
       },
-      "updatedAt": "2020-04-21T00:01:23.000000042Z"
+      "updatedAt": "2020-04-23T00:00:23.000000042Z"
     },
     "subaccountId": "SubAccountID field. IDX: 1",
     "subaccountRegion": "region-value-idx-1"
@@ -34,7 +34,7 @@
         "description": "esc for succeeded op.. IDX: 2",
         "state": "succeeded"
       },
-      "updatedAt": "2020-04-21T00:02:23.000000042Z"
+      "updatedAt": "2020-04-25T00:00:23.000000042Z"
     },
     "subaccountId": "SubAccountID field. IDX: 2",
     "subaccountRegion": "region-value-idx-2"

--- a/components/kyma-environment-broker/internal/appinfo/testdata/TestRuntimeInfoHandlerSuccess/instances_with_provision_and_deprovision_operations.golden.json
+++ b/components/kyma-environment-broker/internal/appinfo/testdata/TestRuntimeInfoHandlerSuccess/instances_with_provision_and_deprovision_operations.golden.json
@@ -18,7 +18,7 @@
         "description": "esc for succeeded op.. IDX: 1",
         "state": "succeeded"
       },
-      "updatedAt": "2020-04-21T00:01:23.000000042Z"
+      "updatedAt": "2020-04-23T00:00:23.000000042Z"
     },
     "subaccountId": "SubAccountID field. IDX: 1",
     "subaccountRegion": "region-value-idx-1"
@@ -42,7 +42,7 @@
         "description": "esc for succeeded op.. IDX: 2",
         "state": "succeeded"
       },
-      "updatedAt": "2020-04-21T00:02:23.000000042Z"
+      "updatedAt": "2020-04-25T00:00:23.000000042Z"
     },
     "subaccountId": "SubAccountID field. IDX: 2",
     "subaccountRegion": "region-value-idx-2"

--- a/components/kyma-environment-broker/internal/appinfo/testdata/TestRuntimeInfoHandlerSuccess/instances_with_provision_operation.golden.json
+++ b/components/kyma-environment-broker/internal/appinfo/testdata/TestRuntimeInfoHandlerSuccess/instances_with_provision_operation.golden.json
@@ -14,7 +14,7 @@
         "description": "esc for succeeded op.. IDX: 1",
         "state": "succeeded"
       },
-      "updatedAt": "2020-04-21T00:01:23.000000042Z"
+      "updatedAt": "2020-04-23T00:00:23.000000042Z"
     },
     "subaccountId": "SubAccountID field. IDX: 1",
     "subaccountRegion": "region-value-idx-1"
@@ -34,7 +34,7 @@
         "description": "esc for succeeded op.. IDX: 2",
         "state": "succeeded"
       },
-      "updatedAt": "2020-04-21T00:02:23.000000042Z"
+      "updatedAt": "2020-04-25T00:00:23.000000042Z"
     },
     "subaccountId": "SubAccountID field. IDX: 2",
     "subaccountRegion": "region-value-idx-2"

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1217"
+      version: "PR-1214"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
updatedAt/modifiedAt timestamp value was taken from Instance, which is updated only in special cases for corresponding OSB API change like PATCH request (for example changing Instance parameters). Because `/runtimes` and `/info/runtimes` are technical endpoints and the entity which is described Runtime, the proper timestamp for the last "change" for particular Runtime is the timestamp of last operation update for this Runtime.

 For example, if the provisioning operation for the Runtime has finished (despite the state - success or failure), and this is the only operation for this particular Runtime, the last operation's `updatedAt` timestamp should be shown in the presentation layer as the last change for the chosen Runtime.


Changes proposed in this pull request:

- KEB takes timestamp for updatedAt/modifiedAt timestamp value on runtime status endpoints (`/runtimes`, `/info/runtimes`) from last operation for this runtime

**Related issue(s)**
https://github.com/kyma-project/control-plane/issues/1171
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
