### PR TITLE
KEB DB tests use SQL statements defined in the schema migrator instead of test_utils

### DIFF
--- a/components/kyma-environment-broker/internal/cis/e2e/tests_utils.go
+++ b/components/kyma-environment-broker/internal/cis/e2e/tests_utils.go
@@ -42,9 +42,9 @@ func initTestDBInstancesTables(t *testing.T, connectionURL string) error {
 				t.Logf("Cannot apply file %s", file.Name())
 				return err
 			}
-			t.Logf("File %s applied to database", file.Name())
 		}
 	}
+	t.Log("Files applied to database")
 
 	return nil
 }

--- a/components/kyma-environment-broker/internal/cis/e2e/tests_utils.go
+++ b/components/kyma-environment-broker/internal/cis/e2e/tests_utils.go
@@ -2,11 +2,12 @@ package e2e
 
 import (
 	"fmt"
+	"io/ioutil"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/postsql"
 
 	"github.com/google/uuid"
@@ -24,12 +25,33 @@ func initTestDBInstancesTables(t *testing.T, connectionURL string) error {
 		return err
 	}
 
-	tables := storage.FixTables()
-	if _, err := connection.Exec(tables[postsql.InstancesTableName]); err != nil {
-		t.Log("Cannot create table Instances")
+	//tables := storage.FixTables()
+	//if _, err := connection.Exec(tables[postsql.InstancesTableName]); err != nil {
+	//	t.Log("Cannot create table Instances")
+	//	return err
+	//}
+	//t.Log("Table Instances added to database")
+
+	dirPath := "./../../../../schema-migrator/migrations/kyma-environment-broker/"
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		t.Logf("Cannot read files from directory %s", dirPath)
 		return err
 	}
-	t.Log("Table Instances added to database")
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), "up.sql") {
+			v, err := ioutil.ReadFile(dirPath + file.Name())
+			if err != nil {
+				t.Logf("Cannot read file %s", file.Name())
+			}
+			if _, err = connection.Exec(string(v)); err != nil {
+				t.Logf("Cannot apply file %s", file.Name())
+				return err
+			}
+			t.Logf("File %s applied to database", file.Name())
+		}
+	}
 
 	return nil
 }

--- a/components/kyma-environment-broker/internal/cis/e2e/tests_utils.go
+++ b/components/kyma-environment-broker/internal/cis/e2e/tests_utils.go
@@ -25,13 +25,6 @@ func initTestDBInstancesTables(t *testing.T, connectionURL string) error {
 		return err
 	}
 
-	//tables := storage.FixTables()
-	//if _, err := connection.Exec(tables[postsql.InstancesTableName]); err != nil {
-	//	t.Log("Cannot create table Instances")
-	//	return err
-	//}
-	//t.Log("Table Instances added to database")
-
 	dirPath := "./../../../../schema-migrator/migrations/kyma-environment-broker/"
 	files, err := ioutil.ReadDir(dirPath)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/storage/tests_utils.go
+++ b/components/kyma-environment-broker/internal/storage/tests_utils.go
@@ -3,9 +3,11 @@ package storage
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,12 +220,32 @@ func InitTestDBTables(t *testing.T, connectionURL string) (func(), error) {
 		return cleanupFunc, nil
 	}
 
-	for name, v := range FixTables() {
-		if _, err := connection.Exec(v); err != nil {
-			t.Logf("Cannot create table %s", name)
-			return nil, err
+	//for name, v := range FixTables() {
+	//	if _, err := connection.Exec(v); err != nil {
+	//		t.Logf("Cannot create table %s", name)
+	//		return nil, err
+	//	}
+	//	t.Logf("Table %s added to database", name)
+	//}
+	dirPath := "./../../../../../schema-migrator/migrations/kyma-environment-broker/"
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		log.Printf("Cannot read files from directory %s", dirPath)
+		return nil, err
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), "up.sql") {
+			v, err := ioutil.ReadFile(dirPath + file.Name())
+			if err != nil {
+				log.Printf("Cannot read file %s", file.Name())
+			}
+			if _, err = connection.Exec(string(v)); err != nil {
+				log.Printf("Cannot apply file %s", file.Name())
+				return nil, err
+			}
+			log.Printf("File %s applied to database", file.Name())
 		}
-		t.Logf("Table %s added to database", name)
 	}
 
 	return cleanupFunc, nil
@@ -251,12 +273,33 @@ func SetupTestDBTables(connectionURL string) (cleanupFunc func(), err error) {
 		return cleanupFunc, nil
 	}
 
