### PR TITLE
add flag to display subscription-global-account-id to kcp-cli

### DIFF
--- a/tools/cli/pkg/command/runtime.go
+++ b/tools/cli/pkg/command/runtime.go
@@ -144,7 +144,6 @@ func (cmd *RuntimeCommand) Validate() error {
 func (cmd *RuntimeCommand) printRuntimes(runtimes runtime.RuntimesPage) error {
 	switch {
 	case cmd.output == tableOutput:
-
 		if cmd.display.SubscriptionGlobalAccountID {
 			tableColumns = append(tableColumns[:1+1], tableColumns[1:]...)
 			tableColumns[1] = printer.Column{

--- a/tools/cli/pkg/command/runtime.go
+++ b/tools/cli/pkg/command/runtime.go
@@ -21,6 +21,11 @@ type RuntimeCommand struct {
 	params   runtime.ListParameters
 	states   []string
 	opDetail bool
+	display  Display
+}
+
+type Display struct {
+	SubscriptionGlobalAccountID bool
 }
 
 var tableColumns = []printer.Column{
@@ -79,6 +84,7 @@ The command supports filtering Runtimes based on various attributes. See the lis
 	cobraCmd.Flags().StringSliceVarP(&cmd.params.Shoots, "shoot", "c", nil, "Filter by Shoot cluster name. You can provide multiple values, either separated by a comma (e.g. shoot1,shoot2), or by specifying the option multiple times.")
 	cobraCmd.Flags().StringSliceVarP(&cmd.params.GlobalAccountIDs, "account", "g", nil, "Filter by global account ID. You can provide multiple values, either separated by a comma (e.g. GAID1,GAID2), or by specifying the option multiple times.")
 	cobraCmd.Flags().StringSliceVarP(&cmd.params.SubAccountIDs, "subaccount", "s", nil, "Filter by subaccount ID. You can provide multiple values, either separated by a comma (e.g. SAID1,SAID2), or by specifying the option multiple times.")
+	cobraCmd.Flags().BoolVar(&cmd.display.SubscriptionGlobalAccountID, "subscription-global-account-id", false, "Display Subscription Global Account ID.")
 	cobraCmd.Flags().StringSliceVarP(&cmd.params.InstanceIDs, "instance-id", "i", nil, "Filter by instance ID. You can provide multiple values, either separated by a comma (e.g. ID1,ID2), or by specifying the option multiple times.")
 	cobraCmd.Flags().StringSliceVarP(&cmd.params.RuntimeIDs, "runtime-id", "r", nil, "Filter by Runtime ID. You can provide multiple values, either separated by a comma (e.g. ID1,ID2), or by specifying the option multiple times.")
 	cobraCmd.Flags().StringSliceVarP(&cmd.params.Regions, "region", "R", nil, "Filter by provider region. You can provide multiple values, either separated by a comma (e.g. westeurope,northeurope), or by specifying the option multiple times.")
@@ -138,6 +144,15 @@ func (cmd *RuntimeCommand) Validate() error {
 func (cmd *RuntimeCommand) printRuntimes(runtimes runtime.RuntimesPage) error {
 	switch {
 	case cmd.output == tableOutput:
+
+		if cmd.display.SubscriptionGlobalAccountID {
+			tableColumns = append(tableColumns[:1+1], tableColumns[1:]...)
+			tableColumns[1] = printer.Column{
+				Header:    "Subscription Global Account ID",
+				FieldSpec: "{.subscriptionGlobalAccountID}",
+			}
+		}
+
 		if cmd.opDetail {
 			tableColumns = append(tableColumns, printer.Column{
 				Header:    "KYMA VERSION",


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- adds flag `--subscription-global-account-id` to kcp-cli to display additional field

```bash
$ ./kcp-darwin runtimes --subscription-global-account-id
GLOBALACCOUNT ID                        Subscription Global Account ID   SUBACCOUNT ID                               SHOOT       REGION         PLAN         CREATED AT            STATE
3e64ebae-38b5-46a0-b1ed-9ccee153a0ae    empty-gaID                                                                   c-48452c7                               2020/03/30 08:05:11   failed (deprovision)
3e64ebae-38b5-46a0-b1ed-9ccee153a0ae                                                                                                                         2020/04/01 14:01:35   failed (deprovision)
3e64ebae-38b5-46a0-b1ed-9ccee153a0ae                                                                                                                         2020/04/15 16:36:06   failed (deprovision)
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

- #1254