### PR TITLE
Hide authorization headers in logs

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-1276"
     provisioner:
       dir:
-      version: "PR-1328"
+      version: "PR-1326"
     kyma_environment_broker:
       dir:
       version: "PR-1324"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Provisioner error logs contain all headers, which include sensitive data - authorisation headers.

Changes proposed in this pull request:

- hide sensitive headers from logs (`Authorization`)
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
