### PR TITLE
Improvement of checking Kyma version before starting cluster deprovision 

### DIFF
--- a/components/provisioner/cmd/init.go
+++ b/components/provisioner/cmd/init.go
@@ -3,11 +3,12 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
 	"time"
+
+	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
 
 	"github.com/kyma-project/control-plane/components/provisioner/internal/operations/queue"
 

--- a/components/provisioner/cmd/init.go
+++ b/components/provisioner/cmd/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
@@ -41,6 +42,7 @@ func newProvisioningService(
 	dbsFactory dbsession.Factory,
 	releaseProvider release.Provider,
 	directorService director.DirectorClient,
+	installationClient installation.Service,
 	kubernetesVersionProvider gardener.KubernetesVersionProvider,
 	provisioningQueue queue.OperationQueue,
 	provisioningNoInstallQueue queue.OperationQueue,
@@ -58,7 +60,7 @@ func newProvisioningService(
 	inputConverter := provisioning.NewInputConverter(uuidGenerator, releaseProvider, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, forceAllowPrivilegedContainers)
 	graphQLConverter := provisioning.NewGraphQLConverter()
 
-	return provisioning.NewProvisioningService(inputConverter, graphQLConverter, directorService, dbsFactory, provisioner, uuidGenerator, kubernetesVersionProvider, provisioningQueue, provisioningNoInstallQueue, deprovisioningQueue, deprovisioningNoInstallQueue, upgradeQueue, shootUpgradeQueue, hibernationQueue)
+	return provisioning.NewProvisioningService(inputConverter, graphQLConverter, directorService, dbsFactory, provisioner, uuidGenerator, kubernetesVersionProvider, installationClient, provisioningQueue, provisioningNoInstallQueue, deprovisioningQueue, deprovisioningNoInstallQueue, upgradeQueue, shootUpgradeQueue, hibernationQueue)
 }
 
 func newDirectorClient(config config) (director.DirectorClient, error) {

--- a/components/provisioner/cmd/main.go
+++ b/components/provisioner/cmd/main.go
@@ -268,6 +268,7 @@ func main() {
 		dbsFactory,
 		releaseProvider,
 		directorClient,
+		installationService,
 		gardener.NewKubernetesVersionProvider(shootClient),
 		provisioningQueue,
 		provisioningNoInstallQueue,

--- a/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
+++ b/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
@@ -248,7 +248,7 @@ func TestProvisioning_ProvisionRuntimeWithDatabase(t *testing.T) {
 			inputConverter := provisioning.NewInputConverter(uuidGenerator, provider, "Project", defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, forceAllowPrivilegedContainers)
 			graphQLConverter := provisioning.NewGraphQLConverter()
 
-			provisioningService := provisioning.NewProvisioningService(inputConverter, graphQLConverter, directorServiceMock, dbsFactory, provisioner, uuidGenerator, gardener.NewKubernetesVersionProvider(shootInterface), provisioningQueue, provisioningNoInstallQueue, deprovisioningQueue, deprovisioningNoInstallQueue, upgradeQueue, shootUpgradeQueue, shootHibernationQueue)
+			provisioningService := provisioning.NewProvisioningService(inputConverter, graphQLConverter, directorServiceMock, dbsFactory, provisioner, uuidGenerator, gardener.NewKubernetesVersionProvider(shootInterface), installationServiceMock, provisioningQueue, provisioningNoInstallQueue, deprovisioningQueue, deprovisioningNoInstallQueue, upgradeQueue, shootUpgradeQueue, shootHibernationQueue)
 
 			validator := api.NewValidator()
 

--- a/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
+++ b/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
@@ -120,6 +120,10 @@ func TestProvisioning_ProvisionRuntimeWithDatabase(t *testing.T) {
 	installationServiceMock.On("PerformCleanup", mock.Anything).Return(nil)
 	installationServiceMock.On("TriggerUninstall", mock.Anything).Return(nil)
 
+	// to separate from other tests
+	installationServiceMockForDeprovisiong := &installationMocks.Service{}
+	installationServiceMockForDeprovisiong.On("CheckInstallationState", mock.Anything).Return(installation.InstallationState{State: "Installed"}, nil)
+
 	ctx := context.WithValue(context.Background(), middlewares.Tenant, tenant)
 	ctx = context.WithValue(ctx, middlewares.SubAccountID, subAccountId)
 
@@ -248,7 +252,7 @@ func TestProvisioning_ProvisionRuntimeWithDatabase(t *testing.T) {
 			inputConverter := provisioning.NewInputConverter(uuidGenerator, provider, "Project", defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, forceAllowPrivilegedContainers)
 			graphQLConverter := provisioning.NewGraphQLConverter()
 
-			provisioningService := provisioning.NewProvisioningService(inputConverter, graphQLConverter, directorServiceMock, dbsFactory, provisioner, uuidGenerator, gardener.NewKubernetesVersionProvider(shootInterface), installationServiceMock, provisioningQueue, provisioningNoInstallQueue, deprovisioningQueue, deprovisioningNoInstallQueue, upgradeQueue, shootUpgradeQueue, shootHibernationQueue)
+			provisioningService := provisioning.NewProvisioningService(inputConverter, graphQLConverter, directorServiceMock, dbsFactory, provisioner, uuidGenerator, gardener.NewKubernetesVersionProvider(shootInterface), installationServiceMockForDeprovisiong, provisioningQueue, provisioningNoInstallQueue, deprovisioningQueue, deprovisioningNoInstallQueue, upgradeQueue, shootUpgradeQueue, shootHibernationQueue)
 
 			validator := api.NewValidator()
 

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -1,13 +1,12 @@
 package provisioning
 
 import (
+	installationSDK "github.com/kyma-incubator/hydroform/install/installation"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
-	"github.com/kyma-project/control-plane/components/provisioner/internal/util/k8s"
-	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
-
 	"github.com/kyma-project/control-plane/components/provisioner/internal/util"
+	"github.com/kyma-project/control-plane/components/provisioner/internal/util/k8s"
 
 	"github.com/kyma-project/control-plane/components/provisioner/internal/apperrors"
 
@@ -214,7 +213,7 @@ func (r *service) DeprovisionRuntime(id string) (string, apperrors.AppError) {
 
 	installationState, err := r.installationClient.CheckInstallationState(k8sConfig)
 
-	if err == nil && util.NotNilOrEmpty(cluster.ActiveKymaConfigId) && installationState.State == string(v1alpha1.StateInstalled) {
+	if err == nil && util.NotNilOrEmpty(cluster.ActiveKymaConfigId) && installationState.State != installationSDK.NoInstallationState {
 		log.Infof("Starting deprovisioning steps for runtime %s with installation", cluster.ID)
 		r.deprovisioningQueue.Add(operation.ID)
 	} else {

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -214,12 +214,12 @@ func (r *service) DeprovisionRuntime(id string) (string, apperrors.AppError) {
 
 	installationState, err := r.installationClient.CheckInstallationState(k8sConfig)
 
-	if err == nil && util.NotNilOrEmpty(cluster.ActiveKymaConfigId) && installationState.State != installationSDK.NoInstallationState {
-		log.Infof("Starting deprovisioning steps for runtime %s with installation", cluster.ID)
-		r.deprovisioningQueue.Add(operation.ID)
-	} else {
+	if err != nil || util.IsNilOrEmpty(cluster.ActiveKymaConfigId) || installationState.State == installationSDK.NoInstallationState {
 		log.Infof("Starting deprovisioning steps for runtime %s without installation", cluster.ID)
 		r.deprovisioningNoInstallQueue.Add(operation.ID)
+	} else {
+		log.Infof("Starting deprovisioning steps for runtime %s with installation", cluster.ID)
+		r.deprovisioningQueue.Add(operation.ID)
 	}
 
 	return operation.ID, nil

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -1,8 +1,9 @@
 package provisioning
 
 import (
-	installationSDK "github.com/kyma-incubator/hydroform/install/installation"
 	"time"
+
+	installationSDK "github.com/kyma-incubator/hydroform/install/installation"
 
 	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/util"

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -214,20 +214,10 @@ func (r *service) DeprovisionRuntime(id string) (string, apperrors.AppError) {
 
 	installationState, err := r.installationClient.CheckInstallationState(k8sConfig)
 
-	// TODO remove this log message!!!
-	// This is only only for debug
-	if err != nil {
-		log.Infof("Error while checking installation state :%s.", err.Error())
-	}
-
-	log.Infof("Installation state is :%s.", installationState.State)
-
 	if err == nil && util.NotNilOrEmpty(cluster.ActiveKymaConfigId) && installationState.State == string(v1alpha1.StateInstalled) {
-		// "Kyma classic" mode
 		log.Infof("Starting deprovisioning steps for runtime %s with installation", cluster.ID)
 		r.deprovisioningQueue.Add(operation.ID)
 	} else {
-		// Kyma 2.0 mode
 		log.Infof("Starting deprovisioning steps for runtime %s without installation", cluster.ID)
 		r.deprovisioningNoInstallQueue.Add(operation.ID)
 	}

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -212,9 +212,9 @@ func (r *service) DeprovisionRuntime(id string) (string, apperrors.AppError) {
 		return "", apperrors.Internal("error: failed to create kubernetes config from raw: %s", err.Error())
 	}
 
-	installationState, err := r.installationClient.CheckInstallationState(k8sConfig)
+	installationState, _ := r.installationClient.CheckInstallationState(k8sConfig)
 
-	if err != nil || util.IsNilOrEmpty(cluster.ActiveKymaConfigId) || installationState.State == installationSDK.NoInstallationState {
+	if util.IsNilOrEmpty(cluster.ActiveKymaConfigId) || installationState.State == installationSDK.NoInstallationState {
 		log.Infof("Starting deprovisioning steps for runtime %s without installation", cluster.ID)
 		r.deprovisioningNoInstallQueue.Add(operation.ID)
 	} else {

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -1,10 +1,11 @@
 package provisioning
 
 import (
+	"time"
+
 	"github.com/kyma-project/control-plane/components/provisioner/internal/installation"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/util/k8s"
 	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
-	"time"
 
 	"github.com/kyma-project/control-plane/components/provisioner/internal/util"
 

--- a/components/provisioner/internal/provisioning/service_test.go
+++ b/components/provisioner/internal/provisioning/service_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -479,51 +478,6 @@ func TestService_DeprovisionRuntime(t *testing.T) {
 		readWriteSession.On("InsertOperation", mock.MatchedBy(operationMatcher)).Return(nil)
 
 		installationClient.On("CheckInstallationState", mock.Anything).Return(notInstalledState, nil)
-
-		resolver := NewProvisioningService(inputConverter, graphQLConverter, nil, sessionFactoryMock, provisioner, uuid.NewUUIDGenerator(), nil, installationClient, nil, nil, nil, deprovisioningNoInstallQueue, nil, nil, nil)
-
-		//when
-		opID, err := resolver.DeprovisionRuntime(runtimeID)
-		require.NoError(t, err)
-
-		//then
-		assert.Equal(t, operationID, opID)
-		sessionFactoryMock.AssertExpectations(t)
-		readWriteSession.AssertExpectations(t)
-		provisioner.AssertExpectations(t)
-		installationClient.AssertExpectations(t)
-		deprovisioningNoInstallQueue.AssertExpectations(t)
-	})
-
-	t.Run("Should start Runtime deprovisioning without installation and return operation ID when activeKymaConfigID exists but check installation state returns error", func(t *testing.T) {
-		//given
-		operation := model.Operation{
-			ID:             operationID,
-			Type:           model.DeprovisionNoInstall,
-			State:          model.InProgress,
-			StartTimestamp: time.Now(),
-			Message:        "Deprovisioning without installation started",
-			ClusterID:      runtimeID,
-		}
-
-		operationMatcher := getOperationMatcher(operation)
-
-		sessionFactoryMock := &sessionMocks.Factory{}
-		readWriteSession := &sessionMocks.ReadWriteSession{}
-		provisioner := &mocks2.Provisioner{}
-		installationClient := &installationMocks.Service{}
-
-		deprovisioningNoInstallQueue := &mocks.OperationQueue{}
-
-		deprovisioningNoInstallQueue.On("Add", mock.AnythingOfType("string")).Return(nil)
-
-		sessionFactoryMock.On("NewReadWriteSession").Return(readWriteSession)
-		readWriteSession.On("GetLastOperation", runtimeID).Return(lastOperation, nil)
-		readWriteSession.On("GetCluster", runtimeID).Return(cluster, nil)
-		provisioner.On("DeprovisionCluster", mock.MatchedBy(clusterMatcher), mock.MatchedBy(notEmptyUUIDMatcher)).Return(operation, nil)
-		readWriteSession.On("InsertOperation", mock.MatchedBy(operationMatcher)).Return(nil)
-
-		installationClient.On("CheckInstallationState", mock.Anything).Return(installationSDK.InstallationState{}, errors.New("failed while checking installation state"))
 
 		resolver := NewProvisioningService(inputConverter, graphQLConverter, nil, sessionFactoryMock, provisioner, uuid.NewUUIDGenerator(), nil, installationClient, nil, nil, nil, deprovisioningNoInstallQueue, nil, nil, nil)
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-1276"
     provisioner:
       dir:
-      version: "PR-1268"
+      version: "PR-1312"
     kyma_environment_broker:
       dir:
       version: "PR-1291"


### PR DESCRIPTION
Previous implementation to recognise if the version of the cluster being deprovisioned was Kyma 2.x was based on checking  missing `activeKymeConfigId` entry in the database. This entry was present only for previously provisioned `Kyma 1.x `clusters.

It turned out there are some cases when `Kyma 2.x` cluster might still have assigned this data. It is in the case of Kyma 1.x clusters upgraded to version `Kyma 2.x` because the upgrade was performed by the Reconciler and Provisioner was not aware about it. As a result Kyma version installed on the cluster was not identified correctly and deprovisioning ended with a failure.  

The current mechanism is using `installationSDK` library to identify if deprovisioned cluster was installed as `Kyma 1.x` (with `kyma-installer` and `installation CR`). In the  other case we assume that it is `Kyma 2.x `cluster and we don't init uninstallation step - just delete the Kubernetes cluster and cleanup the environment.

