### PR TITLE
Install openssl from edge

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.sac
+++ b/components/kyma-environment-broker/Dockerfile.sac
@@ -20,6 +20,7 @@ RUN apk --update add ca-certificates
 FROM alpine:3.14.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
+RUN apk --no-cache add --update openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -20,7 +20,7 @@ global:
       version: "PR-1285"
     kyma_environments_subaccount_cleanup_job:
       dir:
-      version: "PR-1279"
+      version: "PR-1339"
     subscription_cleanup_job:
       dir:
       version: "PR-1268"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

OpenSSL from edge has version [1.1.1m-r1](https://pkgs.alpinelinux.org/package/edge/main/x86/openssl#), this is to remediate CVE-2021-4160 present in current `1.1.1l-r7`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
