### PR TITLE
Remove RuntimeID from KEB metrics

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/operation_duration.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_duration.go
@@ -25,14 +25,14 @@ func NewOperationDurationCollector() *OperationDurationCollector {
 			Name:      "provisioning_duration_minutes",
 			Help:      "The time of the provisioning process",
 			Buckets:   prometheus.LinearBuckets(20, 2, 40),
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "plan_id"}),
 		deprovisioningHistogram: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "deprovisioning_duration_minutes",
 			Help:      "The time of the deprovisioning process",
 			Buckets:   prometheus.LinearBuckets(1, 1, 30),
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "plan_id"}),
 	}
 }
 
@@ -56,7 +56,7 @@ func (c *OperationDurationCollector) OnProvisioningSucceeded(ctx context.Context
 	pp := op.ProvisioningParameters
 	minutes := op.UpdatedAt.Sub(op.CreatedAt).Minutes()
 	c.provisioningHistogram.
-		WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).Observe(minutes)
+		WithLabelValues(op.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).Observe(minutes)
 
 	return nil
 }
@@ -72,7 +72,7 @@ func (c *OperationDurationCollector) OnDeprovisioningStepProcessed(ctx context.C
 	if stepProcessed.OldOperation.State == domain.InProgress && op.State == domain.Succeeded {
 		minutes := op.UpdatedAt.Sub(op.CreatedAt).Minutes()
 		c.deprovisioningHistogram.
-			WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).Observe(minutes)
+			WithLabelValues(op.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).Observe(minutes)
 	}
 
 	return nil

--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -32,9 +32,9 @@ const (
 )
 
 // OperationResultCollector provides the following metrics:
-// - compass_keb_provisioning_result{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}
-// - compass_keb_deprovisioning_result{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}
-// - compass_keb_upgrade_result{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}
+// - compass_keb_provisioning_result{"operation_id", "instance_id", "global_account_id", "plan_id"}
+// - compass_keb_deprovisioning_result{"operation_id", "instance_id", "global_account_id", "plan_id"}
+// - compass_keb_upgrade_result{"operation_id", "instance_id", "global_account_id", "plan_id"}
 // These gauges show the status of the operation.
 // The value of the gauge could be:
 // 0 - Failed
@@ -57,25 +57,25 @@ func NewOperationResultCollector() *OperationResultCollector {
 			Subsystem: prometheusSubsystem,
 			Name:      "provisioning_result",
 			Help:      "Result of the provisioning",
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "plan_id"}),
 		deprovisioningResultGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "deprovisioning_result",
 			Help:      "Result of the deprovisioning",
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "plan_id"}),
 		upgradeKymaResultGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "upgrade_kyma_result",
 			Help:      "Result of the kyma upgrade",
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "plan_id"}),
 		upgradeClusterResultGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "upgrade_cluster_result",
 			Help:      "Result of the cluster upgrade",
-		}, []string{"operation_id", "runtime_id", "instance_id", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "global_account_id", "plan_id"}),
 	}
 }
 
