### PR TITLE
Keb add kyma version

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -570,7 +570,7 @@ func (s *BrokerSuiteTest) AssertProvisionerStartedProvisioning(operationID strin
 
 func (s *BrokerSuiteTest) FinishUpgradeKymaOperationByReconciler(operationID string) {
 	var upgradeOp *internal.UpgradeKymaOperation
-	err := wait.Poll(pollingInterval, 2*time.Second, func() (bool, error) {
+	err := wait.Poll(pollingInterval, 3*time.Second, func() (bool, error) {
 		op, err := s.db.Operations().GetUpgradeKymaOperationByID(operationID)
 		if err != nil {
 			return false, nil
@@ -584,7 +584,7 @@ func (s *BrokerSuiteTest) FinishUpgradeKymaOperationByReconciler(operationID str
 	assert.NoError(s.t, err)
 
 	var state *reconcilerApi.HTTPClusterResponse
-	err = wait.Poll(pollingInterval, 2*time.Second, func() (bool, error) {
+	err = wait.Poll(pollingInterval, 1*time.Second, func() (bool, error) {
 		state, err = s.reconcilerClient.GetCluster(upgradeOp.InstanceDetails.RuntimeID, upgradeOp.ClusterConfigurationVersion)
 		if err != nil {
 			return false, err

--- a/components/kyma-environment-broker/internal/broker/instance_update.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update.go
@@ -336,12 +336,6 @@ func (b *UpdateEndpoint) isKyma2(instance *internal.Instance) (bool, string, err
 	if err != nil {
 		return false, "", err
 	}
-	kv := ""
-	if s.KymaConfig.Version != "" {
-		kv = s.KymaConfig.Version
-	}
-	if s.ClusterSetup != nil && s.ClusterSetup.KymaConfig.Version != "" {
-		kv = s.ClusterSetup.KymaConfig.Version
-	}
+	kv := s.GetKymaVersion()
 	return internal.DetermineMajorVersion(kv) == 2, kv, nil
 }

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -441,6 +441,8 @@ type RuntimeState struct {
 	KymaConfig    gqlschema.KymaConfigInput     `json:"kymaConfig"`
 	ClusterConfig gqlschema.GardenerConfigInput `json:"clusterConfig"`
 	ClusterSetup  *reconcilerApi.Cluster        `json:"clusterSetup,omitempty"`
+
+	KymaVersion string
 }
 
 func (r *RuntimeState) GetKymaConfig() gqlschema.KymaConfigInput {
@@ -451,6 +453,9 @@ func (r *RuntimeState) GetKymaConfig() gqlschema.KymaConfigInput {
 }
 
 func (r *RuntimeState) GetKymaVersion() string {
+	if r.KymaVersion != "" {
+		return r.KymaVersion
+	}
 	if r.ClusterSetup != nil {
 		return r.ClusterSetup.KymaConfig.Version
 	}

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -442,7 +442,7 @@ type RuntimeState struct {
 	ClusterConfig gqlschema.GardenerConfigInput `json:"clusterConfig"`
 	ClusterSetup  *reconcilerApi.Cluster        `json:"clusterSetup,omitempty"`
 
-	KymaVersion string
+	KymaVersion string `json:"kyma_version"`
 }
 
 func (r *RuntimeState) GetKymaConfig() gqlschema.KymaConfigInput {

--- a/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
+++ b/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
@@ -70,9 +70,10 @@ func (s *UpgradeShootStep) Run(operation internal.UpdatingOperation, log logrus.
 	}
 
 	log.Infof("call to provisioner succeeded, got operation ID %q", *provisionerResponse.ID)
-	err = s.runtimeStateStorage.Insert(
-		internal.NewRuntimeState(*provisionerResponse.RuntimeID, operation.Operation.ID, nil, gardenerUpgradeInputToConfigInput(input)),
-	)
+
+	rs := internal.NewRuntimeState(*provisionerResponse.RuntimeID, operation.Operation.ID, nil, gardenerUpgradeInputToConfigInput(input))
+	rs.KymaVersion = operation.RuntimeVersion.Version
+	err = s.runtimeStateStorage.Insert(rs)
 	if err != nil {
 		log.Errorf("cannot insert runtimeState: %s", err)
 		return operation, 10 * time.Second, nil

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
@@ -103,9 +103,8 @@ func (s *UpgradeClusterStep) Run(operation internal.UpgradeClusterOperation, log
 	log = log.WithField("runtimeID", *provisionerResponse.RuntimeID)
 	log.Infof("call to provisioner succeeded, got operation ID %q", *provisionerResponse.ID)
 
-	err = s.runtimeStateStorage.Insert(
-		internal.NewRuntimeState(*provisionerResponse.RuntimeID, operation.Operation.ID, nil, gardenerUpgradeInputToConfigInput(input)),
-	)
+	rs := internal.NewRuntimeState(*provisionerResponse.RuntimeID, operation.Operation.ID, nil, gardenerUpgradeInputToConfigInput(input))
+	err := s.runtimeStateStorage.Insert(rs)
 	if err != nil {
 		log.Errorf("cannot insert runtimeState: %s", err)
 		return operation, 10 * time.Second, nil

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
@@ -104,7 +104,7 @@ func (s *UpgradeClusterStep) Run(operation internal.UpgradeClusterOperation, log
 	log.Infof("call to provisioner succeeded, got operation ID %q", *provisionerResponse.ID)
 
 	rs := internal.NewRuntimeState(*provisionerResponse.RuntimeID, operation.Operation.ID, nil, gardenerUpgradeInputToConfigInput(input))
-	err := s.runtimeStateStorage.Insert(rs)
+	err = s.runtimeStateStorage.Insert(rs)
 	if err != nil {
 		log.Errorf("cannot insert runtimeState: %s", err)
 		return operation, 10 * time.Second, nil

--- a/components/kyma-environment-broker/internal/runtimeversion/runtimeversion.go
+++ b/components/kyma-environment-broker/internal/runtimeversion/runtimeversion.go
@@ -1,6 +1,7 @@
 package runtimeversion
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -103,7 +104,7 @@ func extractMajorVersionNumberFromVersionString(version string) (int, error) {
 	splitVer := strings.Split(version, ".")
 	majorVerNum, err := strconv.Atoi(splitVer[0])
 	if err != nil {
-		return 0, errors.New("cannot convert major version to int")
+		return 0, fmt.Errorf("cannot convert major version (version: \"%s\") to int", version)
 	}
 	return majorVerNum, nil
 }

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/runtime_state.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/runtime_state.go
@@ -176,9 +176,9 @@ func (s *runtimeState) GetLatestWithKymaVersionByRuntimeID(runtimeID string) (in
 	if result.KymaConfig.Version != "" {
 		return result, nil
 	}
-	//if result.KymaVersion != "" {
-	//	return result, nil
-	//}
+	if result.KymaVersion != "" {
+		return result, nil
+	}
 
 	return internal.RuntimeState{}, fmt.Errorf("failed to find RuntimeState with kyma version for runtime %s ", runtimeID)
 }

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/runtime_state.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/runtime_state.go
@@ -176,8 +176,11 @@ func (s *runtimeState) GetLatestWithKymaVersionByRuntimeID(runtimeID string) (in
 	if result.KymaConfig.Version != "" {
 		return result, nil
 	}
+	//if result.KymaVersion != "" {
+	//	return result, nil
+	//}
 
-	return internal.RuntimeState{}, fmt.Errorf("failed to find RuntimeState with kyma version for runtime %s", runtimeID)
+	return internal.RuntimeState{}, fmt.Errorf("failed to find RuntimeState with kyma version for runtime %s ", runtimeID)
 }
 
 func (s *runtimeState) runtimeStateToDB(state internal.RuntimeState) (dbmodel.RuntimeStateDTO, error) {
@@ -250,6 +253,7 @@ func (s *runtimeState) toRuntimeState(dto *dbmodel.RuntimeStateDTO) (internal.Ru
 		KymaConfig:    kymaCfg,
 		ClusterConfig: clusterCfg,
 		ClusterSetup:  clusterSetup,
+		KymaVersion:   dto.KymaVersion,
 	}, nil
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1334"
     kyma_environment_broker:
       dir:
-      version: "PR-1337"
+      version: "PR-1335"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1285"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The runtime_state entity contains a field in the DB "kyma_version" which was updated by manual SQL script. The logic in the code executes a query, which filters by that field. But after that, it reads the kyma version from other field. In that case, the runtimestate contains the kyma_version (so the row was returned), but it was only gardener cluster update  - no kyma version in the data.
