### PR TITLE
Add a startupProbe

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
@@ -95,7 +95,9 @@ spec:
           protocol: TCP
         livenessProbe:
           {{- toYaml .Values.deployment.livenessProbe | nindent 10 }}
-        readinessProbe:
+        startupProbe:
+          {{- toYaml .Values.deployment.startupProbe | nindent 10 }}
+         readinessProbe:
           {{- toYaml .Values.deployment.readinessProbe | nindent 10 }}
         resources:
           {{- toYaml .Values.deployment.resources | nindent 10 }}

--- a/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
@@ -97,7 +97,7 @@ spec:
           {{- toYaml .Values.deployment.livenessProbe | nindent 10 }}
         startupProbe:
           {{- toYaml .Values.deployment.startupProbe | nindent 10 }}
-         readinessProbe:
+        readinessProbe:
           {{- toYaml .Values.deployment.readinessProbe | nindent 10 }}
         resources:
           {{- toYaml .Values.deployment.resources | nindent 10 }}

--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -98,6 +98,13 @@ deployment:
     successThreshold: 1
     timeoutSeconds: 2
 
+  startupProbe:
+    httpGet:
+      path: /health/ready
+      port: http
+    failureThreshold: 180
+    periodSeconds: 10
+
   livenessProbe:
     httpGet:
       path: /health/live


### PR DESCRIPTION
**Description**

Add startupProbe to mothership-reconciler deployment


**Related issue(s)**
See: https://github.com/kyma-incubator/reconciler/issues/820