### PR TITLE
Set maxSurge = 1 for least disruptive Gardener upgrades

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_test.go
@@ -85,7 +85,7 @@ func TestCreateRuntimeStep_Run(t *testing.T) {
 				WorkerCidr:                          "10.250.0.0/19",
 				AutoScalerMin:                       2,
 				AutoScalerMax:                       10,
-				MaxSurge:                            4,
+				MaxSurge:                            1,
 				MaxUnavailable:                      0,
 				TargetSecret:                        "",
 				EnableKubernetesVersionAutoUpdate:   ptr.Bool(autoUpdateKubernetesVersion),

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -54,7 +54,7 @@ func TestCreateRuntimeWithoutKyma_Run(t *testing.T) {
 				WorkerCidr:                          "10.250.0.0/19",
 				AutoScalerMin:                       2,
 				AutoScalerMax:                       10,
-				MaxSurge:                            4,
+				MaxSurge:                            1,
 				MaxUnavailable:                      0,
 				TargetSecret:                        "",
 				EnableKubernetesVersionAutoUpdate:   ptr.Bool(autoUpdateKubernetesVersion),

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -174,7 +174,7 @@ func (p *AWSHAInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  1,
 			AutoScalerMax:  10,
-			MaxSurge:       2,
+			MaxSurge:       1,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AwsConfig: &gqlschema.AWSProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -48,7 +48,7 @@ func (p *AWSInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  2,
 			AutoScalerMax:  10,
-			MaxSurge:       4,
+			MaxSurge:       1,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AwsConfig: &gqlschema.AWSProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -45,7 +45,7 @@ func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  2,
 			AutoScalerMax:  10,
-			MaxSurge:       4,
+			MaxSurge:       1,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
@@ -80,8 +80,8 @@ func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  2,
 			AutoScalerMax:  10,
-			MaxSurge:       4,
-			MaxUnavailable: 1,
+			MaxSurge:       1,
+			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{
 					VnetCidr: "10.250.0.0/19",
@@ -166,7 +166,7 @@ func (p *AzureHAInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  1,
 			AutoScalerMax:  10,
-			MaxSurge:       2,
+			MaxSurge:       1,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/gcp_provider.go
+++ b/components/kyma-environment-broker/internal/provider/gcp_provider.go
@@ -44,7 +44,7 @@ func (p *GcpInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  2,
 			AutoScalerMax:  10,
-			MaxSurge:       4,
+			MaxSurge:       1,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				GcpConfig: &gqlschema.GCPProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/openstack_provider.go
+++ b/components/kyma-environment-broker/internal/provider/openstack_provider.go
@@ -29,7 +29,7 @@ func (p *OpenStackInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:        "10.250.0.0/19",
 			AutoScalerMin:     2,
 			AutoScalerMax:     4,
-			MaxSurge:          4,
+			MaxSurge:          1,
 			MaxUnavailable:    0,
 			ExposureClassName: ptr.String(DefaultExposureClass),
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1198"
     kyma_environment_broker:
       dir:
-      version: "PR-1201"
+      version: "PR-1253"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
**Description**

Set shoot maxSurge to 1 in all plans for the least disruptive Gardener upgrades. Do not allow 2 concurrent drains for typical 2-node runtimes.

Workaround until https://github.tools.sap/kyma/backlog/issues/2122 is implemented.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
