### PR TITLE
Adjust query function to get latest Runtimestate with Kyma version

### DIFF
--- a/components/kyma-environment-broker/internal/storage/driver/postsql/runtime_state.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/runtime_state.go
@@ -149,10 +149,10 @@ func (s *runtimeState) GetLatestWithReconcilerInputByRuntimeID(runtimeID string)
 
 func (s *runtimeState) GetLatestWithKymaVersionByRuntimeID(runtimeID string) (internal.RuntimeState, error) {
 	sess := s.NewReadSession()
-	var states []dbmodel.RuntimeStateDTO
+	var state dbmodel.RuntimeStateDTO
 	var lastErr dberr.Error
 	err := wait.PollImmediate(defaultRetryInterval, defaultRetryTimeout, func() (bool, error) {
-		states, lastErr = sess.GetLatestRuntimeStatesByRuntimeID(runtimeID, 100)
+		state, lastErr = sess.GetLatestRuntimeStateWithKymaVersionByRuntimeID(runtimeID)
 		if lastErr != nil {
 			if dberr.IsNotFound(lastErr) {
 				return false, dberr.NotFound("RuntimeState for runtime %s not found", runtimeID)
@@ -165,17 +165,16 @@ func (s *runtimeState) GetLatestWithKymaVersionByRuntimeID(runtimeID string) (in
 	if err != nil {
 		return internal.RuntimeState{}, lastErr
 	}
-	for _, state := range states {
-		result, err := s.toRuntimeState(&state)
-		if err != nil {
-			return internal.RuntimeState{}, errors.Wrap(err, "while converting runtime state")
-		}
-		if result.ClusterSetup != nil && result.ClusterSetup.KymaConfig.Version != "" {
-			return result, nil
-		}
-		if result.KymaConfig.Version != "" {
-			return result, nil
-		}
+
+	result, err := s.toRuntimeState(&state)
+	if err != nil {
+		return internal.RuntimeState{}, errors.Wrap(err, "while converting runtime state")
+	}
+	if result.ClusterSetup != nil && result.ClusterSetup.KymaConfig.Version != "" {
+		return result, nil
+	}
+	if result.KymaConfig.Version != "" {
+		return result, nil
 	}
 
 	return internal.RuntimeState{}, fmt.Errorf("failed to find RuntimeState with kyma version for runtime %s", runtimeID)

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/runtimestate_test.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/runtimestate_test.go
@@ -161,4 +161,60 @@ func TestRuntimeState(t *testing.T) {
 		assert.NotNil(t, gotRuntimeState.ClusterSetup)
 		assert.Equal(t, gotRuntimeState.ClusterSetup.RuntimeID, runtimeStateWithReconcilerInput1.ClusterSetup.RuntimeID)
 	})
+
+	t.Run("should fetch latest RuntimeState with Kyma version", func(t *testing.T) {
+		containerCleanupFunc, cfg, err := storage.InitTestDBContainer(t, ctx, "test_DB_1")
+		require.NoError(t, err)
+		defer containerCleanupFunc()
+
+		tablesCleanupFunc, err := storage.InitTestDBTables(t, cfg.ConnectionURL())
+		require.NoError(t, err)
+		defer tablesCleanupFunc()
+
+		cipher := storage.NewEncrypter(cfg.SecretKey)
+		brokerStorage, _, err := storage.NewFromConfig(cfg, cipher, logrus.StandardLogger())
+		require.NoError(t, err)
+		require.NotNil(t, brokerStorage)
+
+		fixRuntimeID := "runtimeID"
+		fixKymaVersion := "2.0.3"
+
+		fixRuntimeStateID1 := "runtimestate1"
+		fixOperationID1 := "operation1"
+		runtimeStateWithoutReconcilerInput := fixture.FixRuntimeState(fixRuntimeStateID1, fixRuntimeID, fixOperationID1)
+		runtimeStateWithoutReconcilerInput.CreatedAt = runtimeStateWithoutReconcilerInput.CreatedAt.Add(time.Hour * 2)
+
+		fixRuntimeStateID2 := "runtimestate2"
+		fixOperationID2 := "operation2"
+		runtimeStateWithReconcilerInput := fixture.FixRuntimeState(fixRuntimeStateID2, fixRuntimeID, fixOperationID2)
+		runtimeStateWithReconcilerInput.CreatedAt = runtimeStateWithReconcilerInput.CreatedAt.Add(time.Hour * 1)
+		runtimeStateWithReconcilerInput.ClusterSetup = &reconcilerApi.Cluster{
+			KymaConfig: reconcilerApi.KymaConfig{
+				Version: fixKymaVersion,
+			},
+			RuntimeID: fixRuntimeID,
+		}
+
+		storage := brokerStorage.RuntimeStates()
+
+		err = storage.Insert(runtimeStateWithoutReconcilerInput)
+		require.NoError(t, err)
+		err = storage.Insert(runtimeStateWithReconcilerInput)
+		require.NoError(t, err)
+
+		gotRuntimeStates, err := storage.ListByRuntimeID(fixRuntimeID)
+		require.NoError(t, err)
+		assert.Len(t, gotRuntimeStates, 2)
+
+		gotRuntimeState, err := storage.GetLatestByRuntimeID(fixRuntimeID)
+		require.NoError(t, err)
+		assert.Equal(t, gotRuntimeState.ID, runtimeStateWithoutReconcilerInput.ID)
+		assert.Nil(t, gotRuntimeState.ClusterSetup)
+
+		gotRuntimeState, err = storage.GetLatestWithKymaVersionByRuntimeID(fixRuntimeID)
+		require.NoError(t, err)
+		assert.Equal(t, gotRuntimeState.ID, runtimeStateWithReconcilerInput.ID)
+		assert.NotNil(t, gotRuntimeState.ClusterSetup)
+		assert.Equal(t, fixKymaVersion, gotRuntimeState.ClusterSetup.KymaConfig.Version)
+	})
 }

--- a/components/kyma-environment-broker/internal/storage/postsql/factory.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/factory.go
@@ -42,7 +42,7 @@ type ReadSession interface {
 	GetOperationStatsForOrchestration(orchestrationID string) ([]dbmodel.OperationStatEntry, error)
 	GetLatestRuntimeStateByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error)
 	GetLatestRuntimeStateWithReconcilerInputByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error)
-	GetLatestRuntimeStatesByRuntimeID(runtimeID string, count int) ([]dbmodel.RuntimeStateDTO, dberr.Error)
+	GetLatestRuntimeStateWithKymaVersionByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error)
 }
 
 //go:generate mockery -name=WriteSession

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -446,10 +446,10 @@ func (r readSession) GetLatestRuntimeStateWithKymaVersionByRuntimeID(runtimeID s
 		if err == dbr.ErrNotFound {
 			return state, dberr.NotFound("cannot find latest runtime state with kyma version: %s", err)
 		}
-		return state, dberr.Internal("Failed to get the latest runtime states with kyma version: %s", err)
+		return state, dberr.Internal("Failed to get the latest runtime state with kyma version: %s", err)
 	}
 	if count == 0 {
-		return state, dberr.NotFound("cannot find latest runtime states with kyma version: %s", err)
+		return state, dberr.NotFound("found 0 latest runtime states with kyma version: %s", err)
 	}
 	return state, nil
 }

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -429,33 +429,29 @@ func (r readSession) GetLatestRuntimeStateWithReconcilerInputByRuntimeID(runtime
 	return state, nil
 }
 
-func (r readSession) GetLatestRuntimeStatesByRuntimeID(runtimeID string, n int) ([]dbmodel.RuntimeStateDTO, dberr.Error) {
-	var states []dbmodel.RuntimeStateDTO
-	condition := dbr.And(dbr.Eq("runtime_id", runtimeID), dbr.Or(
-		dbr.And(dbr.Neq("cluster_setup", nil), dbr.Neq("cluster_setup", "")),
-		dbr.And(dbr.Neq("kyma_config", nil), dbr.Neq("kyma_config", "")),
-	))
+func (r readSession) GetLatestRuntimeStateWithKymaVersionByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error) {
+	var state dbmodel.RuntimeStateDTO
+	condition := dbr.And(dbr.Eq("runtime_id", runtimeID),
+		dbr.And(dbr.Neq("kyma_version", nil), dbr.Neq("kyma_version", "")),
+	)
 
 	count, err := r.session.
 		Select("*").
 		From(RuntimeStateTableName).
 		Where(condition).
 		OrderDesc(CreatedAtField).
-		// because both cluster_setup as well as kyma_config are encrypted
-		// we can't easily query the content of the json. This gets the last
-		// N operations for further processing
-		Limit(uint64(n)).
-		Load(&states)
+		Limit(1).
+		Load(&state)
 	if err != nil {
 		if err == dbr.ErrNotFound {
-			return states, dberr.NotFound("cannot find latest 10 runtime states: %s", err)
+			return state, dberr.NotFound("cannot find latest runtime state with kyma version: %s", err)
 		}
-		return states, dberr.Internal("Failed to get the latest 10 runtime states: %s", err)
+		return state, dberr.Internal("Failed to get the latest runtime states with kyma version: %s", err)
 	}
 	if count == 0 {
-		return states, dberr.NotFound("cannot find latest 10 runtime states with reconciler input: %s", err)
+		return state, dberr.NotFound("cannot find latest runtime states with kyma version: %s", err)
 	}
-	return states, nil
+	return state, nil
 }
 
 func (r readSession) getOperation(condition dbr.Builder) (dbmodel.OperationDTO, dberr.Error) {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1312"
     kyma_environment_broker:
       dir:
-      version: "PR-1308"
+      version: "PR-1320"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1285"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- replace GetLatestRuntimeStatesByRuntimeID() with GetLatestRuntimeStateWithKymaVersionByRuntimeID(),
- adjust GetLatestWithKymaVersionByRuntimeID(),
- provide test case for fetching the latest Runtimestate with Kyma version by RuntimeId

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Ref: #1264 