### PR TITLE
Resuse cluster name for reconciler calls

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
+++ b/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
@@ -309,4 +309,6 @@ func TestKymaUpgrade_UpgradeAfterMigration(t *testing.T) {
 	assert.NotEqual(t, rsu1.ID, rsu2.ID, "runtime_state ID from update should differ runtime_state ID from upgrade")
 	assert.Equal(t, upgradeKymaOperationID, rsu2.OperationID, "runtime state upgrade operation ID")
 	assert.ElementsMatch(t, componentNames(rsu2.ClusterSetup.KymaConfig.Components), []string{"ory", "monitoring", "btp-operator"})
+
+	assert.Equal(t, rsu1.ClusterConfig.Name, rsu2.ClusterConfig.Name)
 }

--- a/components/kyma-environment-broker/internal/fixture/fixture.go
+++ b/components/kyma-environment-broker/internal/fixture/fixture.go
@@ -397,7 +397,11 @@ func (c *SimpleInputCreator) SetLabel(key, val string) internal.ProvisionerInput
 	return c
 }
 
-func (c *SimpleInputCreator) SetKubeconfig(kcfg string) internal.ProvisionerInputCreator {
+func (c *SimpleInputCreator) SetKubeconfig(_ string) internal.ProvisionerInputCreator {
+	return c
+}
+
+func (c *SimpleInputCreator) SetClusterName(_ string) internal.ProvisionerInputCreator {
 	return c
 }
 

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -44,6 +44,7 @@ type ProvisionerInputCreator interface {
 	SetInstanceID(instanceID string) ProvisionerInputCreator
 	SetShootDomain(shootDomain string) ProvisionerInputCreator
 	SetShootDNSProviders(dnsProviders gardener.DNSProvidersData) ProvisionerInputCreator
+	SetClusterName(name string) ProvisionerInputCreator
 }
 
 // GitKymaProject and GitKymaRepo define public Kyma GitHub parameters used for
@@ -266,6 +267,7 @@ type InstanceDetails struct {
 	RuntimeID         string                    `json:"runtime_id"`
 	ShootName         string                    `json:"shoot_name"`
 	ShootDomain       string                    `json:"shoot_domain"`
+	ClusterName       string                    `json:"clusterName"`
 	ShootDNSProviders gardener.DNSProvidersData `json:"shoot_dns_providers"`
 	XSUAA             XSUAAData                 `json:"xsuaa"`
 	Ems               EmsData                   `json:"ems"`

--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -61,6 +61,8 @@ type RuntimeInput struct {
 	kubeconfig        string
 	shootDomain       string
 	shootDnsProviders gardener.DNSProvidersData
+	runtimeName       string
+	clusterName       string
 }
 
 func (r *RuntimeInput) EnableOptionalComponent(componentName string) internal.ProvisionerInputCreator {
@@ -111,6 +113,13 @@ func (r *RuntimeInput) SetRuntimeID(runtimeID string) internal.ProvisionerInputC
 
 func (r *RuntimeInput) SetKubeconfig(kubeconfig string) internal.ProvisionerInputCreator {
 	r.kubeconfig = kubeconfig
+	return r
+}
+
+func (r *RuntimeInput) SetClusterName(name string) internal.ProvisionerInputCreator {
+	if name != "" {
+		r.clusterName = name
+	}
 	return r
 }
 
@@ -574,6 +583,11 @@ func (r *RuntimeInput) applyGlobalConfigurationForUpgradeRuntime() error {
 }
 
 func (r *RuntimeInput) adjustRuntimeName() error {
+	// if the cluster name was created before, it must be used instead of generating one
+	if r.clusterName != "" {
+		r.provisionRuntimeInput.RuntimeInput.Name = r.clusterName
+		return nil
+	}
 
 	reg, err := regexp.Compile("[^a-zA-Z0-9\\-\\.]+")
 	if err != nil {

--- a/components/kyma-environment-broker/internal/process/input/input.go
+++ b/components/kyma-environment-broker/internal/process/input/input.go
@@ -61,7 +61,6 @@ type RuntimeInput struct {
 	kubeconfig        string
 	shootDomain       string
 	shootDnsProviders gardener.DNSProvidersData
-	runtimeName       string
 	clusterName       string
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/automock/provisioner_input_creator.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/automock/provisioner_input_creator.go
@@ -329,6 +329,22 @@ func (_m *ProvisionerInputCreator) SetShootDomain(shootDomain string) internal.P
 	return r0
 }
 
+// SetClusterName provides a mock function with given fields: shootDomain
+func (_m *ProvisionerInputCreator) SetClusterName(clusterName string) internal.ProvisionerInputCreator {
+	ret := _m.Called(clusterName)
+
+	var r0 internal.ProvisionerInputCreator
+	if rf, ok := ret.Get(0).(func(string) internal.ProvisionerInputCreator); ok {
+		r0 = rf(clusterName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(internal.ProvisionerInputCreator)
+		}
+	}
+
+	return r0
+}
+
 // SetShootName provides a mock function with given fields: _a0
 func (_m *ProvisionerInputCreator) SetShootName(_a0 string) internal.ProvisionerInputCreator {
 	ret := _m.Called(_a0)

--- a/components/kyma-environment-broker/internal/process/provisioning/base_provision_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/base_provision_test.go
@@ -102,6 +102,10 @@ func (c *simpleInputCreator) SetInstanceID(_ string) internal.ProvisionerInputCr
 	return c
 }
 
+func (c *simpleInputCreator) SetClusterName(_ string) internal.ProvisionerInputCreator {
+	return c
+}
+
 func (c *simpleInputCreator) AppendOverrides(component string, overrides []*gqlschema.ConfigEntryInput) internal.ProvisionerInputCreator {
 	c.overrides[component] = append(c.overrides[component], overrides...)
 	return c

--- a/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go
@@ -61,11 +61,12 @@ func (s *CreateClusterConfigurationStep) Run(operation internal.ProvisioningOper
 		return operation, 10 * time.Second, nil
 	}
 
-	log.Infof("Creating Cluster Configuration: cluster(runtimeID)=%s, kymaVersion=%s, kymaProfile=%s, components=[%s]",
+	log.Infof("Creating Cluster Configuration: cluster(runtimeID)=%s, kymaVersion=%s, kymaProfile=%s, components=[%s], name=%s",
 		clusterConfiguration.RuntimeID,
 		clusterConfiguration.KymaConfig.Version,
 		clusterConfiguration.KymaConfig.Profile,
-		s.componentList(clusterConfiguration))
+		s.componentList(clusterConfiguration),
+		clusterConfiguration.RuntimeInput.Name)
 	state, err := s.reconcilerClient.ApplyClusterConfig(clusterConfiguration)
 	switch {
 	case kebError.IsTemporaryError(err):
@@ -81,6 +82,7 @@ func (s *CreateClusterConfigurationStep) Run(operation internal.ProvisioningOper
 
 	updatedOperation, repeat := s.operationManager.UpdateOperation(operation, func(operation *internal.ProvisioningOperation) {
 		operation.ClusterConfigurationVersion = state.ConfigurationVersion
+		operation.ClusterName = clusterConfiguration.RuntimeInput.Name
 	}, log)
 	if repeat != 0 {
 		log.Errorf("cannot save cluster configuration version")

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_cluster_configuration.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_cluster_configuration.go
@@ -121,6 +121,7 @@ func (s *ApplyClusterConfigurationStep) Run(operation internal.UpgradeKymaOperat
 	updatedOperation, repeat := s.operationManager.UpdateOperation(operation, func(operation *internal.UpgradeKymaOperation) {
 		operation.ClusterConfigurationVersion = state.ConfigurationVersion
 		operation.ClusterConfigurationApplied = true
+		operation.ClusterName = clusterConfiguration.RuntimeInput.Name
 	}, log)
 	if repeat != 0 {
 		log.Errorf("cannot save cluster configuration version")

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_cluster_configuration.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_cluster_configuration.go
@@ -78,7 +78,8 @@ func (s *ApplyClusterConfigurationStep) Run(operation internal.UpgradeKymaOperat
 		SetInstanceID(operation.InstanceID).
 		SetShootName(operation.InstanceDetails.ShootName).
 		SetShootDomain(operation.ShootDomain).
-		SetProvisioningParameters(operation.ProvisioningParameters)
+		SetProvisioningParameters(operation.ProvisioningParameters).
+		SetClusterName(operation.ClusterName)
 
 	clusterConfiguration, err := operation.InputCreator.CreateClusterConfiguration()
 	if err != nil {
@@ -98,11 +99,12 @@ func (s *ApplyClusterConfigurationStep) Run(operation internal.UpgradeKymaOperat
 		return operation, 10 * time.Second, nil
 	}
 
-	log.Infof("Apply Cluster Configuration: cluster(runtimeID)=%s, kymaVersion=%s, kymaProfile=%s, components=[%s]",
+	log.Infof("Apply Cluster Configuration: cluster(runtimeID)=%s, kymaVersion=%s, kymaProfile=%s, components=[%s], name=%s",
 		clusterConfiguration.RuntimeID,
 		clusterConfiguration.KymaConfig.Version,
 		clusterConfiguration.KymaConfig.Profile,
-		s.componentList(clusterConfiguration))
+		s.componentList(clusterConfiguration),
+		clusterConfiguration.RuntimeInput.Name)
 	state, err := s.reconcilerClient.ApplyClusterConfig(clusterConfiguration)
 	switch {
 	case kebError.IsTemporaryError(err):

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/simple_provisioner_input_creator_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/simple_provisioner_input_creator_test.go
@@ -26,6 +26,7 @@ type simpleInputCreator struct {
 	shootName         *string
 	shootDomain       string
 	shootDnsProviders gardener.DNSProvidersData
+	clusterName       string
 }
 
 func (c *simpleInputCreator) EnableOptionalComponent(name string) internal.ProvisionerInputCreator {
@@ -44,6 +45,11 @@ func (c *simpleInputCreator) DisableOptionalComponent(name string) internal.Prov
 
 func (c *simpleInputCreator) SetLabel(key, val string) internal.ProvisionerInputCreator {
 	c.labels[key] = val
+	return c
+}
+
+func (c *simpleInputCreator) SetClusterName(name string) internal.ProvisionerInputCreator {
+	c.clusterName = name
 	return c
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1306"
     kyma_environment_broker:
       dir:
-      version: "PR-1406"
+      version: "PR-1418"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1380"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- Once the cluster name is created, it is stored as a `clusterName` in the instance details and can be reused by next operations

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
