### PR TITLE
Add "cleaner" component reconciler

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -50,6 +50,7 @@ global:
   components:
     - base
     - busola-migrator
+    - cleaner
     - connectivity-proxy
     - istio-configuration
     - ory


### PR DESCRIPTION
**Description**

Add "cleaner" component reconciler (introduced to the reconciler codebase some time ago) in order to perform final cleanup of resources during Kyma undeploy (delete) operation.

Changes proposed in this pull request:
- Add "cleaner" component reconciler to the global components list

**Related issue(s)**
See also: https://github.com/kyma-incubator/reconciler/issues/333