### PR TITLE
Set delete strategy to "all" for SKR

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/files/reconciler.yaml
+++ b/resources/kcp/charts/mothership-reconciler/files/reconciler.yaml
@@ -20,6 +20,7 @@ mothership:
   host: {{ include "mothership-reconciler.fullname" . }}
   port: {{ .Values.service.port }}
   scheduler:
+    deleteStrategy: all
     reconcilers:
 {{- range $component := .Values.global.components }}
       {{ $component }}:


### PR DESCRIPTION
**Description**

Delete strategy for "cleaner" reconciler controls which Custom Resource Finalizers are dropped during the "delete" operation.
The value "all" drops finalizers for all CRs in all namespaces.

Changes proposed in this pull request:
- Set delete strategy for "cleaner" reconciler to "all".

**Related issue(s)**
https://github.com/kyma-incubator/reconciler/pull/709