### PR TITLE
Bump schema-migrator base image to 3.15.0

### DIFF
--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -1,11 +1,11 @@
-FROM alpine:3.14.3
+FROM alpine:3.15.0
 LABEL source=git@github.com:kyma-project/control-plane.git
 
 ARG MIGRATE_VER=4.15.1
 
 WORKDIR /migrate
 
-RUN apk --no-cache add bash>=5.1.8-r0 --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl bash --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache add postgresql-client
 RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 RUN wget https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VER}/migrate.linux-amd64.tar.gz -O - | tar -xz

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -8,7 +8,7 @@ global:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:
       dir:
-      version: "PR-1276"
+      version: "PR-1343"
     provisioner:
       dir:
       version: "PR-1334"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

OpenSSL from edge has version [1.1.1m-r1](https://pkgs.alpinelinux.org/package/edge/main/x86/openssl#), this is to remediate CVE-2021-4160 present in current `1.1.1l-r7`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
