### PR TITLE
Explicitly disable BTP Operator for upgrade queue

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -1195,9 +1195,11 @@ func (s *BrokerSuiteTest) fixExpectedComponentListWithSMOperator(opID string) []
 }
 
 func mockBTPOperatorClusterID() {
-	update.ConfigMapGetter = func(string) internal.ClusterIDGetter {
+	mock := func(string) internal.ClusterIDGetter {
 		return func() (string, error) {
 			return "cluster_id", nil
 		}
 	}
+	update.ConfigMapGetter = mock
+	upgrade_kyma.ConfigMapGetter = mock
 }

--- a/components/kyma-environment-broker/internal/component_input_helpers.go
+++ b/components/kyma-environment-broker/internal/component_input_helpers.go
@@ -18,6 +18,12 @@ const (
 	ServiceCatalogComponentName       = "service-catalog"
 	ServiceCatalogAddonsComponentName = "service-catalog-addons"
 	ServiceManagerComponentName       = "service-manager-proxy"
+
+	// BTP Operator overrides keys
+	BTPOperatorClientID     = "manager.secret.clientid"
+	BTPOperatorClientSecret = "manager.secret.clientsecret"
+	BTPOperatorURL          = "manager.secret.url"
+	BTPOperatorTokenURL     = "manager.secret.tokenurl"
 )
 
 type ClusterIDGetter func() (string, error)
@@ -34,21 +40,21 @@ func DisableServiceManagementComponents(r ProvisionerInputCreator) {
 func getBTPOperatorProvisioningOverrides(creds *ServiceManagerOperatorCredentials) []*gqlschema.ConfigEntryInput {
 	return []*gqlschema.ConfigEntryInput{
 		{
-			Key:    "manager.secret.clientid",
+			Key:    BTPOperatorClientID,
 			Value:  creds.ClientID,
 			Secret: ptr.Bool(true),
 		},
 		{
-			Key:    "manager.secret.clientsecret",
+			Key:    BTPOperatorClientSecret,
 			Value:  creds.ClientSecret,
 			Secret: ptr.Bool(true),
 		},
 		{
-			Key:   "manager.secret.url",
+			Key:   BTPOperatorURL,
 			Value: creds.ServiceManagerURL,
 		},
 		{
-			Key:   "manager.secret.tokenurl",
+			Key:   BTPOperatorTokenURL,
 			Value: creds.URL,
 		},
 	}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/sm_overrides.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/sm_overrides.go
@@ -57,11 +57,11 @@ func (s *ServiceManagerOverridesStep) Run(operation internal.UpgradeKymaOperatio
 		},
 	}
 	operation.InputCreator.AppendOverrides(ServiceManagerComponentName, smOverrides)
+	operation.InputCreator.DisableOptionalComponent(internal.BTPOperatorComponentName)
 
 	operation.InputCreator.EnableOptionalComponent(HelmBrokerComponentName)
 	operation.InputCreator.EnableOptionalComponent(ServiceCatalogComponentName)
 	operation.InputCreator.EnableOptionalComponent(ServiceCatalogAddonsComponentName)
-
 	operation.InputCreator.EnableOptionalComponent(ServiceManagerComponentName)
 
 	return operation, 0, nil

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/sm_overrides_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/sm_overrides_test.go
@@ -78,6 +78,8 @@ func TestServiceManagerOverridesStepSuccess(t *testing.T) {
 				Return(nil).Once()
 			inputCreatorMock.On("EnableOptionalComponent", mock.Anything).
 				Return(nil)
+			inputCreatorMock.On("DisableOptionalComponent", mock.Anything).
+				Return(nil)
 
 			factory := servicemanager.NewClientFactory(tC.overrideParams)
 			operation := internal.UpgradeKymaOperation{

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1268"
     kyma_environment_broker:
       dir:
-      version: "PR-1292"
+      version: "PR-1287"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1279"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For update and provisioning, we explicitly disable BTP operator and only enable it when appropriate creds are present. For upgrade, we relied on different logic and that is inheriting `InputCreator` from previous operations which may not be as robust as we thought. This is an effort to unify components enablement/disablement related to SVCAT migration.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
mitigation of https://github.com/kyma-project/control-plane/issues/1286