### PR TITLE
Add remove service instance step to deprovisioning queue

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -164,7 +164,7 @@ func NewBrokerSuiteTest(t *testing.T) *BrokerSuiteTest {
 	deprovisionManager := deprovisioning.NewManager(db.Operations(), eventBroker, logs.WithField("deprovisioning", "manager"))
 	deprovisioningQueue := NewDeprovisioningProcessingQueue(ctx, workersAmount, deprovisionManager, cfg, db, eventBroker,
 		provisionerClient, avsDel, internalEvalAssistant, externalEvalAssistant, smcf,
-		bundleBuilder, edpClient, accountProvider, reconcilerClient, logs,
+		bundleBuilder, edpClient, accountProvider, reconcilerClient, fakeK8sClientProvider(fakeK8sSKRClient), logs,
 	)
 
 	deprovisioningQueue.SpeedUp(10000)

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -862,6 +862,10 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 		},
 		{
 			weight: 1,
+			step:   deprovisioning.NewRemoveServiceInstanceStep(db.Operations()),
+		},
+		{
+			weight: 1,
 			step:   deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant),
 		},
 		{

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -346,7 +346,8 @@ func main() {
 
 	deprovisionManager := deprovisioning.NewManager(db.Operations(), eventBroker, logs.WithField("deprovisioning", "manager"))
 	deprovisionQueue := NewDeprovisioningProcessingQueue(ctx, workersAmount, deprovisionManager, &cfg, db, eventBroker, provisionerClient,
-		avsDel, internalEvalAssistant, externalEvalAssistant, serviceManagerClientFactory, bundleBuilder, edpClient, accountProvider, reconcilerClient, logs)
+		avsDel, internalEvalAssistant, externalEvalAssistant, serviceManagerClientFactory, bundleBuilder, edpClient, accountProvider, reconcilerClient,
+		k8sClientProvider, logs)
 
 	updateManager := update.NewManager(db.Operations(), eventBroker, cfg.OperationTimeout, logs)
 	updateQueue := NewUpdateProcessingQueue(ctx, updateManager, 3, db, inputFactory, provisionerClient, eventBroker, runtimeVerConfigurator, db.RuntimeStates(),
@@ -845,7 +846,7 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 	provisionerClient provisioner.Client, avsDel *avs.Delegator, internalEvalAssistant *avs.InternalEvalAssistant,
 	externalEvalAssistant *avs.ExternalEvalAssistant, smcf deprovisioning.SMClientFactory, bundleBuilder ias.BundleBuilder,
 	edpClient deprovisioning.EDPClient, accountProvider hyperscaler.AccountProvider, reconcilerClient reconciler.Client,
-	logs logrus.FieldLogger) *process.Queue {
+	k8sClientProvider func(kcfg string) (client.Client, error), logs logrus.FieldLogger) *process.Queue {
 
 	deprovisioningInit := deprovisioning.NewInitialisationStep(db.Operations(), db.Instances(), provisionerClient, accountProvider, smcf, cfg.OperationTimeout)
 	deprovisionManager.InitStep(deprovisioningInit)
@@ -855,6 +856,10 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 		weight   int
 		step     deprovisioning.Step
 	}{
+		{
+			weight: 1,
+			step:   deprovisioning.NewGetKubeconfigStep(db.Operations(), provisionerClient, k8sClientProvider),
+		},
 		{
 			weight: 1,
 			step:   deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant),

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -350,9 +350,11 @@ type DeprovisioningOperation struct {
 	SMClientFactory SMClientFactory `json:"-"`
 
 	// Temporary indicates that this deprovisioning operation must not remove the instance
-	Temporary                   bool      `json:"temporary"`
-	ClusterConfigurationDeleted bool      `json:"clusterConfigurationDeleted"`
-	ReconcilerDeregistrationAt  time.Time `json:"reconcilerDeregistrationAt"`
+	Temporary                   bool          `json:"temporary"`
+	ClusterConfigurationDeleted bool          `json:"clusterConfigurationDeleted"`
+	IsServiceInstanceDeleted    bool          `json:"isServiceInstanceDeleted"`
+	ReconcilerDeregistrationAt  time.Time     `json:"reconcilerDeregistrationAt"`
+	K8sClient                   client.Client `json:"-"`
 }
 
 func (op *DeprovisioningOperation) TimeSinceReconcilerDeregistrationTriggered() time.Duration {

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -353,6 +353,7 @@ type DeprovisioningOperation struct {
 	Temporary                   bool          `json:"temporary"`
 	ClusterConfigurationDeleted bool          `json:"clusterConfigurationDeleted"`
 	IsServiceInstanceDeleted    bool          `json:"isServiceInstanceDeleted"`
+	Retries                     int           `json:"-"`
 	ReconcilerDeregistrationAt  time.Time     `json:"reconcilerDeregistrationAt"`
 	K8sClient                   client.Client `json:"-"`
 }

--- a/components/kyma-environment-broker/internal/process/deprovisioning/get_kubeconfig_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/get_kubeconfig_step.go
@@ -46,8 +46,9 @@ func (s *GetKubeconfigStep) Run(operation internal.DeprovisioningOperation, log 
 	}
 
 	if operation.RuntimeID == "" {
-		log.Errorf("Runtime ID is empty")
-		return s.operationManager.OperationFailed(operation, "Runtime ID is empty", nil, log)
+		log.Infof("RuntimeID is empty, skipping step")
+		operation.IsServiceInstanceDeleted = true
+		return operation, 0, nil
 	}
 
 	status, err := s.provisionerClient.RuntimeStatus(operation.ProvisioningParameters.ErsContext.GlobalAccountID, operation.RuntimeID)

--- a/components/kyma-environment-broker/internal/process/deprovisioning/get_kubeconfig_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/get_kubeconfig_step.go
@@ -1,0 +1,74 @@
+package deprovisioning
+
+import (
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provisioner"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type GetKubeconfigStep struct {
+	provisionerClient   provisioner.Client
+	operationManager    *process.DeprovisionOperationManager
+	provisioningTimeout time.Duration
+	k8sClientProvider   func(kcfg string) (client.Client, error)
+}
+
+func NewGetKubeconfigStep(os storage.Operations, provisionerClient provisioner.Client, k8sClientProvider func(kcfg string) (client.Client, error)) *GetKubeconfigStep {
+	return &GetKubeconfigStep{
+		provisionerClient: provisionerClient,
+		operationManager:  process.NewDeprovisionOperationManager(os),
+		k8sClientProvider: k8sClientProvider,
+	}
+}
+
+func (s *GetKubeconfigStep) Name() string {
+	return "Get_Kubeconfig"
+}
+
+func (s *GetKubeconfigStep) Run(operation internal.DeprovisioningOperation, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
+	if operation.IsServiceInstanceDeleted {
+		return operation, 0, nil
+	}
+
+	if operation.Kubeconfig != "" {
+		cli, err := s.k8sClientProvider(operation.Kubeconfig)
+		if err != nil {
+			log.Errorf("Unable to create k8s client from the kubeconfig")
+			return s.operationManager.OperationFailed(operation, "could not create a k8s client", err, log)
+		}
+		operation.K8sClient = cli
+		return operation, 0, nil
+	}
+
+	if operation.RuntimeID == "" {
+		log.Errorf("Runtime ID is empty")
+		return s.operationManager.OperationFailed(operation, "Runtime ID is empty", nil, log)
+	}
+
+	status, err := s.provisionerClient.RuntimeStatus(operation.ProvisioningParameters.ErsContext.GlobalAccountID, operation.RuntimeID)
+	if err != nil {
+		log.Errorf("call to provisioner RuntimeStatus failed: %s", err.Error())
+		return operation, 1 * time.Minute, nil
+	}
+
+	if status.RuntimeConfiguration.Kubeconfig == nil {
+		log.Errorf("kubeconfig is not provided")
+		return operation, 1 * time.Minute, nil
+	}
+
+	cli, err := s.k8sClientProvider(*status.RuntimeConfiguration.Kubeconfig)
+	if err != nil {
+		log.Errorf("Unable to create k8s client from the kubeconfig")
+		return s.operationManager.OperationFailed(operation, "could not create a k8s client", err, log)
+	}
+
+	operation.Kubeconfig = *status.RuntimeConfiguration.Kubeconfig
+	operation.K8sClient = cli
+
+	return operation, 0, nil
+}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -9,8 +9,8 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/sirupsen/logrus"
-	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -56,7 +56,6 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 		return s.operationManager.OperationFailed(operation, "could not get service instance to be deleted", nil, log)
 	}
 
-	// todo error handling, cases: cannot delete, slow delete, SM outage
 	err = s.deleteServiceInstance(operation.K8sClient, si)
 
 	switch err.(type) {
@@ -75,8 +74,8 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 	return s.operationManager.OperationFailed(operation, "could not delete service instance", nil, log)
 }
 
-func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) (*apiextensions.CustomResourceDefinition, error) {
-	si := &apiextensions.CustomResourceDefinition{}
+func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) (*unstructured.Unstructured, error) {
+	si := &unstructured.Unstructured{}
 
 	err := k8sClient.Get(context.Background(), client.ObjectKey{
 		Namespace: serviceInstanceNamespace,
@@ -101,7 +100,7 @@ func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) 
 	return nil, err
 }
 
-func (s *RemoveServiceInstanceStep) deleteServiceInstance(k8sClient client.Client, si *apiextensions.CustomResourceDefinition) error {
+func (s *RemoveServiceInstanceStep) deleteServiceInstance(k8sClient client.Client, si *unstructured.Unstructured) error {
 	err := k8sClient.Delete(context.Background(), si)
 	return err
 }

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors2 "k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,7 +93,7 @@ func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) 
 	}, si)
 	if err == nil {
 		return si, nil
-	} else if client.IgnoreNotFound(err) != nil {
+	} else if client.IgnoreNotFound(err) != nil && !k8serrors2.IsNoMatchError(err) {
 		return nil, err
 	}
 
@@ -108,7 +109,7 @@ func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) 
 	}, si)
 	if err == nil {
 		return si, nil
-	} else if client.IgnoreNotFound(err) != nil {
+	} else if client.IgnoreNotFound(err) != nil && !k8serrors2.IsNoMatchError(err) {
 		return nil, err
 	}
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -67,6 +67,7 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 		log.Warnf("could not delete %s service instance, status: %s", serviceInstanceName, err)
 		return s.retryOrFail(&operation, &log)
 	case nil:
