### PR TITLE
KEB: Use configurable reconciler timeout in upgrade Check_Cluster_Configuration step

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -883,7 +883,7 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 		// (also return operation, 0, nil at the end of apply_cluster_configuration)
 		{
 			weight: 1,
-			step:   upgrade_kyma.NewCheckClusterConfigurationStep(db.Operations(), reconcilerClient, 15*time.Minute),
+			step:   upgrade_kyma.NewCheckClusterConfigurationStep(db.Operations(), reconcilerClient, cfg.Reconciler.ProvisioningTimeout),
 			cnd:    upgrade_kyma.ForKyma2,
 		},
 		{

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1198"
     kyma_environment_broker:
       dir:
-      version: "PR-1267"
+      version: "PR-1269"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1187"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Use the same (configurable) reconciler `ProvisioningTimeout`  in Kyma 2 upgrade process when polling mothership-reconciler, which is used during the provisioning process.

