### PR TITLE
Bump Mothership Fluent-Bit Plugin to 1.8.15-a6fa9cb0 / Fix Connection Defaults

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -27,7 +27,7 @@ db:
   maxOpenConns: 50 # if n <= 0, then there is no limit on the number of open connections. The default is 0 (unlimited).
   maxIdleConns: 20 # If n <= 0, no idle connections are retained. The default max idle connections is currently 2. This may change in a future release.
   connMaxLifetime: 10m # If d <= 0, connections are not closed due to a connection's age.
-  connMaxIdleTime: 0s # If d <= 0, connections are not closed due to a connection's idle time.
+  connMaxIdleTime: 10m # If d <= 0, connections are not closed due to a connection's idle time.
 
 preComponents:
   - [cluster-essentials, istio-configuration, istio, certificates]

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -161,7 +161,7 @@ global:
       # this will create the predefined configMap and secret with data for test purposes only. Should never be enabled on Production.
       useTestConfig: false
       image: eu.gcr.io/kyma-project/tpi/fluent-bit
-      tag: 1.8.9-aef5095d
+      tag: 1.8.15-a6fa9cb0
       persistence:
         enabled: true
         accessMode: ReadWriteOnce


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bumps Fluent-Bit Image in addition to regular image bump of reconciler to 1.8.15-a6fa9cb0
- Increases Connection Defaults in Control Plane for ConnMaxIdleTime in sync with https://github.com/kyma-incubator/reconciler/pull/1021

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-incubator/reconciler/pull/1049
https://github.com/kyma-incubator/reconciler/issues/959
https://github.com/kyma-project/control-plane/commit/1af9a289ec83cde0e40b548ed9e9e2aa09421a27