### PR TITLE
Bump CloudSQL proxy image to 1.28.1

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -1,7 +1,7 @@
 global:
   defaultTenant: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae
   images:
-    cloudsql_proxy_image: eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.27.0-alpine-7c52185c
+    cloudsql_proxy_image: eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.28.1-alpine-877b295c
     mothership_reconciler: "eu.gcr.io/kyma-project/incubator/reconciler/mothership:e635ce55"
     component_reconciler: "eu.gcr.io/kyma-project/incubator/reconciler/component:e635ce55"
     containerRegistry:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Using latest upstream CloudSQL proxy image to remediate [OpenSSL CVE-2021-4160](https://nvd.nist.gov/vuln/detail/CVE-2021-4160).

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- [x] https://github.com/kyma-project/third-party-images/pull/181