### PR TITLE
Fix shoot filter response

### DIFF
--- a/tools/cli/pkg/command/reconciliations.go
+++ b/tools/cli/pkg/command/reconciliations.go
@@ -200,6 +200,13 @@ func (cmd *ReconciliationCommand) Run() error {
 		for _, dto := range listRtResp.Data {
 			runtimes = append(runtimes, dto.RuntimeID)
 		}
+		if len(runtimes) == 0 {
+			err = cmd.printReconciliation([]mothership.HTTPReconciliationInfo{})
+			if err != nil {
+				return errors.Wrap(err, "while printing runtimes")
+			}
+			return nil
+		}
 	}
 
 	// fetch reconciliations

--- a/tools/cli/pkg/command/reconciliations_test.go
+++ b/tools/cli/pkg/command/reconciliations_test.go
@@ -282,6 +282,28 @@ func TestReconciliationCommand_Run(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Do not fetch reconciliations when shoot id unknown and runtime not provided",
+			fields: fields{
+				ctx:              testCtx,
+				output:           outputJSON,
+				shoots:           []string{"hakunamatata"},
+				provideKebClient: buildProvideEmptyKebResponse(ctrl),
+				provideMshipClient: func(_ string, _ *http.Client) (mothership.ClientInterface, error) {
+					m := msmock.NewMockClientInterface(ctrl)
+					m.EXPECT().
+						GetReconciliations(gomock.Any(), gomock.Any()).
+						Return(
+							&http.Response{
+								StatusCode: 200,
+								Body:       io.NopCloser(strings.NewReader("[]")),
+							}, nil).
+						Times(0)
+					return m, nil
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "Mothership internal error",
 			fields: fields{
 				ctx:              testCtx,


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- IF shoot filter is provided it has to correspond to a valid runtime, otherwise no call to mothership is made

**Related issue(s)**
https://github.com/kyma-incubator/reconciler/issues/693