### PR TITLE
Disable SVCAT related components for migration

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -1684,14 +1684,14 @@ func TestUpdateSCMigrationSuccess(t *testing.T) {
 	updateOperationID := suite.DecodeOperationID(resp)
 	suite.FinishUpdatingOperationByProvisioner(updateOperationID)
 
-	// check first call to reconciler installing BTP-Operator and sc-migration
+	// check first call to reconciler installing BTP-Operator and sc-migration, disabling SVCAT
 	rsu1, err := suite.db.RuntimeStates().GetLatestWithReconcilerInputByRuntimeID(i.RuntimeID)
 	assert.NoError(t, err, "getting runtime mid update")
 	assert.Equal(t, updateOperationID, rsu1.OperationID, "runtime state update operation ID")
 	assert.ElementsMatch(t, rsu1.KymaConfig.Components, []*gqlschema.ComponentConfigurationInput{})
-	assert.ElementsMatch(t, componentNames(rs.ClusterSetup.KymaConfig.Components), []string{"service-catalog-addons", "ory", "monitoring", "helm-broker", "service-manager-proxy", "service-catalog", "btp-operator", "sc-migration"})
+	assert.ElementsMatch(t, componentNames(rs.ClusterSetup.KymaConfig.Components), []string{"ory", "monitoring", "btp-operator", "sc-migration"})
 
-	// check second call to reconciler and see that sc-migration and svcat related components are gone
+	// check second call to reconciler and see that sc-migration is no longer present and svcat related components are gone as well
 	suite.FinishUpdatingOperationByReconciler(updateOperationID)
 	suite.AssertShootUpgrade(updateOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{

--- a/components/kyma-environment-broker/internal/process/update/sc_migration.go
+++ b/components/kyma-environment-broker/internal/process/update/sc_migration.go
@@ -43,18 +43,31 @@ func (s *SCMigrationStep) Name() string {
 }
 
 func (s *SCMigrationStep) Run(operation internal.UpdatingOperation, logger logrus.FieldLogger) (internal.UpdatingOperation, time.Duration, error) {
+	containsSCMigrationComponent := false
+	var components []reconcilerApi.Component
 	for _, c := range operation.LastRuntimeState.ClusterSetup.KymaConfig.Components {
+		if c.Component != internal.ServiceCatalogComponentName &&
+			c.Component != internal.ServiceCatalogAddonsComponentName &&
+			c.Component != internal.HelmBrokerComponentName &&
+			c.Component != internal.ServiceManagerComponentName {
+			components = append(components, c)
+		} else {
+			// disable reconciler on SVCAT related components so sc-migration can migrate them
+			operation.RequiresReconcilerUpdate = true
+		}
 		if c.Component == SCMigrationComponentName {
-			// already exists
-			return operation, 0, nil
+			containsSCMigrationComponent = true
 		}
 	}
-	c, err := getComponentInput(s.components, SCMigrationComponentName, operation.RuntimeVersion)
-	if err != nil {
-		return s.operationManager.OperationFailed(operation, err.Error(), logger)
+	if !containsSCMigrationComponent {
+		c, err := getComponentInput(s.components, SCMigrationComponentName, operation.RuntimeVersion)
+		if err != nil {
+			return s.operationManager.OperationFailed(operation, err.Error(), logger)
+		}
+		components = append(components, c)
+		operation.RequiresReconcilerUpdate = true
 	}
-	operation.LastRuntimeState.ClusterSetup.KymaConfig.Components = append(operation.LastRuntimeState.ClusterSetup.KymaConfig.Components, c)
-	operation.RequiresReconcilerUpdate = true
+	operation.LastRuntimeState.ClusterSetup.KymaConfig.Components = components
 	return operation, 0, nil
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1198"
     kyma_environment_broker:
       dir:
-      version: "PR-1258"
+      version: "PR-1263"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

```
panic: Operation cannot be fulfilled on usagekinds.servicecatalog.kyma-project.io "serverless-function": the object has been modified; please apply your changes to the latest version and try again
```
The update queue should disable svcat related components for the sc-migration. Disabling a reconciler currently won't remove the component, it will just stop reconciler on reconciling resources for those disabled components.

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/12843
https://github.com/kyma-project/control-plane/pull/825