### PR TITLE
Fix resetting autoscaler params in cluster upgrade operation

### DIFF
--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/initialisation.go
@@ -115,20 +115,6 @@ func (s *InitialisationStep) Run(operation internal.UpgradeClusterOperation, log
 }
 
 func (s *InitialisationStep) initializeUpgradeShootRequest(operation internal.UpgradeClusterOperation, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {
-	// rewrite necessary data from ProvisioningOperation to operation internal.UpgradeOperation
-	provisioningOperation, err := s.operationStorage.GetProvisioningOperationByInstanceID(operation.InstanceID)
-	if err != nil {
-		log.Errorf("while getting provisioning operation from storage")
-		return operation, s.timeSchedule.Retry, nil
-	}
-
-	operation, delay := s.operationManager.UpdateOperation(operation, func(op *internal.UpgradeClusterOperation) {
-		op.ProvisioningParameters = provisioningOperation.ProvisioningParameters
-	}, log)
-	if delay != 0 {
-		return operation, delay, nil
-	}
-
 	log.Infof("create provisioner input creator for plan ID %q", operation.ProvisioningParameters)
 	creator, err := s.inputBuilder.CreateUpgradeShootInput(operation.ProvisioningParameters)
 	switch {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1268"
     kyma_environment_broker:
       dir:
-      version: "PR-1291"
+      version: "PR-1308"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1285"


### PR DESCRIPTION
**Description**

Service Instance update API call can change a runtime's autoscaler min/max parameters. However during orchestrated cluster upgrade, the provisioner shoot upgrade input is built using the original provisioning parameters used during runtime creation, which case updated parameters to be reset back to their original value.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