-	for name, v := range FixTables() {
-		if _, err := connection.Exec(v); err != nil {
-			log.Printf("Cannot create table %s", name)
-			return nil, err
+	//for name, v := range FixTables() {
+	//	if _, err := connection.Exec(v); err != nil {
+	//		log.Printf("Cannot create table %s", name)
+	//		return nil, err
+	//	}
+	//	log.Printf("Table %s added to database", name)
+	//}
+
+	dirPath := "./../../../../../schema-migrator/migrations/kyma-environment-broker/"
+	files, err := ioutil.ReadDir(dirPath)
+	if err != nil {
+		log.Printf("Cannot read files from directory %s", dirPath)
+		return nil, err
+	}
+
+	for _, file := range files {
+		if strings.HasSuffix(file.Name(), "up.sql") {
+			v, err := ioutil.ReadFile(dirPath + file.Name())
+			if err != nil {
+				log.Printf("Cannot read file %s", file.Name())
+			}
+			if _, err = connection.Exec(string(v)); err != nil {
+				log.Printf("Cannot apply file %s", file.Name())
+				return nil, err
+			}
+			log.Printf("File %s applied to database", file.Name())
 		}
-		log.Printf("Table %s added to database", name)
 	}
 
 	return cleanupFunc, nil
@@ -381,69 +424,69 @@ func isDBContainerAvailable(hostname, port string) (isAvailable bool, dbCfg Conf
 	return false, Config{}, err
 }
 
-func FixTables() map[string]string {
-	return map[string]string{
-		postsql.InstancesTableName: fmt.Sprintf(
-			`CREATE TABLE IF NOT EXISTS %s (
-			instance_id varchar(255) PRIMARY KEY,
-			runtime_id varchar(255) NOT NULL,
-			global_account_id varchar(255) NOT NULL,
-			subscription_global_account_id varchar(255) NOT NULL,
-			sub_account_id varchar(255) NOT NULL,
-			service_id varchar(255) NOT NULL,
-			service_name varchar(255) NOT NULL,
-			service_plan_id varchar(255) NOT NULL,
-			service_plan_name varchar(255) NOT NULL,
-			dashboard_url varchar(255) NOT NULL,
-			provisioning_parameters text NOT NULL,
-			provider_region varchar(32) NOT NULL,
-			provider varchar(32) NOT NULL DEFAULT '',
-            version integer NOT NULL DEFAULT 0,
-			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-			deleted_at TIMESTAMPTZ NOT NULL DEFAULT '0001-01-01 00:00:00+00'
-		)`, postsql.InstancesTableName),
-		postsql.OperationTableName: fmt.Sprintf(
-			`CREATE TABLE IF NOT EXISTS %s (
-			id varchar(255) PRIMARY KEY,
-			instance_id varchar(255) NOT NULL,
-			target_operation_id varchar(255) NOT NULL,
-			version integer NOT NULL,
-			state varchar(32) NOT NULL,
-			description text NOT NULL,
-			type varchar(32) NOT NULL,
-			data json NOT NULL,
-			provisioning_parameters json NOT NULL,
-			orchestration_id varchar(64),
-            finished_stages text,
-			created_at TIMESTAMPTZ NOT NULL,
-			updated_at TIMESTAMPTZ NOT NULL
-			)`, postsql.OperationTableName),
-		postsql.OrchestrationTableName: fmt.Sprintf(
-			`CREATE TABLE IF NOT EXISTS %s (
-			orchestration_id varchar(255) PRIMARY KEY,
-			type varchar(32) NOT NULL,
-			state varchar(32) NOT NULL,
-			description text,
-			parameters text NOT NULL,
-			runtime_operations text,
-			created_at TIMESTAMPTZ NOT NULL,
-			updated_at TIMESTAMPTZ NOT NULL
-			)`, postsql.OrchestrationTableName),
-		postsql.RuntimeStateTableName: fmt.Sprintf(
-			`CREATE TABLE IF NOT EXISTS %s (
-			id varchar(255) PRIMARY KEY,
-    		runtime_id varchar(255),
-    		operation_id varchar(255),
-    		created_at TIMESTAMPTZ NOT NULL,
-			kyma_config text,
-			cluster_config text,
-			cluster_setup text,
-			kyma_version text,
-			k8s_version text
-			)`, postsql.RuntimeStateTableName),
-	}
-}
+//func FixTables() map[string]string {
+//	return map[string]string{
+//		postsql.InstancesTableName: fmt.Sprintf(
+//			`CREATE TABLE IF NOT EXISTS %s (
+//			instance_id varchar(255) PRIMARY KEY,
+//			runtime_id varchar(255) NOT NULL,
+//			global_account_id varchar(255) NOT NULL,
+//			subscription_global_account_id varchar(255) NOT NULL,
+//			sub_account_id varchar(255) NOT NULL,
+//			service_id varchar(255) NOT NULL,
+//			service_name varchar(255) NOT NULL,
+//			service_plan_id varchar(255) NOT NULL,
+//			service_plan_name varchar(255) NOT NULL,
+//			dashboard_url varchar(255) NOT NULL,
+//			provisioning_parameters text NOT NULL,
+//			provider_region varchar(32) NOT NULL,
+//			provider varchar(32) NOT NULL DEFAULT '',
+//           version integer NOT NULL DEFAULT 0,
+//			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+//			deleted_at TIMESTAMPTZ NOT NULL DEFAULT '0001-01-01 00:00:00+00'
+//		)`, postsql.InstancesTableName),
+//		postsql.OperationTableName: fmt.Sprintf(
+//			`CREATE TABLE IF NOT EXISTS %s (
+//			id varchar(255) PRIMARY KEY,
+//			instance_id varchar(255) NOT NULL,
+//			target_operation_id varchar(255) NOT NULL,
+//			version integer NOT NULL,
+//			state varchar(32) NOT NULL,
+//			description text NOT NULL,
+//			type varchar(32) NOT NULL,
+//			data json NOT NULL,
+//			provisioning_parameters json NOT NULL,
+//			orchestration_id varchar(64),
+//           finished_stages text,
+//			created_at TIMESTAMPTZ NOT NULL,
+//			updated_at TIMESTAMPTZ NOT NULL
+//			)`, postsql.OperationTableName),
+//		postsql.OrchestrationTableName: fmt.Sprintf(
+//			`CREATE TABLE IF NOT EXISTS %s (
+//			orchestration_id varchar(255) PRIMARY KEY,
+//			type varchar(32) NOT NULL,
+//			state varchar(32) NOT NULL,
+//			description text,
+//			parameters text NOT NULL,
+//			runtime_operations text,
+//			created_at TIMESTAMPTZ NOT NULL,
+//			updated_at TIMESTAMPTZ NOT NULL
+//			)`, postsql.OrchestrationTableName),
+//		postsql.RuntimeStateTableName: fmt.Sprintf(
+//			`CREATE TABLE IF NOT EXISTS %s (
+//			id varchar(255) PRIMARY KEY,
+//   		runtime_id varchar(255),
+//   		operation_id varchar(255),
+//   		created_at TIMESTAMPTZ NOT NULL,
+//			kyma_config text,
+//			cluster_config text,
+//			cluster_setup text,
+//			kyma_version text,
+//			k8s_version text
+//			)`, postsql.RuntimeStateTableName),
+//	}
+//}
 
 func clearDBQuery() string {
 	return fmt.Sprintf("TRUNCATE TABLE %s, %s, %s, %s RESTART IDENTITY CASCADE",

--- a/components/kyma-environment-broker/internal/storage/tests_utils.go
+++ b/components/kyma-environment-broker/internal/storage/tests_utils.go
@@ -220,13 +220,6 @@ func InitTestDBTables(t *testing.T, connectionURL string) (func(), error) {
 		return cleanupFunc, nil
 	}
 
-	//for name, v := range FixTables() {
-	//	if _, err := connection.Exec(v); err != nil {
-	//		t.Logf("Cannot create table %s", name)
-	//		return nil, err
-	//	}
-	//	t.Logf("Table %s added to database", name)
-	//}
 	dirPath := "./../../../../../schema-migrator/migrations/kyma-environment-broker/"
 	files, err := ioutil.ReadDir(dirPath)
 	if err != nil {
@@ -272,14 +265,6 @@ func SetupTestDBTables(connectionURL string) (cleanupFunc func(), err error) {
 	} else if initialized {
 		return cleanupFunc, nil
 	}
-
-	//for name, v := range FixTables() {
-	//	if _, err := connection.Exec(v); err != nil {
-	//		log.Printf("Cannot create table %s", name)
-	//		return nil, err
-	//	}
-	//	log.Printf("Table %s added to database", name)
-	//}
 
 	dirPath := "./../../../../../schema-migrator/migrations/kyma-environment-broker/"
 	files, err := ioutil.ReadDir(dirPath)
@@ -423,70 +408,6 @@ func isDBContainerAvailable(hostname, port string) (isAvailable bool, dbCfg Conf
 
 	return false, Config{}, err
 }
-
-//func FixTables() map[string]string {
-//	return map[string]string{
-//		postsql.InstancesTableName: fmt.Sprintf(
-//			`CREATE TABLE IF NOT EXISTS %s (
-//			instance_id varchar(255) PRIMARY KEY,
-//			runtime_id varchar(255) NOT NULL,
-//			global_account_id varchar(255) NOT NULL,
-//			subscription_global_account_id varchar(255) NOT NULL,
-//			sub_account_id varchar(255) NOT NULL,
-//			service_id varchar(255) NOT NULL,
-//			service_name varchar(255) NOT NULL,
-//			service_plan_id varchar(255) NOT NULL,
-//			service_plan_name varchar(255) NOT NULL,
-//			dashboard_url varchar(255) NOT NULL,
-//			provisioning_parameters text NOT NULL,
-//			provider_region varchar(32) NOT NULL,
-//			provider varchar(32) NOT NULL DEFAULT '',
-//           version integer NOT NULL DEFAULT 0,
-//			created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-//			updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-//			deleted_at TIMESTAMPTZ NOT NULL DEFAULT '0001-01-01 00:00:00+00'
-//		)`, postsql.InstancesTableName),
-//		postsql.OperationTableName: fmt.Sprintf(
-//			`CREATE TABLE IF NOT EXISTS %s (
-//			id varchar(255) PRIMARY KEY,
-//			instance_id varchar(255) NOT NULL,
-//			target_operation_id varchar(255) NOT NULL,
-//			version integer NOT NULL,
-//			state varchar(32) NOT NULL,
-//			description text NOT NULL,
-//			type varchar(32) NOT NULL,
-//			data json NOT NULL,
-//			provisioning_parameters json NOT NULL,
-//			orchestration_id varchar(64),
-//           finished_stages text,
-//			created_at TIMESTAMPTZ NOT NULL,
-//			updated_at TIMESTAMPTZ NOT NULL
-//			)`, postsql.OperationTableName),
-//		postsql.OrchestrationTableName: fmt.Sprintf(
-//			`CREATE TABLE IF NOT EXISTS %s (
-//			orchestration_id varchar(255) PRIMARY KEY,
-//			type varchar(32) NOT NULL,
-//			state varchar(32) NOT NULL,
-//			description text,
-//			parameters text NOT NULL,
-//			runtime_operations text,
-//			created_at TIMESTAMPTZ NOT NULL,
-//			updated_at TIMESTAMPTZ NOT NULL
-//			)`, postsql.OrchestrationTableName),
-//		postsql.RuntimeStateTableName: fmt.Sprintf(
-//			`CREATE TABLE IF NOT EXISTS %s (
-//			id varchar(255) PRIMARY KEY,
-//   		runtime_id varchar(255),
-//   		operation_id varchar(255),
-//   		created_at TIMESTAMPTZ NOT NULL,
-//			kyma_config text,
-//			cluster_config text,
-//			cluster_setup text,
-//			kyma_version text,
-//			k8s_version text
-//			)`, postsql.RuntimeStateTableName),
-//	}
-//}
 
 func clearDBQuery() string {
 	return fmt.Sprintf("TRUNCATE TABLE %s, %s, %s, %s RESTART IDENTITY CASCADE",

--- a/components/kyma-environment-broker/internal/storage/tests_utils.go
+++ b/components/kyma-environment-broker/internal/storage/tests_utils.go
@@ -237,9 +237,9 @@ func InitTestDBTables(t *testing.T, connectionURL string) (func(), error) {
 				log.Printf("Cannot apply file %s", file.Name())
 				return nil, err
 			}
-			log.Printf("File %s applied to database", file.Name())
 		}
 	}
+	log.Printf("Files applied to database")
 
 	return cleanupFunc, nil
 }
@@ -283,9 +283,9 @@ func SetupTestDBTables(connectionURL string) (cleanupFunc func(), err error) {
 				log.Printf("Cannot apply file %s", file.Name())
 				return nil, err
 			}
-			log.Printf("File %s applied to database", file.Name())
 		}
 	}
+	log.Printf("Files applied to database")
 
 	return cleanupFunc, nil
 }


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Replacing fixed tables in tests with SQL statements defined in the schema migrator

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
