### PR TITLE
Use installHint in generated kubeconfig

### DIFF
--- a/components/kubeconfig-service/pkg/transformer/kubeconfig.go
+++ b/components/kubeconfig-service/pkg/transformer/kubeconfig.go
@@ -45,11 +45,20 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
       args:
-      - oidc-login
       - get-token
       - "--oidc-issuer-url={{ .OIDCIssuerURL }}"
       - "--oidc-client-id={{ .OIDCClientID }}"
       - "--oidc-extra-scope=email"
       - "--oidc-extra-scope=openid"
-      command: kubectl
+      command: kubectl-oidc_login
+      installHint: |
+        kubelogin plugin is required to proceed with authentication
+        # Homebrew (macOS and Linux)
+        brew install int128/kubelogin/kubelogin
+
+        # Krew (macOS, Linux, Windows and ARM)
+        kubectl krew install oidc-login
+
+        # Chocolatey (Windows)
+        choco install kubelogin
 `

--- a/components/kubeconfig-service/pkg/transformer/transformer_test.go
+++ b/components/kubeconfig-service/pkg/transformer/transformer_test.go
@@ -90,12 +90,21 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
       args:
-      - oidc-login
       - get-token
       - "--oidc-issuer-url=testIssuerURL"
       - "--oidc-client-id=testClientId"
       - "--oidc-extra-scope=email"
       - "--oidc-extra-scope=openid"
-      command: kubectl
+      command: kubectl-oidc_login
+      installHint: |
+        kubelogin plugin is required to proceed with authentication
+        # Homebrew (macOS and Linux)
+        brew install int128/kubelogin/kubelogin
+
+        # Krew (macOS, Linux, Windows and ARM)
+        kubectl krew install oidc-login
+
+        # Chocolatey (Windows)
+        choco install kubelogin
 `
 )

--- a/components/kyma-environment-broker/internal/kubeconfig/builder_test.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/builder_test.go
@@ -146,13 +146,22 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
       args:
-      - oidc-login
       - get-token
       - "--oidc-issuer-url=%s"
       - "--oidc-client-id=%s"
       - "--oidc-extra-scope=email"
       - "--oidc-extra-scope=openid"
-      command: kubectl
+      command: kubectl-oidc_login
+      installHint: |
+        kubelogin plugin is required to proceed with authentication
+        # Homebrew (macOS and Linux)
+        brew install int128/kubelogin/kubelogin
+
+        # Krew (macOS, Linux, Windows and ARM)
+        kubectl krew install oidc-login
+
+        # Chocolatey (Windows)
+        choco install kubelogin
 `, issuerURL, clientID,
 	)
 }

--- a/components/kyma-environment-broker/internal/kubeconfig/kubeconfig.go
+++ b/components/kyma-environment-broker/internal/kubeconfig/kubeconfig.go
@@ -45,11 +45,20 @@ users:
     exec:
       apiVersion: client.authentication.k8s.io/v1beta1
       args:
-      - oidc-login
       - get-token
       - "--oidc-issuer-url={{ .OIDCIssuerURL }}"
       - "--oidc-client-id={{ .OIDCClientID }}"
       - "--oidc-extra-scope=email"
       - "--oidc-extra-scope=openid"
-      command: kubectl
+      command: kubectl-oidc_login
+      installHint: |
+        kubelogin plugin is required to proceed with authentication
+        # Homebrew (macOS and Linux)
+        brew install int128/kubelogin/kubelogin
+
+        # Krew (macOS, Linux, Windows and ARM)
+        kubectl krew install oidc-login
+
+        # Chocolatey (Windows)
+        choco install kubelogin
 `

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -15,7 +15,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
-  tag: "PR-1106"
+  tag: "PR-1297"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- target `kubectl-oidc_login` executable in kubeconfig file in user section
- apply installHint in case the required `kubectl-oidc_login` plugin is not installed
**Related issue(s)**
https://github.com/kyma-project/control-plane/issues/1295