### PR TITLE
fix: Mothership Reconciler Values: increase connMaxIdleTime to not immediately close the connection

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -27,7 +27,7 @@ db:
   maxOpenConns: 50 # if n <= 0, then there is no limit on the number of open connections. The default is 0 (unlimited).
   maxIdleConns: 20 # If n <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.
   connMaxLifetime: 10m # If d <= 0, connections are not closed due to a connection's age.
-  connMaxIdleTime: 0s # If d <= 0, connections are not closed due to a connection's idle time.
+  connMaxIdleTime: 10m # If d <= 0, connections are not closed due to a connection's idle time.
 
 preComponents:
   - [cluster-essentials, istio-configuration, istio, certificates]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Introduces 10m Idle Time to not immediately close connections for the mothership DB Pool

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
