### PR TITLE
Change pre-merge jobs to run MR in verbose mode

### DIFF
--- a/tools/reconciler/Makefile
+++ b/tools/reconciler/Makefile
@@ -10,10 +10,9 @@ deploy-reconciler:
 		--set compass.enabled=false --set mothership-reconciler.db.encryptionKey=5bc19d3a2032fb8795cd86e08b473a351631505d2522991266b1fb85f89bad5f \
 		--set mothership-reconciler.db.serviceHost=reconciler-postgresql --set mothership-reconciler.db.reconcilerUsername=postgres \
 		--set mothership-reconciler.db.reconcilerPassword=test --set mothership-reconciler.options.verbose=true \
-		--set postgresql.postgresqlPassword=test --set postgresql.persistence.enabled=false \
+		--set postgresql.postgresqlPassword=test --set postgresql.persistence.enabled=true \
 		--set global.mothership_reconciler.auditlog.useTestConfig=true --set global.mothership_reconciler.auditlog.persistence.enabled=false \
 		--set postgresql.initdbScriptsConfigMap=reconciler-postgresql-db-init \
-		--set postgresql.persistence.enabled=true \
 		--set migratorJobs.enabled=false ../../resources/kcp > reconciler.yaml
 	kubectl apply -f reconciler.yaml
 	rm reconciler.yaml


### PR DESCRIPTION
Change pre-merge jobs to run MR in verbose mode and removed conflicting options

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change pre-merge jobs to run MR in verbose mode
- remove conflicting options for `postgresql.persistence.enabled` option

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