+		operation.IsServiceInstanceDeleted = true
 		return operation, 0, nil
 	}
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -1,0 +1,4 @@
+package deprovisioning
+
+type RemoveInstanceStep struct {
+}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -2,7 +2,6 @@ package deprovisioning
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -11,6 +10,7 @@ import (
 	"github.com/sirupsen/logrus"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -76,10 +76,15 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 
 func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) (*unstructured.Unstructured, error) {
 	si := &unstructured.Unstructured{}
+	si.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "services.cloud.sap.com",
+		Version: "v1",
+		Kind:    "ServiceInstance",
+	})
 
 	err := k8sClient.Get(context.Background(), client.ObjectKey{
 		Namespace: serviceInstanceNamespace,
-		Name:      fmt.Sprintf("%s.%s", serviceInstanceName, svcatObjectKey),
+		Name:      serviceInstanceName,
 	}, si)
 	if err == nil {
 		return si, nil
@@ -89,7 +94,7 @@ func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) 
 
 	err = k8sClient.Get(context.Background(), client.ObjectKey{
 		Namespace: serviceInstanceNamespace,
-		Name:      fmt.Sprintf("%s.%s", serviceInstanceName, btpOperatorObjectKey),
+		Name:      serviceInstanceName,
 	}, si)
 	if err == nil {
 		return si, nil

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -1,4 +1,115 @@
 package deprovisioning
 
-type RemoveInstanceStep struct {
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/sirupsen/logrus"
+	apiextensions "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	serviceInstanceName      = "uaa-issuer"
+	serviceInstanceNamespace = "kyma-system"
+	svcatObjectKey           = "serviceinstances.servicecatalog.k8s.io"
+	btpOperatorObjectKey     = "serviceinstances.services.cloud.sap.com"
+	allowedRetries           = 5
+)
+
+type RemoveServiceInstanceStep struct {
+	operationManager *process.DeprovisionOperationManager
+}
+
+func NewRemoveServiceInstanceStep(os storage.Operations) *RemoveServiceInstanceStep {
+	return &RemoveServiceInstanceStep{
+		operationManager: process.NewDeprovisionOperationManager(os),
+	}
+}
+
+func (s *RemoveServiceInstanceStep) Name() string {
+	return "Remove_ServiceInstance"
+}
+
+func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperation, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
+	if operation.IsServiceInstanceDeleted {
+		return operation, 0, nil
+	}
+
+	if operation.K8sClient == nil {
+		log.Errorf("k8s client must be provided")
+		return s.operationManager.OperationFailed(operation, "k8s client must be provided", nil, log)
+	}
+
+	si, err := s.getServiceInstance(operation.K8sClient)
+	if err != nil {
+		if k8serrors.IsNotFound(err) {
+			operation.IsServiceInstanceDeleted = true
+			return operation, 0, nil
+		}
+		log.Errorf("while getting %s service instance from the cluster", serviceInstanceName)
+		return s.operationManager.OperationFailed(operation, "could not get service instance to be deleted", nil, log)
+	}
+
+	// todo error handling, cases: cannot delete, slow delete, SM outage
+	err = s.deleteServiceInstance(operation.K8sClient, si)
+
+	switch err.(type) {
+	case *k8serrors.UnexpectedObjectError:
+		log.Errorf("could not delete %s service instance, unknown status: %s", serviceInstanceName, err)
+		return s.operationManager.OperationFailed(operation, "could not delete service instance", nil, log)
+	case *k8serrors.StatusError:
+		operation.Retries++
+		log.Warnf("could not delete %s service instance, status: %s", serviceInstanceName, err)
+		s.retryOrFail(&operation, &log)
+	case nil:
+		return operation, 0, nil
+	}
+
+	log.Errorf("could not delete %s service instance, %s", serviceInstanceName, err)
+	return s.operationManager.OperationFailed(operation, "could not delete service instance", nil, log)
+}
+
+func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) (*apiextensions.CustomResourceDefinition, error) {
+	si := &apiextensions.CustomResourceDefinition{}
+
+	err := k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: serviceInstanceNamespace,
+		Name:      fmt.Sprintf("%s.%s", serviceInstanceName, svcatObjectKey),
+	}, si)
+	if err == nil {
+		return si, nil
+	} else if client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
+	err = k8sClient.Get(context.Background(), client.ObjectKey{
+		Namespace: serviceInstanceNamespace,
+		Name:      fmt.Sprintf("%s.%s", serviceInstanceName, btpOperatorObjectKey),
+	}, si)
+	if err == nil {
+		return si, nil
+	} else if client.IgnoreNotFound(err) != nil {
+		return nil, err
+	}
+
+	return nil, err
+}
+
+func (s *RemoveServiceInstanceStep) deleteServiceInstance(k8sClient client.Client, si *apiextensions.CustomResourceDefinition) error {
+	err := k8sClient.Delete(context.Background(), si)
+	return err
+}
+
+func (s *RemoveServiceInstanceStep) retryOrFail(operation *internal.DeprovisioningOperation, log *logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
+	if operation.Retries > allowedRetries {
+		(*log).Errorf("could not delete %s service instance, timeout reached", serviceInstanceName)
+		return s.operationManager.OperationFailed(*operation, "could not delete service instance", nil, *log)
+	}
+	return *operation, time.Second * 20, nil
 }

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -77,8 +77,8 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) (*unstructured.Unstructured, error) {
 	si := &unstructured.Unstructured{}
 	si.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "services.cloud.sap.com",
-		Version: "v1",
+		Group:   "servicecatalog.k8s.io",
+		Version: "v1beta1",
 		Kind:    "ServiceInstance",
 	})
 
