### PR TITLE
Fix aws lite regions

### DIFF
--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -205,16 +205,16 @@ func (p *AWSInput) Provider() internal.CloudProvider {
 }
 
 func (p *AWSTrialInput) Defaults() *gqlschema.ClusterConfigInput {
-	return awsLiteDefaults()
+	return awsLiteDefaults(DefaultAWSTrialRegion)
 }
 
-func awsLiteDefaults() *gqlschema.ClusterConfigInput {
+func awsLiteDefaults(region string) *gqlschema.ClusterConfigInput {
 	return &gqlschema.ClusterConfigInput{
 		GardenerConfig: &gqlschema.GardenerConfigInput{
 			DiskType:       ptr.String("gp2"),
 			VolumeSizeGb:   ptr.Integer(50),
 			MachineType:    "m5.xlarge",
-			Region:         DefaultAWSTrialRegion,
+			Region:         region,
 			Provider:       "aws",
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  1,
@@ -227,7 +227,7 @@ func awsLiteDefaults() *gqlschema.ClusterConfigInput {
 					VpcCidr: "10.250.0.0/16",
 					AwsZones: []*gqlschema.AWSZoneInput{
 						{
-							Name:         ZoneForAWSRegion(DefaultAWSTrialRegion),
+							Name:         ZoneForAWSRegion(region),
 							PublicCidr:   "10.250.32.0/20",
 							InternalCidr: "10.250.48.0/20",
 							WorkerCidr:   "10.250.0.0/19",
@@ -271,10 +271,9 @@ func (p *AWSTrialInput) Provider() internal.CloudProvider {
 }
 
 func (p *AWSFreemiumInput) Defaults() *gqlschema.ClusterConfigInput {
-	defaults := awsLiteDefaults()
-
 	// Lite (freemium) must have the same defaults as Trial plan, but there was a requirement to change a region only for Trial.
-	defaults.GardenerConfig.Region = DefaultAWSRegion
+	defaults := awsLiteDefaults(DefaultAWSRegion)
+
 	return defaults
 }
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1478"
     kyma_environment_broker:
       dir:
-      version: "PR-1491"
+      version: "PR-1513"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1380"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- the aws lite (freemium) plan was overriding default lite region to different one, but not updating zones which makes a problem with aws freemium provisioning

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
