### PR TITLE
Install OpenSSL lib from edge in various KEB components

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.sac
+++ b/components/kyma-environment-broker/Dockerfile.sac
@@ -20,7 +20,7 @@ RUN apk --update add ca-certificates
 FROM alpine:3.14.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
-RUN apk --no-cache add --update openssl --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/components/kyma-environment-broker/Dockerfile.sac
+++ b/components/kyma-environment-broker/Dockerfile.sac
@@ -20,8 +20,8 @@ RUN apk --update add ca-certificates
 FROM alpine:3.14.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
-RUN apk --no-cache add --update openssl openssl-dev --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
-RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+RUN apk --no-cache add --update openssl openssl-dev --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update curl --repository=https://dl-cdn.alpinelinux.org/alpine/v3.14/main
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=build /bin/accountcleanup /bin/accountcleanup

--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -7,9 +7,9 @@ WORKDIR /migrate
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk --no-cache add --update openssl openssl-dev bash --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl openssl-dev bash --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache add postgresql-client
-RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
+RUN apk --no-cache add --update curl --repository=https://dl-cdn.alpinelinux.org/alpine/v3.14/main
 RUN wget -q "https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VER}/migrate.linux-amd64.tar.gz" -O - | tar -xz
 RUN mv migrate /usr/local/bin/migrate
 

--- a/components/schema-migrator/Dockerfile
+++ b/components/schema-migrator/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /migrate
 
 SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 
-RUN apk --no-cache add --update openssl bash --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+RUN apk --no-cache add --update openssl openssl-dev bash --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 RUN apk --no-cache add postgresql-client
 RUN apk --no-cache add --update curl --repository=http://dl-cdn.alpinelinux.org/alpine/v3.14/main
 RUN wget -q "https://github.com/golang-migrate/migrate/releases/download/v${MIGRATE_VER}/migrate.linux-amd64.tar.gz" -O - | tar -xz

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -8,7 +8,7 @@ global:
       path: eu.gcr.io/kyma-project/control-plane
     schema_migrator:
       dir:
-      version: "PR-1346"
+      version: "PR-1348"
     provisioner:
       dir:
       version: "PR-1346"
@@ -20,7 +20,7 @@ global:
       version: "PR-1285"
     kyma_environments_subaccount_cleanup_job:
       dir:
-      version: "PR-1339"
+      version: "PR-1348"
     subscription_cleanup_job:
       dir:
       version: "PR-1346"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Recently, I updated only OpenSSL client but not the library, which was still installed from the stable repo.
```
$ docker run kyma-environment-subaccount-cleanup-job openssl version
OpenSSL 1.1.1m  14 Dec 2021 (Library: OpenSSL 1.1.1l  24 Aug 2021)
```
this ensures the library is also the latest available from edge and not vulnerable to https://github.com/advisories/GHSA-ph2x-8239-7xc7
```
$ docker run kyma-environment-subaccount-cleanup-job openssl version
OpenSSL 1.1.1m  14 Dec 2021
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/control-plane/pull/1343, https://github.com/kyma-project/control-plane/pull/1339