### PR TITLE
Fix setting/restoring AVS maintenance during Kyma 2 upgrade

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -918,7 +918,7 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 		// (also return operation, 0, nil at the end of apply_cluster_configuration)
 		{
 			weight: 1,
-			step:   upgrade_kyma.NewCheckClusterConfigurationStep(db.Operations(), reconcilerClient, cfg.Reconciler.ProvisioningTimeout),
+			step:   upgrade_kyma.NewCheckClusterConfigurationStep(db.Operations(), reconcilerClient, upgradeEvalManager, cfg.Reconciler.ProvisioningTimeout),
 			cnd:    upgrade_kyma.ForKyma2,
 		},
 		{

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/avs_maintenance.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/avs_maintenance.go
@@ -1,0 +1,53 @@
+package upgrade_kyma
+
+import (
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs"
+	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
+	"github.com/sirupsen/logrus"
+)
+
+func SetAvsStatusMaintenance(evaluationManager *avs.EvaluationManager, operationManager *process.UpgradeKymaOperationManager, operation internal.UpgradeKymaOperation, log logrus.FieldLogger) (internal.UpgradeKymaOperation, error) {
+	hasMonitors := evaluationManager.HasMonitors(operation.Avs)
+	inMaintenance := evaluationManager.InMaintenance(operation.Avs)
+	var err error = nil
+	var delay time.Duration = 0
+
+	if hasMonitors && !inMaintenance {
+		log.Infof("setting AVS evaluations statuses to maintenance")
+		err = evaluationManager.SetMaintenanceStatus(&operation.Avs, log)
+		operation, delay = operationManager.UpdateOperation(operation, func(op *internal.UpgradeKymaOperation) {
+			op.Avs.AvsInternalEvaluationStatus = operation.Avs.AvsInternalEvaluationStatus
+			op.Avs.AvsExternalEvaluationStatus = operation.Avs.AvsExternalEvaluationStatus
+		}, log)
+		if err == nil && delay > 0 {
+			err = kebError.NewTemporaryError("failed to update avs status in operation")
+		}
+	}
+
+	return operation, err
+}
+
+func RestoreAvsStatus(evaluationManager *avs.EvaluationManager, operationManager *process.UpgradeKymaOperationManager, operation internal.UpgradeKymaOperation, log logrus.FieldLogger) (internal.UpgradeKymaOperation, error) {
+	hasMonitors := evaluationManager.HasMonitors(operation.Avs)
+	inMaintenance := evaluationManager.InMaintenance(operation.Avs)
+	var err error = nil
+	var delay time.Duration = 0
+
+	if hasMonitors && inMaintenance {
+		log.Infof("clearing AVS maintenantce statuses and restoring original AVS evaluation statuses")
+		err = evaluationManager.RestoreStatus(&operation.Avs, log)
+		operation, delay = operationManager.UpdateOperation(operation, func(op *internal.UpgradeKymaOperation) {
+			op.Avs.AvsInternalEvaluationStatus = operation.Avs.AvsInternalEvaluationStatus
+			op.Avs.AvsExternalEvaluationStatus = operation.Avs.AvsExternalEvaluationStatus
+		}, log)
+		if err == nil && delay > 0 {
+			err = kebError.NewTemporaryError("failed to update avs status in operation")
+		}
+	}
+
+	return operation, err
+}

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation_test.go
@@ -641,7 +641,7 @@ func TestInitialisationStep_Run(t *testing.T) {
 		provisionerClient.On("RuntimeOperationStatus", fixGlobalAccountID, fixProvisionerOperationID).Return(
 			func(accountID string, operationID string) gqlschema.OperationStatus {
 				callCounter++
-				if callCounter <= 2 {
+				if callCounter < 2 {
 					return gqlschema.OperationStatus{
 						ID:        ptr.String(fixProvisionerOperationID),
 						Operation: "",

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1360"
     kyma_environment_broker:
       dir:
-      version: "PR-1352"
+      version: "PR-1370"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1361"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Extract Setting & restoring AVS maintenance status to functions outside of Initialization step
- Set AVS statuses in maintenance correctly in Initialization step for both Kyma 1 and Kyma 2 runtimes
- Restore AVS statuses at the end of processing in Initialization step for Kyma 1 runtimes
- Restore AVS statuses at the end of processing in Check_Cluster_Configuration step for Kyma 2 runtimes

