### PR TITLE
Remove ClusterID override from BTP-Operator upgrade queue

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -1242,5 +1242,4 @@ func mockBTPOperatorClusterID() {
 		}
 	}
 	update.ConfigMapGetter = mock
-	upgrade_kyma.ConfigMapGetter = mock
 }

--- a/components/kyma-environment-broker/internal/component_input_helpers.go
+++ b/components/kyma-environment-broker/internal/component_input_helpers.go
@@ -94,18 +94,6 @@ func CreateBTPOperatorProvisionInput(r ProvisionerInputCreator, creds *ServiceMa
 	r.AppendOverrides(BTPOperatorComponentName, overrides)
 }
 
-func CreateBTPOperatorUpdateInput(r ProvisionerInputCreator, creds *ServiceManagerOperatorCredentials, clusterIdGetter ClusterIDGetter) error {
-	id, err := clusterIdGetter()
-	if err != nil {
-		return err
-	}
-	provisioning := getBTPOperatorProvisioningOverrides(creds)
-	update := getBTPOperatorUpdateOverrides(creds, id)
-	r.AppendOverrides(BTPOperatorComponentName, provisioning)
-	r.AppendOverrides(BTPOperatorComponentName, update)
-	return nil
-}
-
 func GetClusterIDWithKubeconfig(kubeconfig string) ClusterIDGetter {
 	return func() (string, error) {
 		cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/btp_operator_overrides.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/btp_operator_overrides.go
@@ -8,8 +8,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var ConfigMapGetter func(string) internal.ClusterIDGetter = internal.GetClusterIDWithKubeconfig
-
 type BTPOperatorOverridesStep struct{}
 
 func NewBTPOperatorOverridesStep() *BTPOperatorOverridesStep {
@@ -21,12 +19,7 @@ func (s *BTPOperatorOverridesStep) Name() string {
 }
 
 func (s *BTPOperatorOverridesStep) Run(operation internal.UpgradeKymaOperation, log logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
-	if operation.InstanceDetails.SCMigrationTriggered {
-		cm := ConfigMapGetter(operation.InstanceDetails.Kubeconfig)
-		internal.CreateBTPOperatorUpdateInput(operation.InputCreator, operation.ProvisioningParameters.ErsContext.SMOperatorCredentials, cm)
-	} else {
-		internal.CreateBTPOperatorProvisionInput(operation.InputCreator, operation.ProvisioningParameters.ErsContext.SMOperatorCredentials)
-	}
+	internal.CreateBTPOperatorProvisionInput(operation.InputCreator, operation.ProvisioningParameters.ErsContext.SMOperatorCredentials)
 	operation.InputCreator.EnableOptionalComponent(internal.BTPOperatorComponentName)
 	operation.InputCreator.DisableOptionalComponent(internal.ServiceManagerComponentName)
 	operation.InputCreator.DisableOptionalComponent(internal.HelmBrokerComponentName)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1589"
     kyma_environment_broker:
       dir:
-      version: "PR-1574"
+      version: "PR-1599"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1527"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The ClusterID is not used by the BTP-Operator itself, only by the migration tool. For the update operation, KEB still populates this information but in the upgrade queue, it's no longer necessary.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
closes: https://github.com/kyma-project/control-plane/issues/1597