### PR TITLE
Set provisioning parameters when processing deprovisioning operation

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -13,13 +13,14 @@ const (
 	prometheusNamespace = "compass"
 	prometheusSubsystem = "keb"
 
-	resultFailed     float64 = 0
-	resultSucceeded  float64 = 1
-	resultInProgress float64 = 2
-	resultPending    float64 = 3
-	resultCanceling  float64 = 4
-	resultCanceled   float64 = 5
-	resultRetrying   float64 = 6
+	resultFailed        float64 = 0
+	resultSucceeded     float64 = 1
+	resultInProgress    float64 = 2
+	resultPending       float64 = 3
+	resultCanceling     float64 = 4
+	resultCanceled      float64 = 5
+	resultRetrying      float64 = 6
+	resultUnimplemented float64 = 7
 )
 
 type LastOperationState = domain.LastOperationState
@@ -208,6 +209,10 @@ func (c *OperationResultCollector) OnDeprovisioningStepProcessed(ctx context.Con
 		resultValue = resultSucceeded
 	case domain.Failed:
 		resultValue = resultFailed
+	case Pending:
+		resultValue = resultPending
+	default:
+		resultValue = resultUnimplemented
 	}
 	op := stepProcessed.Operation
 	pp := op.ProvisioningParameters

--- a/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/initialisation.go
@@ -99,6 +99,9 @@ func (s *InitialisationStep) run(operation internal.DeprovisioningOperation, log
 	}
 	if op.State == domain.InProgress {
 		log.Info("waiting for provisioning operation to finish")
+		// This is only in memory copy because metrics depend on provisioning parameters being available, this doesn't persist them in KEB database
+		operation.SubAccountID = operation.ProvisioningParameters.ErsContext.SubAccountID
+		operation.ProvisioningParameters = op.ProvisioningParameters
 		return operation, time.Minute, nil
 	}
 	operation, repeat := s.operationManager.UpdateOperation(operation, func(operation *internal.DeprovisioningOperation) {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1306"
     kyma_environment_broker:
       dir:
-      version: "PR-1417"
+      version: "PR-1443"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1380"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When the deprovisioning operation is triggered while the provisioning operation is still in progress, KEB reports confusing metrics and duplicate time-series for each `instance_id`.

```
compass_keb_deprovisioning_result{global_account_id="",instance_id="test-jw160",operation_id="782f1126-fc42-44c9-98a5-b4b8686f1a44",plan_id=""} 0
compass_keb_deprovisioning_result{global_account_id="e449f875-b5b2-4485-b7c0-98725c0571bf",instance_id="test-jw160",operation_id="782f1126-fc42-44c9-98a5-b4b8686f1a44",plan_id="361c511f-f939-4621-b228-d0fb79a1fe15"} 2
```

This is because `initialization_step` in the provisioning queue detects the provisioning operation is not finished and tells the manager to put the processing of this back in the queue before getting `ProvisioningParameters`.

The second bug was that the switch-case statement translating operation status to operation status metrics didn't contain `pending` at all, falling through the statement and keeping the default value for float64, which is 0.

This PR adds the information to the runtime object for metrics processing as well as `pending` case and it seems to have resolved the issue, correctly reporting deprovisioning operation in pending status.

```
compass_keb_deprovisioning_result{global_account_id="e449f875-b5b2-4485-b7c0-98725c0571bf",instance_id="test-jw166",operation_id="cbb9157f-edb8-4b40-875a-59d2fefd46cd",plan_id="361c511f-f939-4621-b228-d0fb79a1fe15"} 3
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
