### PR TITLE
Add grego952 as a documentaion CODEOWNER in KCP

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,7 +53,7 @@
 /components/reconciler @m00g3n @dbadura @pPrecel @moelsayed @clebs @jeremyharisch @khlifi411 @Tomasz-Smelcerz-SAP @ruanxin
 
 # All .md files
-*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl
+*.md @klaudiagrz @mmitoraj @majakurcius @alexandra-simeonova @NHingerl @grego952
 
 # Owners of the .kyma-project-io folder
 /.kyma-project-io/ @m00g3n @pPrecel @dbadura


### PR DESCRIPTION
**Description**

As @grego952 has been working with Kyma for over 3 months as a Technical Writer and has gained expertise in this domain, he should be added to the documentation CODEOWNERS.

Changes proposed in this pull request:

- Add @grego952 to KCP documentation CODEOWNERS

**Related issue**
[#13077 ](https://github.com/kyma-project/kyma/issues/13077)
