### PR TITLE
Disable sc-migration component for upgrade queue on kyma2

### DIFF
--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_cluster_configuration.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_cluster_configuration.go
@@ -32,6 +32,7 @@ func (s *ApplyClusterConfigurationStep) Name() string {
 }
 
 func (s *ApplyClusterConfigurationStep) Run(operation internal.UpgradeKymaOperation, log logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
+	operation.InputCreator.DisableOptionalComponent(internal.SCMigrationComponentName)
 	operation.InputCreator.SetRuntimeID(operation.InstanceDetails.RuntimeID).
 		SetInstanceID(operation.InstanceID).
 		SetShootName(operation.InstanceDetails.ShootName).

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1134"
     kyma_environment_broker:
       dir:
-      version: "PR-1184"
+      version: "PR-1217"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In #825, the `sc-migration` component was introduced and disabled for all queues except for upgrade with kyma2.0. 
For kyma1.x it is disabled here:

https://github.com/kyma-project/control-plane/blob/b7bdccf6100da21795877ad798777a6867d81238/components/kyma-environment-broker/internal/process/upgrade_kyma/upgrade_kyma_step.go#L52

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
