### PR TITLE
KCP CLI: username is not allowed to be set by USERNAME environment variable

### DIFF
--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -96,8 +96,6 @@ func SetGlobalOpts(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().String(GlobalOpts.gardenerNamespace, "", "Gardener Namespace (project) to use. Can also be set using the KCP_GARDENER_NAMESPACE environment variable.")
 	viper.BindPFlag(GlobalOpts.gardenerNamespace, cmd.PersistentFlags().Lookup(GlobalOpts.gardenerNamespace))
-
-	viper.BindEnv(GlobalOpts.username)
 }
 
 // ValidateGlobalOpts checks the presence of the required global configuration parameters


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- USERNAME environment variable collides with shell default OS username on Windows and some Linux distributions. 
- Only allow specifying username in configuration file for tech user purposes, when ROPC is needed

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
