### PR TITLE
feat: enable new cleaner script on mothership

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
@@ -74,6 +74,8 @@ spec:
           - --config=mothership-configuration/reconciler.yaml
           - --migrate-database
           - --purge-older-than=96h
+          - --reconciliations-keep-n-latest=150
+          - --entities-max-age-days=4
           {{- if .Values.options.verbose }}
           - --verbose
           {{- end }}

--- a/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
@@ -73,7 +73,6 @@ spec:
           - start
           - --config=mothership-configuration/reconciler.yaml
           - --migrate-database
-          - --purge-older-than=96h
           - --reconciliations-keep-n-latest=150
           - --entities-max-age-days=4
           {{- if .Values.options.verbose }}


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Sets the value for  flags (via args) to enable new inventory and reconciliations cleanup
- All reconciliations and deleted inventory clusters before 4 days will be dropped
- Only recent 150 reconciliations will be retained, others will be dropped

**Related issue(s)**
https://github.com/kyma-incubator/reconciler/issues/884
https://github.com/kyma-incubator/reconciler/issues/867
