### PR TITLE
Remove gardener for subscriptioncleanup job

### DIFF
--- a/components/kyma-environment-broker/common/gardener/client.go
+++ b/components/kyma-environment-broker/common/gardener/client.go
@@ -8,8 +8,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-
-	gardener_apis "github.com/gardener/gardener/pkg/client/core/clientset/versioned/typed/core/v1beta1"
 )
 
 type SecretBinding struct {
@@ -85,36 +83,4 @@ func NewGardenerClusterConfig(kubeconfigPath string) (*restclient.Config, error)
 
 func RESTConfig(kubeconfig []byte) (*restclient.Config, error) {
 	return clientcmd.RESTConfigFromKubeConfig(kubeconfig)
-}
-
-// NOTE: for subscription cleanup job backwards compatibility
-
-func gardenerNamespace(projectName string) string {
-	return fmt.Sprintf("garden-%s", projectName)
-}
-
-func NewClient(config *restclient.Config) (*gardener_apis.CoreV1beta1Client, error) {
-	clientset, err := gardener_apis.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-
-	return clientset, nil
-}
-
-func NewGardenerSecretBindingsInterface(gardenerClient *gardener_apis.CoreV1beta1Client, gardenerProjectName string) gardener_apis.SecretBindingInterface {
-	gardenerNamespace := gardenerNamespace(gardenerProjectName)
-	return gardenerClient.SecretBindings(gardenerNamespace)
-}
-
-func NewGardenerShootInterface(gardenerClusterCfg *restclient.Config, gardenerProjectName string) (gardener_apis.ShootInterface, error) {
-
-	gardenerNamespace := gardenerNamespace(gardenerProjectName)
-
-	gardenerClusterClient, err := gardener_apis.NewForConfig(gardenerClusterCfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return gardenerClusterClient.Shoots(gardenerNamespace), nil
 }

--- a/components/kyma-environment-broker/common/gardener/client.go
+++ b/components/kyma-environment-broker/common/gardener/client.go
@@ -23,6 +23,15 @@ func (b SecretBinding) GetSecretRefName() string {
 	return str
 }
 
+func (b SecretBinding) GetSecretRefNamespace() string {
+	str, _, err := unstructured.NestedString(b.Unstructured.Object, "secretRef", "namespace")
+	if err != nil {
+		// NOTE this is a safety net, gardener v1beta1 API would need to break the contract for this to panic
+		panic(fmt.Sprintf("SecretBinding missing field '.secretRef.namespace': %v", err))
+	}
+	return str
+}
+
 type Shoot struct {
 	unstructured.Unstructured
 }

--- a/components/kyma-environment-broker/go.mod
+++ b/components/kyma-environment-broker/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/Peripli/service-manager v0.23.4
 	github.com/Peripli/service-manager-cli v1.11.14
 	github.com/dlmiddlecote/sqlstats v1.0.2
-	github.com/gardener/gardener v1.45.0
 	github.com/gocraft/dbr v0.0.0-20190714181702-8114670a83bd
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/uuid v1.3.0
@@ -78,6 +77,7 @@ require (
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/gardener/gardener v1.44.4 // indirect
 	github.com/go-logr/logr v1.2.3 // indirect
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect

--- a/components/kyma-environment-broker/go.sum
+++ b/components/kyma-environment-broker/go.sum
@@ -443,8 +443,8 @@ github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWp
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fvbommel/sortorder v1.0.1/go.mod h1:uk88iVf1ovNn1iLfgUVU2F9o5eO30ui720w+kxuqRs0=
-github.com/gardener/gardener v1.45.0 h1:7KGKm5q7mrmqnsY3w5Jsw3zCbt1CPFMXrQkfgkT+d2g=
-github.com/gardener/gardener v1.45.0/go.mod h1:BsQ9s0Ms5rU1IAS1doVceBGj4kNBhSMQKaDB4a2ba4k=
+github.com/gardener/gardener v1.44.4 h1:YLGcyHipGy00TMjQ/GuuQxubczo849orJzseBq7O4Is=
+github.com/gardener/gardener v1.44.4/go.mod h1:y8f1w9u44YuDAowo3PWmR79LhUv4TeTTb/1dhAFbKzc=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
 github.com/gavv/httpexpect v0.0.0-20170820080527-c44a6d7bb636 h1:FbWwmG7qBNykpmPppq5767far39ty4P7lOhpPNK8Ik4=
 github.com/gavv/httpexpect v0.0.0-20170820080527-c44a6d7bb636/go.mod h1:x+9tiU1YnrOvnB725RkpoLv1M62hOWzwo5OXotisrKc=
@@ -929,7 +929,6 @@ github.com/onsi/ginkgo v1.14.2/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
-github.com/onsi/ginkgo/v2 v2.1.3 h1:e/3Cwtogj0HA+25nMP1jCMDIf8RtRYbGwGGuBIFztkc=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,16 +14,16 @@ global:
       version: "PR-1589"
     kyma_environment_broker:
       dir:
-      version: "PR-1610"
+      version: "PR-1600"
     kyma_environments_cleanup_job:
       dir:
-      version: "PR-1527"
+      version: "PR-1600"
     kyma_environments_subaccount_cleanup_job:
       dir:
-      version: "PR-1527"
+      version: "PR-1600"
     kyma_environments_subscription_cleanup_job:
       dir:
-      version: "PR-1474"
+      version: "PR-1600"
     kyma_metrics_collector:
       dir:
       version: "PR-1608"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

followup to https://github.com/kyma-project/control-plane/pull/1527, where KEB is stripping its dependency on gardener. Gardener is a rich source of CVEs There is only a very small subset of gardener API that KEB needs and it doesn't depend on the implementation at all.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/control-plane/issues/1471