@@ -119,7 +119,7 @@ func (c *OperationResultCollector) OnUpgradeKymaStepProcessed(ctx context.Contex
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
 	c.upgradeKymaResultGauge.
-		WithLabelValues(op.Operation.ID, op.Operation.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		WithLabelValues(op.Operation.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 
 	return nil
@@ -151,7 +151,7 @@ func (c *OperationResultCollector) OnUpgradeClusterStepProcessed(ctx context.Con
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
 	c.upgradeClusterResultGauge.
-		WithLabelValues(op.Operation.ID, op.Operation.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		WithLabelValues(op.Operation.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 
 	return nil
@@ -165,7 +165,7 @@ func (c *OperationResultCollector) OnProvisioningSucceeded(ctx context.Context, 
 	op := provisioningSucceeded.Operation
 	pp := op.ProvisioningParameters
 	c.provisioningResultGauge.WithLabelValues(
-		op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		op.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultSucceeded)
 
 	return nil
@@ -189,7 +189,7 @@ func (c *OperationResultCollector) OnProvisioningStepProcessed(ctx context.Conte
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
 	c.provisioningResultGauge.
-		WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		WithLabelValues(op.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 
 	return nil
@@ -212,7 +212,7 @@ func (c *OperationResultCollector) OnDeprovisioningStepProcessed(ctx context.Con
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters
 	c.deprovisioningResultGauge.
-		WithLabelValues(op.ID, op.RuntimeID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
+		WithLabelValues(op.ID, op.InstanceID, pp.ErsContext.GlobalAccountID, pp.PlanID).
 		Set(resultValue)
 	return nil
 }

--- a/components/kyma-environment-broker/internal/metrics/step_result.go
+++ b/components/kyma-environment-broker/internal/metrics/step_result.go
@@ -11,8 +11,8 @@ import (
 )
 
 // StepResultCollector provides the following metrics:
-// - compass_keb_provisioning_step_result{"operation_id", "runtime_id", "instance_id", "step_name", "global_account_id", "plan_id"}
-// - compass_keb_deprovisioning_step_result{"operation_id", "runtime_id", "instance_id", "step_name", "global_account_id", "plan_id"}
+// - compass_keb_provisioning_step_result{"operation_id",  "instance_id", "step_name", "global_account_id", "plan_id"}
+// - compass_keb_deprovisioning_step_result{"operation_id",  "instance_id", "step_name", "global_account_id", "plan_id"}
 // These gauges show the status of the operation step.
 // The value of the gauge could be:
 // 0 - Failed
@@ -30,13 +30,13 @@ func NewStepResultCollector() *StepResultCollector {
 			Subsystem: prometheusSubsystem,
 			Name:      "provisioning_step_result",
 			Help:      "Result of the provisioning step",
-		}, []string{"operation_id", "runtime_id", "instance_id", "step_name", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "step_name", "global_account_id", "plan_id"}),
 		deprovisioningResultGauge: prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: prometheusNamespace,
 			Subsystem: prometheusSubsystem,
 			Name:      "deprovisioning_step_result",
 			Help:      "Result of the deprovisioning step",
-		}, []string{"operation_id", "runtime_id", "instance_id", "step_name", "global_account_id", "plan_id"}),
+		}, []string{"operation_id", "instance_id", "step_name", "global_account_id", "plan_id"}),
 	}
 }
 
@@ -71,7 +71,6 @@ func (c *StepResultCollector) OnProvisioningStepProcessed(ctx context.Context, e
 	pp := op.ProvisioningParameters
 	c.provisioningResultGauge.WithLabelValues(
 		op.ID,
-		op.RuntimeID,
 		op.InstanceID,
 		stepProcessed.StepName,
 		pp.ErsContext.GlobalAccountID,
@@ -106,7 +105,6 @@ func (c *StepResultCollector) OnDeprovisioningStepProcessed(ctx context.Context,
 	pp := op.ProvisioningParameters
 	c.deprovisioningResultGauge.WithLabelValues(
 		op.ID,
-		op.RuntimeID,
 		op.InstanceID,
 		stepProcessed.StepName,
 		pp.ErsContext.GlobalAccountID,

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1306"
     kyma_environment_broker:
       dir:
-      version: "PR-1401"
+      version: "PR-1406"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1380"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
There are duplicate time-series for the same instance, once with `RuntimeID` and once without. For example:
```
compass_keb_provisioning_result{global_account_id="e449f875-b5b2-4485-b7c0-98725c0571bf",instance_id="test-jw148",operation_id="1d02bba0-20cc-4203-8d1d-84d2d2e21eb5",plan_id="361c511f-f939-4621-b228-d0fb79a1fe15",runtime_id=""} 2
compass_keb_provisioning_result{global_account_id="e449f875-b5b2-4485-b7c0-98725c0571bf",instance_id="test-jw148",operation_id="1d02bba0-20cc-4203-8d1d-84d2d2e21eb5",plan_id="361c511f-f939-4621-b228-d0fb79a1fe15",runtime_id="588a6fc4-ea11-407b-9906-25fcb2119a4e"} 2
```
The reason for duplicated `compass_keb_provisioning_result` time-series for each `InstanceID` is that KEB updates the value after each step in the provisioning queue. The problem is, steps before `NewCreateRuntimeStep` for kyma1 and `NewCreateRuntimeWithoutKymaStep` for kyma2 don't have `RuntimeID` yet, so that is why there is one `compass_keb_provisioning_result` without `RuntimeID` tracking progress of steps until the creation of runtime step and then second `compass_keb_provisioning_result` with `RuntimeID` tracking progress of steps after the create runtime step.

It was decided that we should be fine removing `runtime_id` from all KEB metrics as a similar uniqueness guarantee is provided by `InstanceID` x `GlobalAccountID`.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
