### PR TITLE
kcp-cli orchestration sends slack info message

### DIFF
--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -53,6 +53,7 @@ type GlobalOptionsKey struct {
 	kebAPIURL          string
 	mothershipAPIURL   string
 	kubeconfigAPIURL   string
+	slackAPIURL        string
 	gardenerKubeconfig string
 	gardenerNamespace  string
 	username           string
@@ -66,6 +67,7 @@ var GlobalOpts = GlobalOptionsKey{
 	kebAPIURL:          "keb-api-url",
 	mothershipAPIURL:   "mothership-api-url",
 	kubeconfigAPIURL:   "kubeconfig-api-url",
+	slackAPIURL:        "slack-api-url",
 	gardenerKubeconfig: "gardener-kubeconfig",
 	gardenerNamespace:  "gardener-namespace",
 	username:           "username",
@@ -84,6 +86,9 @@ func SetGlobalOpts(cmd *cobra.Command) {
 
 	cmd.PersistentFlags().String(GlobalOpts.kebAPIURL, "", "Kyma Environment Broker API URL to use for all commands. Can also be set using the KCP_KEB_API_URL environment variable.")
 	viper.BindPFlag(GlobalOpts.kebAPIURL, cmd.PersistentFlags().Lookup(GlobalOpts.kebAPIURL))
+
+	cmd.PersistentFlags().String(GlobalOpts.slackAPIURL, "", "Slack API URL to use for all commands. Can also be set using the SLACK_API_URL environment variable.")
+	viper.BindPFlag(GlobalOpts.slackAPIURL, cmd.PersistentFlags().Lookup(GlobalOpts.slackAPIURL))
 
 	cmd.PersistentFlags().String(GlobalOpts.mothershipAPIURL, "", "Mothership API URL to use for all commands. Can also be set using the KCP_MOTHERSHIP_API_URL environment variable.")
 	viper.BindPFlag(GlobalOpts.mothershipAPIURL, cmd.PersistentFlags().Lookup(GlobalOpts.mothershipAPIURL))
@@ -142,6 +147,11 @@ func (keys *GlobalOptionsKey) MothershipAPIURL() string {
 // KubeconfigAPIURL gets the kubeconfig-api-url global parameter
 func (keys *GlobalOptionsKey) KubeconfigAPIURL() string {
 	return viper.GetString(keys.kubeconfigAPIURL)
+}
+
+// SlackAPIURL gets the slack-api-url global parameter
+func (keys *GlobalOptionsKey) SlackAPIURL() string {
+	return viper.GetString(keys.slackAPIURL)
 }
 
 // GardenerKubeconfig gets the gardener-kubeconfig global parameter

--- a/tools/cli/pkg/command/send_slack_notification.go
+++ b/tools/cli/pkg/command/send_slack_notification.go
@@ -1,0 +1,112 @@
+package command
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+type Attachment struct {
+	Text  string `json:"text"`
+	Color string `json:"color"`
+	Title string `json:"title"`
+}
+
+type SlackRequestBody struct {
+	Text        string       `json:"text"`
+	Icon_emoji  string       `json:"icon_emoji"`
+	Attachments []Attachment `json:"attachments"`
+	Username    string       `json:"username"`
+}
+
+const ICON_EMOJI = ":high_brightness:"
+const SLACK_USER_NAME = "upgrade-info"
+const SLACK_COLOR = "#36a64f" //green
+
+var upgradeOpts = []string{"parallel-workers", "schedule", "strategy",
+	"target", "target-exclude", "verbose", "version"}
+
+// SendSlackNotification will post message including attachments to slackhookUrl.
+func SendSlackNotification(title string, cobraCmd *cobra.Command, output string) error {
+	slackhookUrl := GlobalOpts.SlackAPIURL()
+	triggeredCmd := revertUpgradeOpts(title, cobraCmd)
+	attachment := Attachment{
+		Color: SLACK_COLOR,
+		Text:  triggeredCmd + "\n" + output,
+	}
+
+	slackBody, _ := json.Marshal(SlackRequestBody{Text: "New " + title + " is triggerred",
+		Icon_emoji: ICON_EMOJI, Username: SLACK_USER_NAME, Attachments: []Attachment{attachment}})
+	req, err := http.NewRequest(http.MethodPost, slackhookUrl, bytes.NewBuffer(slackBody))
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// Drain response body and close, return error to context if there isn't any.
+	defer func() {
+		derr := drainResponseBody(resp.Body)
+		if err == nil {
+			err = derr
+		}
+		cerr := resp.Body.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("calling %s returned %s status", slackhookUrl, resp.Status)
+	}
+
+	bodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("while decoding slack response body")
+	}
+	bodyString := string(bodyBytes)
+	if bodyString != "ok" {
+		return fmt.Errorf("non-ok response returned from Slack")
+	}
+	return nil
+}
+
+func drainResponseBody(body io.Reader) error {
+	if body == nil {
+		return nil
+	}
+	_, err := io.Copy(ioutil.Discard, io.LimitReader(body, 4096))
+	return err
+}
+
+func revertUpgradeOpts(title string, cobraCmd *cobra.Command) string {
+	commnd := "kcp " + title
+	cobraCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+		for _, col := range upgradeOpts {
+			if flag.Name == col && flag.Value.String() != "" {
+				if (flag.Name == "strategy" && flag.Value.String() == "parallel") ||
+					((flag.Name == "verbose" || flag.Name == "parallel-workers") && flag.Value.String() == "0") ||
+					((flag.Name == "target" || flag.Name == "target-exclude") && flag.Value.String() == "[]") {
+					continue
+				} else if flag.Name == "target" || flag.Name == "target-exclude" {
+					commnd = commnd + " --" + flag.Name + " " + strings.Trim(flag.Value.String(), "[]")
+				} else {
+					commnd = commnd + " --" + flag.Name + " " + flag.Value.String()
+				}
+			}
+		}
+	})
+	return commnd
+}

--- a/tools/cli/pkg/command/upgrade_cluster.go
+++ b/tools/cli/pkg/command/upgrade_cluster.go
@@ -60,7 +60,7 @@ func (cmd *UpgradeClusterCommand) Run() error {
 	}
 	fmt.Println("OrchestrationID:", ur.OrchestrationID)
 
-	if !cmd.orchestrationParams.DryRun {
+	if !cmd.orchestrationParams.DryRun && GlobalOpts.SlackAPIURL() != "" {
 		slack_title := `upgrade cluster`
 		slack_err := SendSlackNotification(slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
 		if slack_err != nil {

--- a/tools/cli/pkg/command/upgrade_cluster.go
+++ b/tools/cli/pkg/command/upgrade_cluster.go
@@ -44,7 +44,9 @@ func (cmd *UpgradeClusterCommand) Validate() error {
 	if err != nil {
 		return err
 	}
-
+	if GlobalOpts.SlackAPIURL() == "" {
+		return fmt.Errorf("missing required %s option", GlobalOpts.SlackAPIURL())
+	}
 	return nil
 }
 
@@ -57,5 +59,13 @@ func (cmd *UpgradeClusterCommand) Run() error {
 		return errors.Wrap(err, "while triggering kyma upgrade")
 	}
 	fmt.Println("OrchestrationID:", ur.OrchestrationID)
+
+	if !cmd.orchestrationParams.DryRun {
+		slack_title := `upgrade cluster`
+		slack_err := SendSlackNotification(slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
+		if slack_err != nil {
+			return errors.Wrap(slack_err, "while sending notification to slack")
+		}
+	}
 	return nil
 }

--- a/tools/cli/pkg/command/upgrade_cluster.go
+++ b/tools/cli/pkg/command/upgrade_cluster.go
@@ -45,7 +45,7 @@ func (cmd *UpgradeClusterCommand) Validate() error {
 		return err
 	}
 	if GlobalOpts.SlackAPIURL() == "" {
-		return fmt.Errorf("missing required %s option", GlobalOpts.SlackAPIURL())
+		fmt.Println("Note: Ignore sending slack notification when slackAPIURL is empty")
 	}
 	return nil
 }

--- a/tools/cli/pkg/command/upgrade_kyma.go
+++ b/tools/cli/pkg/command/upgrade_kyma.go
@@ -58,6 +58,14 @@ func (cmd *UpgradeKymaCommand) Run() error {
 		return errors.Wrap(err, "while triggering kyma upgrade")
 	}
 	fmt.Println("OrchestrationID:", ur.OrchestrationID)
+
+	if !cmd.orchestrationParams.DryRun {
+		slack_title := `upgrade kyma`
+		slack_err := SendSlackNotification(slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
+		if slack_err != nil {
+			return errors.Wrap(slack_err, "while sending notification to slack")
+		}
+	}
 	return nil
 }
 
@@ -77,6 +85,10 @@ func (cmd *UpgradeKymaCommand) Validate() error {
 		cmd.orchestrationParams.Kyma = &orchestration.KymaParameters{Version: cmd.version}
 	} else {
 		cmd.orchestrationParams.Kyma.Version = cmd.version
+	}
+
+	if GlobalOpts.SlackAPIURL() == "" {
+		return fmt.Errorf("missing required %s option", GlobalOpts.SlackAPIURL())
 	}
 
 	return nil

--- a/tools/cli/pkg/command/upgrade_kyma.go
+++ b/tools/cli/pkg/command/upgrade_kyma.go
@@ -59,7 +59,7 @@ func (cmd *UpgradeKymaCommand) Run() error {
 	}
 	fmt.Println("OrchestrationID:", ur.OrchestrationID)
 
-	if !cmd.orchestrationParams.DryRun {
+	if !cmd.orchestrationParams.DryRun && GlobalOpts.SlackAPIURL() != "" {
 		slack_title := `upgrade kyma`
 		slack_err := SendSlackNotification(slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
 		if slack_err != nil {

--- a/tools/cli/pkg/command/upgrade_kyma.go
+++ b/tools/cli/pkg/command/upgrade_kyma.go
@@ -88,7 +88,7 @@ func (cmd *UpgradeKymaCommand) Validate() error {
 	}
 
 	if GlobalOpts.SlackAPIURL() == "" {
-		return fmt.Errorf("missing required %s option", GlobalOpts.SlackAPIURL())
+		fmt.Println("Note: Ignore sending slack notification when slackAPIURL is empty")
 	}
 
 	return nil


### PR DESCRIPTION
To implement task [kcp-cli orchestration sends slack info message ](https://github.tools.sap/kyma/backlog/issues/2323) that is auto-trigger  a slack message when execute the command `kcp upgrade kyma/cluster ***` 

testing example is https://sap-ti.slack.com/archives/CSCAQLZ98/p1646799451784189

[](https://app.slack.com/services/BSTAJ7YMC):high_brightness:[upgrade-info](https://app.slack.com/services/BSTAJ7YMC)APP  [12:17 PM](https://sap-ti.slack.com/archives/CSCAQLZ98/p1646799451784189)[](https://app.slack.com/services/BSTAJ7YMC)
upgrade kyma
kcp upgrade kyma  --target shoot=c-6a24f3f  --version 2.0.4
OrchestrationID:c94d828d-812a-4b20-a79b-4e27fe84403b

[](https://app.slack.com/services/BSTAJ7YMC):high_brightness:[upgrade-info](https://app.slack.com/services/BSTAJ7YMC)APP  [12:31 PM](https://sap-ti.slack.com/archives/CSCAQLZ98/p1646800299172309)
upgrade cluster
kcp upgrade cluster --target shoot=c-6a24f3f
OrchestrationID:4b5c793f-afea-446e-8b49-cc50614d8117
