### PR TITLE
Change the level of logs regarding "cluster kubeconfig is nil" error

### DIFF
--- a/components/provisioner/internal/operations/executor.go
+++ b/components/provisioner/internal/operations/executor.go
@@ -115,6 +115,10 @@ func (e *Executor) process(operation model.Operation, cluster model.Cluster, log
 
 		result, err := step.Run(cluster, operation, log)
 		if err != nil {
+			if err.Error() == "cluster kubeconfig is nil" {
+				log.Warnf("Warning, the %s", err.Error())
+				return false, 0, nil
+			}
 			log.Warnf("error while processing operation, stage failed: %s", err.Error())
 			return false, 0, err
 		}

--- a/components/provisioner/internal/operations/executor.go
+++ b/components/provisioner/internal/operations/executor.go
@@ -19,6 +19,8 @@ const (
 	backOffDirectorDelay = 1 * time.Second
 )
 
+var ErrKubeconfigNil = errors.New("cluster kubeconfig is nil")
+
 func NewExecutor(
 	session dbsession.ReadWriteSession,
 	operation model.OperationType,
@@ -115,7 +117,7 @@ func (e *Executor) process(operation model.Operation, cluster model.Cluster, log
 
 		result, err := step.Run(cluster, operation, log)
 		if err != nil {
-			if errors.Is(err, errors.New("cluster kubeconfig is nil")) {
+			if errors.Is(err, ErrKubeconfigNil) {
 				log.Warnf("Warning, the %s", err.Error())
 				break
 			}

--- a/components/provisioner/internal/operations/executor.go
+++ b/components/provisioner/internal/operations/executor.go
@@ -115,7 +115,7 @@ func (e *Executor) process(operation model.Operation, cluster model.Cluster, log
 
 		result, err := step.Run(cluster, operation, log)
 		if err != nil {
-			if err.Error() == "cluster kubeconfig is nil" {
+			if errors.Is(err, errors.New("cluster kubeconfig is nil")) {
 				log.Warnf("Warning, the %s", err.Error())
 				break
 			}

--- a/components/provisioner/internal/operations/executor.go
+++ b/components/provisioner/internal/operations/executor.go
@@ -117,7 +117,7 @@ func (e *Executor) process(operation model.Operation, cluster model.Cluster, log
 		if err != nil {
 			if err.Error() == "cluster kubeconfig is nil" {
 				log.Warnf("Warning, the %s", err.Error())
-				return false, 0, nil
+				break
 			}
 			log.Warnf("error while processing operation, stage failed: %s", err.Error())
 			return false, 0, err

--- a/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
+++ b/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
@@ -65,7 +65,7 @@ func (s *CreateBindingsForOperatorsStep) TimeLimit() time.Duration {
 
 func (s *CreateBindingsForOperatorsStep) Run(cluster model.Cluster, _ model.Operation, log logrus.FieldLogger) (operations.StageResult, error) {
 	if cluster.Kubeconfig == nil {
-		return operations.StageResult{}, fmt.Errorf("cluster kubeconfig is nil")
+		return operations.StageResult{}, operations.ErrKubeconfigNil
 	}
 
 	k8sClient, err := s.k8sClientProvider.CreateK8SClient(*cluster.Kubeconfig)


### PR DESCRIPTION
**Description**
Change the text in the log to indicate that empty Kubeconfig is a warning, not an error.

**Changes proposed in this pull request**

- change the log message from error to warning