@@ -91,6 +91,12 @@ func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) 
 	} else if client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
+
+	si.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   "services.cloud.sap.com",
+		Version: "v1",
+		Kind:    "ServiceInstance",
+	})
 
 	err = k8sClient.Get(context.Background(), client.ObjectKey{
 		Namespace: serviceInstanceNamespace,

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -17,8 +17,11 @@ import (
 const (
 	serviceInstanceName      = "uaa-issuer"
 	serviceInstanceNamespace = "kyma-system"
-	svcatObjectKey           = "serviceinstances.servicecatalog.k8s.io"
-	btpOperatorObjectKey     = "serviceinstances.services.cloud.sap.com"
+	k8sResourceType          = "ServiceInstance"
+	svcatGroup               = "servicecatalog.k8s.io"
+	svcatApiVer              = "v1beta1"
+	btpOperatorGroup         = "services.cloud.sap.com"
+	btpOperatorApiVer        = "v1"
 	allowedRetries           = 5
 )
 
@@ -78,9 +81,9 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) (*unstructured.Unstructured, error) {
 	si := &unstructured.Unstructured{}
 	si.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "servicecatalog.k8s.io",
-		Version: "v1beta1",
-		Kind:    "ServiceInstance",
+		Group:   svcatGroup,
+		Version: svcatApiVer,
+		Kind:    k8sResourceType,
 	})
 
 	err := k8sClient.Get(context.Background(), client.ObjectKey{
@@ -94,9 +97,9 @@ func (s *RemoveServiceInstanceStep) getServiceInstance(k8sClient client.Client) 
 	}
 
 	si.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "services.cloud.sap.com",
-		Version: "v1",
-		Kind:    "ServiceInstance",
+		Group:   btpOperatorGroup,
+		Version: btpOperatorApiVer,
+		Kind:    k8sResourceType,
 	})
 
 	err = k8sClient.Get(context.Background(), client.ObjectKey{

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance.go
@@ -66,7 +66,7 @@ func (s *RemoveServiceInstanceStep) Run(operation internal.DeprovisioningOperati
 	case *k8serrors.StatusError:
 		operation.Retries++
 		log.Warnf("could not delete %s service instance, status: %s", serviceInstanceName, err)
-		s.retryOrFail(&operation, &log)
+		return s.retryOrFail(&operation, &log)
 	case nil:
 		return operation, 0, nil
 	}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
@@ -225,7 +225,7 @@ func (f *fakeK8sClient) Get(ctx context.Context, key client.ObjectKey, obj clien
 }
 
 func (f *fakeK8sClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-	return nil
+	return fmt.Errorf("not implemented in fakeK8sClient")
 }
 
 func (f *fakeK8sClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
@@ -240,25 +240,25 @@ func (f *fakeK8sClient) Delete(ctx context.Context, obj client.Object, opts ...c
 }
 
 func (f *fakeK8sClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	return nil
+	return fmt.Errorf("not implemented in fakeK8sClient")
 }
 
 func (f *fakeK8sClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	return nil
+	return fmt.Errorf("not implemented in fakeK8sClient")
 }
 
 func (f *fakeK8sClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
-	return nil
+	return fmt.Errorf("not implemented in fakeK8sClient")
 }
 
 func (f *fakeK8sClient) Status() client.StatusWriter {
-	return nil
+	panic("not implemented in fakeK8sClient")
 }
 
 func (f *fakeK8sClient) Scheme() *runtime.Scheme {
-	return nil
+	panic("not implemented in fakeK8sClient")
 }
 
 func (f *fakeK8sClient) RESTMapper() meta.RESTMapper {
-	return nil
+	panic("not implemented in fakeK8sClient")
 }

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
@@ -1,1 +1,53 @@
 package deprovisioning
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/fixture"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var si = []byte(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceinstances.services.cloud.sap.com
+spec:
+  group: services.cloud.sap.com
+  names:
+    kind: ServiceInstance
+    listKind: ServiceInstanceList
+    plural: serviceinstances
+    singular: serviceinstance
+  scope: Namespaced
+`)
+
+func TestRemoveServiceInstanceStep(t *testing.T) {
+	t.Run("should remove uaa-issuer service instance (service catalog)", func(t *testing.T) {
+		//given
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+
+		scheme := runtime.NewScheme()
+		err := apiextensionsv1.AddToScheme(scheme)
+		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+		obj, gvk, err := decoder.Decode(si, nil, nil)
+		fmt.Println(gvk)
+		require.NoError(t, err)
+
+		k8sCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj).Build()
+
+		op := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
+		op.State = "in progress"
+		op.K8sClient = k8sCli
+
+		step := NewRemoveServiceInstanceStep(ms)
+	})
+}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
@@ -2,8 +2,10 @@ package deprovisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
@@ -11,7 +13,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -89,7 +92,7 @@ func TestRemoveServiceInstanceStep(t *testing.T) {
 
 		// then
 		assert.Error(t, err)
-		assert.True(t, apierrors.IsNotFound(err))
+		assert.True(t, k8serrors.IsNotFound(err))
 	})
 
 	t.Run("should remove uaa-issuer service instance (btp operator)", func(t *testing.T) {
@@ -145,6 +148,117 @@ func TestRemoveServiceInstanceStep(t *testing.T) {
 
 		// then
 		assert.Error(t, err)
-		assert.True(t, apierrors.IsNotFound(err))
+		assert.True(t, k8serrors.IsNotFound(err))
 	})
+
+	t.Run("should not find uaa-issuer service instance and set flag to true", func(t *testing.T) {
+		// given
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+
+		scheme := runtime.NewScheme()
+		err := apiextensionsv1.AddToScheme(scheme)
+		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
+		fmt.Println(gvk)
+		require.NoError(t, err)
+
+		k8sCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj).Build()
+		require.NoError(t, err)
+
+		op := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
+		op.State = "in progress"
+		op.K8sClient = k8sCli
+
+		step := NewRemoveServiceInstanceStep(ms.Operations())
+
+		// when
+		entry := log.WithFields(logrus.Fields{"step": "TEST"})
+		op, _, err = step.Run(op, entry)
+
+		// then
+		assert.NoError(t, err)
+		assert.True(t, op.IsServiceInstanceDeleted)
+	})
+
+	t.Run("should return step repeat time with 20 sec", func(t *testing.T) {
+		// given
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+		si := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "services.cloud.sap.com/v1",
+			"kind":       "ServiceInstance",
+			"metadata": map[string]interface{}{
+				"name":      "uaa-issuer",
+				"namespace": "kyma-system",
+			},
+		}}
+
+		k8sCli := fakeK8sClient{}
+		err := k8sCli.Create(context.TODO(), si)
+		require.NoError(t, err)
+
+		op := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
+		op.State = "in progress"
+		op.K8sClient = &k8sCli
+
+		step := NewRemoveServiceInstanceStep(ms.Operations())
+
+		// when
+		entry := log.WithFields(logrus.Fields{"step": "TEST"})
+		op, repeat, err := step.Run(op, entry)
+
+		// then
+		assert.NoError(t, err)
+		assert.Equal(t, time.Second*20, repeat)
+		assert.False(t, op.IsServiceInstanceDeleted)
+	})
+}
+
+type fakeK8sClient struct {
+	obj *unstructured.Unstructured
+}
+
+func (f *fakeK8sClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	obj = f.obj
+	return nil
+}
+
+func (f *fakeK8sClient) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	return nil
+}
+
+func (f *fakeK8sClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	f.obj = new(unstructured.Unstructured)
+	f.obj.SetName(obj.GetName())
+	f.obj.SetNamespace(obj.GetNamespace())
+	return nil
+}
+
+func (f *fakeK8sClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return k8serrors.NewInternalError(errors.New("test error"))
+}
+
+func (f *fakeK8sClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return nil
+}
+
+func (f *fakeK8sClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return nil
+}
+
+func (f *fakeK8sClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return nil
+}
+
+func (f *fakeK8sClient) Status() client.StatusWriter {
+	return nil
+}
+
+func (f *fakeK8sClient) Scheme() *runtime.Scheme {
+	return nil
+}
+
+func (f *fakeK8sClient) RESTMapper() meta.RESTMapper {
+	return nil
 }

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
@@ -1,0 +1,1 @@
+package deprovisioning

--- a/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/remove_service_instance_test.go
@@ -11,9 +11,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
@@ -33,6 +36,62 @@ spec:
 `)
 
 func TestRemoveServiceInstanceStep(t *testing.T) {
+	t.Run("should remove uaa-issuer service instance (service catalog)", func(t *testing.T) {
+		// given
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+		si := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "servicecatalog.k8s.io/v1beta1",
+			"kind":       "ServiceInstance",
+			"metadata": map[string]interface{}{
+				"name":      "uaa-issuer",
+				"namespace": "kyma-system",
+			},
+		}}
+
+		scheme := runtime.NewScheme()
+		err := apiextensionsv1.AddToScheme(scheme)
+		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
+		fmt.Println(gvk)
+		require.NoError(t, err)
+
+		k8sCli := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj).Build()
+		err = k8sCli.Create(context.TODO(), si)
+		require.NoError(t, err)
+
+		op := fixture.FixDeprovisioningOperation(fixOperationID, fixInstanceID)
+		op.State = "in progress"
+		op.K8sClient = k8sCli
+
+		step := NewRemoveServiceInstanceStep(ms.Operations())
+
+		// when
+		entry := log.WithFields(logrus.Fields{"step": "TEST"})
+		_, _, err = step.Run(op, entry)
+
+		// then
+		assert.NoError(t, err)
+
+		// given
+		emptySI := &unstructured.Unstructured{}
+		emptySI.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "servicecatalog.k8s.io",
+			Version: "v1beta1",
+			Kind:    "ServiceInstance",
+		})
+
+		// when
+		err = k8sCli.Get(context.TODO(), client.ObjectKey{
+			Namespace: serviceInstanceNamespace,
+			Name:      serviceInstanceName,
+		}, emptySI)
+
+		// then
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
+	})
+
 	t.Run("should remove uaa-issuer service instance (btp operator)", func(t *testing.T) {
 		// given
 		log := logrus.New()
@@ -69,5 +128,23 @@ func TestRemoveServiceInstanceStep(t *testing.T) {
 
 		// then
 		assert.NoError(t, err)
+
+		// given
+		emptySI := &unstructured.Unstructured{}
+		emptySI.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "services.cloud.sap.com",
+			Version: "v1",
+			Kind:    "ServiceInstance",
+		})
+
+		// when
+		err = k8sCli.Get(context.TODO(), client.ObjectKey{
+			Namespace: serviceInstanceNamespace,
+			Name:      serviceInstanceName,
+		}, emptySI)
+
+		// then
+		assert.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err))
 	})
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1523"
     kyma_environment_broker:
       dir:
-      version: "77058a46"
+      version: "PR-1521"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1380"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add step for getting kubeconfig for deprovisioned cluster in deprovisioning queue
- add step for removing uaa-issuer service instance in deprovisioning queue


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
