### PR TITLE
Suspension process cleans the ClusterConfigVersion

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -377,10 +377,6 @@ func (s *BrokerSuiteTest) FailProvisioningOperationByProvisioner(operationID str
 	s.finishOperationByProvisioner(gqlschema.OperationTypeProvision, gqlschema.OperationStateFailed, op.RuntimeID)
 }
 
-func (s *BrokerSuiteTest) FinishDeprovisioningByReconciler(opID string) {
-
-}
-
 func (s *BrokerSuiteTest) FinishDeprovisioningOperationByProvisioner(operationID string) {
 	var op *internal.DeprovisioningOperation
 	err := wait.PollImmediate(pollingInterval, 2*time.Second, func() (done bool, err error) {
@@ -400,7 +396,6 @@ func (s *BrokerSuiteTest) FinishDeprovisioningOperationByProvisioner(operationID
 
 	s.finishOperationByProvisioner(gqlschema.OperationTypeDeprovision, gqlschema.OperationStateSucceeded, op.RuntimeID)
 }
-
 
 func (s *BrokerSuiteTest) FinishUpdatingOperationByProvisioner(operationID string) {
 	var op *internal.UpdatingOperation

--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -377,6 +377,10 @@ func (s *BrokerSuiteTest) FailProvisioningOperationByProvisioner(operationID str
 	s.finishOperationByProvisioner(gqlschema.OperationTypeProvision, gqlschema.OperationStateFailed, op.RuntimeID)
 }
 
+func (s *BrokerSuiteTest) FinishDeprovisioningByReconciler(opID string) {
+
+}
+
 func (s *BrokerSuiteTest) FinishDeprovisioningOperationByProvisioner(operationID string) {
 	var op *internal.DeprovisioningOperation
 	err := wait.PollImmediate(pollingInterval, 2*time.Second, func() (done bool, err error) {
@@ -396,6 +400,7 @@ func (s *BrokerSuiteTest) FinishDeprovisioningOperationByProvisioner(operationID
 
 	s.finishOperationByProvisioner(gqlschema.OperationTypeDeprovision, gqlschema.OperationStateSucceeded, op.RuntimeID)
 }
+
 
 func (s *BrokerSuiteTest) FinishUpdatingOperationByProvisioner(operationID string) {
 	var op *internal.UpdatingOperation
@@ -877,6 +882,8 @@ func (s *BrokerSuiteTest) processReconcilingByOperationID(opID string) {
 	s.WaitForProvisioningState(opID, domain.InProgress)
 	s.AssertProvisionerStartedProvisioning(opID)
 	s.FinishProvisioningOperationByProvisioner(opID, gqlschema.OperationStateSucceeded)
+	_, err := s.gardenerClient.CoreV1beta1().Shoots(fixedGardenerNamespace).Create(context.Background(), s.fixGardenerShootForOperationID(opID), v1.CreateOptions{})
+	require.NoError(s.t, err)
 
 	// Director part
 	s.MarkDirectorWithConsoleURL(opID)
@@ -892,6 +899,12 @@ func (s *BrokerSuiteTest) processProvisioningByInstanceID(iid string) {
 	opID := s.WaitForLastOperation(iid, domain.InProgress)
 
 	s.processProvisioningByOperationID(opID)
+}
+
+func (s *BrokerSuiteTest) processReconciliationByInstanceID(iid string) {
+	opID := s.WaitForLastOperation(iid, domain.InProgress)
+
+	s.processReconcilingByOperationID(opID)
 }
 
 func (s *BrokerSuiteTest) ShootName(id string) string {

--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
@@ -359,7 +358,6 @@ func TestUpdateContext(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
 
-
 func TestUnsuspensionTrialKyma20(t *testing.T) {
 	suite := NewBrokerSuiteTest(t)
 	defer suite.TearDown()
@@ -403,10 +401,8 @@ func TestUnsuspensionTrialKyma20(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	suspensionOpID := suite.WaitForLastOperation(iid, domain.InProgress)
 
-	suite.FinishDeprovisioningByReconciler(suspensionOpID)
 	suite.FinishDeprovisioningOperationByProvisioner(suspensionOpID)
 	suite.WaitForOperationState(suspensionOpID, domain.Succeeded)
-	time.Sleep(5 * time.Second)
 
 	// OSB update
 	suite.Log("*** Unsuspension ***")
@@ -425,8 +421,6 @@ func TestUnsuspensionTrialKyma20(t *testing.T) {
 	suite.processReconciliationByInstanceID(iid)
 
 }
-
-
 
 func TestUnsuspensionTrialWithDefaultProviderChangedForNonDefaultRegion(t *testing.T) {
 	suite := NewBrokerSuiteTest(t)

--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
@@ -357,6 +358,75 @@ func TestUpdateContext(t *testing.T) {
    }`)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 }
+
+
+func TestUnsuspensionTrialKyma20(t *testing.T) {
+	suite := NewBrokerSuiteTest(t)
+	defer suite.TearDown()
+	iid := uuid.New().String()
+
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true&plan_id=7d55d31d-35ae-4438-bf13-6ffdfa107d9f&service_id=47c9dcbf-ff30-448e-ab36-d3bad66ba281", iid),
+		`{
+				   "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+				   "plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
+				   "context": {
+					   "sm_platform_credentials": {
+							  "url": "https://sm.url",
+							  "credentials": {}
+					   },
+					   "globalaccount_id": "g-account-id",
+					   "subaccount_id": "sub-id",
+					   "user_id": "john.smith@email.com"
+				   },
+					"parameters": {
+						"name": "testing-cluster",
+                         "kymaVersion":"2.0"
+			}
+   }`)
+	opID := suite.DecodeOperationID(resp)
+	suite.processReconcilingByOperationID(opID)
+
+	suite.Log("*** Suspension ***")
+
+	// Process Suspension
+	// OSB context update (suspension)
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+       "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+       "plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
+       "context": {
+           "globalaccount_id": "g-account-id",
+           "user_id": "john.smith@email.com",
+           "active": false
+       }
+   }`)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	suspensionOpID := suite.WaitForLastOperation(iid, domain.InProgress)
+
+	suite.FinishDeprovisioningByReconciler(suspensionOpID)
+	suite.FinishDeprovisioningOperationByProvisioner(suspensionOpID)
+	suite.WaitForOperationState(suspensionOpID, domain.Succeeded)
+	time.Sleep(5 * time.Second)
+
+	// OSB update
+	suite.Log("*** Unsuspension ***")
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+       "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+       "plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
+       "context": {
+           "globalaccount_id": "g-account-id",
+           "user_id": "john.smith@email.com",
+			"active": true
+       }
+       
+   }`)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	suite.processReconciliationByInstanceID(iid)
+
+}
+
+
 
 func TestUnsuspensionTrialWithDefaultProviderChangedForNonDefaultRegion(t *testing.T) {
 	suite := NewBrokerSuiteTest(t)

--- a/components/kyma-environment-broker/internal/process/deprovisioning/deregister_cluster.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/deregister_cluster.go
@@ -44,6 +44,7 @@ func (s *DeregisterClusterStep) Run(operation internal.DeprovisioningOperation, 
 
 	modifiedOp, d := s.operationManager.UpdateOperation(operation, func(op *internal.DeprovisioningOperation) {
 		op.ClusterConfigurationDeleted = true
+		op.ClusterConfigurationVersion = 0
 	}, log)
 
 	return modifiedOp, d, nil

--- a/components/kyma-environment-broker/internal/reconciler/fake.go
+++ b/components/kyma-environment-broker/internal/reconciler/fake.go
@@ -52,6 +52,7 @@ func (c *FakeClient) DeleteCluster(clusterName string) error {
 		return nil
 	}
 	c.deleted[clusterName] = struct{}{}
+	delete(c.inventoryClusters, clusterName)
 	return nil
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1198"
     kyma_environment_broker:
       dir:
-      version: "PR-1222"
+      version: "PR-1247"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- the deprovisioning (suspension) process must clean the ClusterConfigurationVersion, so the unsuspension (proviosioning) process does not skip the reconciler call (https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go#L39)

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
