### PR TITLE
Update kcp-kyma-environment-broker-dashboard to have error category and reason

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -2711,12 +2711,13 @@
       {
         "allValue": null,
         "current": {
-          "selected": false,
+          "selected": true,
+          "tags": [],
           "text": [
-            "aws"
+            "All"
           ],
           "value": [
-            "361c511f-f939-4621-b228-d0fb79a1fe15"
+            "$__all"
           ]
         },
         "description": null,
@@ -2728,12 +2729,12 @@
         "name": "plan_id",
         "options": [
           {
-            "selected": false,
+            "selected": true,
             "text": "All",
             "value": "$__all"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "aws",
             "value": "361c511f-f939-4621-b228-d0fb79a1fe15"
           },
@@ -2812,7 +2813,7 @@
           "query": "label_values({__name__=~\"compass_keb_provisioning_result|compass_keb_deprovisioning_result\", plan_id=~\"$plan_id\"}, error_category)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -2846,7 +2847,7 @@
           "query": "label_values({__name__=~\"compass_keb_provisioning_result|compass_keb_deprovisioning_result\", plan_id=~\"$plan_id\", error_category=~\"$error_category\"}, error_reason)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 0,
+        "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -656,6 +656,7 @@
             "mode": "thresholds"
           },
           "custom": {},
+          "displayName": "${__series.name}",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -724,6 +725,7 @@
             "mode": "thresholds"
           },
           "custom": {},
+          "displayName": "${__series.name}",
           "mappings": [],
           "thresholds": {
             "mode": "absolute",

--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -514,13 +514,283 @@
       "valueName": "current"
     },
     {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "#299c46",
+        "#FADE2A",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 95
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 13
+      },
+      "id": 195,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "auto"
+      },
+      "pluginVersion": "",
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "round(sum(increase(compass_keb_operations_provisioning_succeeded_total[$__range])))/(round(sum(increase(compass_keb_operations_provisioning_failed_total[$__range])))+round(sum(increase(compass_keb_operations_provisioning_succeeded_total[$__range]))))*100",
+          "interval": "",
+          "legendFormat": "Provision",
+          "refId": "A"
+        },
+        {
+          "expr": "round(sum(increase(compass_keb_operations_deprovisioning_succeeded_total[$__range])))/(round(sum(increase(compass_keb_operations_deprovisioning_failed_total[$__range])))+round(sum(increase(compass_keb_operations_deprovisioning_succeeded_total[$__range]))))*100",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "Deprovision",
+          "refId": "B"
+        }
+      ],
+      "thresholds": "1,10",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Success Rate (All)",
+      "type": "stat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 6,
+        "y": 13
+      },
+      "id": 196,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "expr": "topk(3, count by (error_category, error_reason) (compass_keb_provisioning_result{plan_id=~\"$plan_id\"} == 0 unless (compass_keb_provisioning_result{plan_id=~\"$plan_id\"} offset $__range == 0)))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{error_category}} - {{error_reason}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Provision - Top 3 error category and reason ($plan_id)",
+      "type": "bargauge"
+    },
+    {
+      "cacheTimeout": null,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 7,
+        "x": 13,
+        "y": 13
+      },
+      "id": 198,
+      "interval": null,
+      "links": [],
+      "maxDataPoints": 100,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {}
+      },
+      "pluginVersion": "",
+      "targets": [
+        {
+          "expr": "topk(3, count by (error_category, error_reason) (compass_keb_deprovisioning_result{plan_id=~\"$plan_id\"} == 0 unless (compass_keb_deprovisioning_result{plan_id=~\"$plan_id\"} offset $__range == 0)))",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{error_category}} - {{error_reason}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Deprovision - Top 3 error category and reason ($plan_id)",
+      "type": "bargauge"
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 13
+        "y": 17
       },
       "id": 159,
       "panels": [],
@@ -560,7 +830,7 @@
         "h": 5,
         "w": 6,
         "x": 0,
-        "y": 14
+        "y": 18
       },
       "id": 188,
       "options": {
@@ -570,7 +840,7 @@
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
-            "lastNotNull"
+            "last"
           ],
           "fields": "",
           "values": false
@@ -588,27 +858,29 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_provisioning_failed_total{plan_id=\"$plan_id\"}[$__range]))",
+          "expr": "round(sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_provisioning_failed_total{plan_id=\"$plan_id\"}[$__range])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Provision ",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]))",
+          "expr": "round(sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range])))",
           "interval": "",
           "legendFormat": "Succeeded",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(compass_keb_operations_provisioning_failed_total{plan_id=\"$plan_id\"}[$__range]))",
+          "expr": "count((compass_keb_provisioning_result{plan_id=\"$plan_id\", error_category=~\"$error_category\", error_reason=~\"$error_reason\"} == 0) unless (compass_keb_provisioning_result{plan_id=\"$plan_id\", error_category=~\"$error_category\", error_reason=~\"$error_reason\"} offset $__range == 0)) or vector(0)",
+          "format": "time_series",
           "hide": false,
+          "instant": false,
           "interval": "",
           "legendFormat": "Failed",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range])) / (sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_provisioning_failed_total{plan_id=\"$plan_id\"}[$__range])) > 0 ) *100",
+          "expr": "sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range])) / (sum(increase(compass_keb_operations_provisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_provisioning_failed_total{plan_id=\"$plan_id\"}[$__range])) > 0 ) *100 or vector(0)",
           "hide": false,
           "interval": "",
           "legendFormat": "Success Rate",
@@ -644,7 +916,7 @@
         "h": 5,
         "w": 2,
         "x": 6,
-        "y": 14
+        "y": 18
       },
       "id": 189,
       "interval": null,
@@ -713,7 +985,7 @@
         "h": 5,
         "w": 4,
         "x": 8,
-        "y": 14
+        "y": 18
       },
       "id": 178,
       "options": {
@@ -788,7 +1060,7 @@
         "h": 5,
         "w": 6,
         "x": 12,
-        "y": 14
+        "y": 18
       },
       "id": 190,
       "options": {
@@ -816,27 +1088,27 @@
       },
       "targets": [
         {
-          "expr": "sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_deprovisioning_failed_total{plan_id=\"$plan_id\"}[$__range]))",
+          "expr": "round(sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_deprovisioning_failed_total{plan_id=\"$plan_id\"}[$__range])))",
           "hide": false,
           "interval": "",
           "legendFormat": "Total Deprovision ",
           "refId": "A"
         },
         {
-          "expr": "sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]))",
+          "expr": "round(sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range])))",
           "interval": "",
           "legendFormat": "Succeeded",
           "refId": "B"
         },
         {
-          "expr": "sum(increase(compass_keb_operations_deprovisioning_failed_total{plan_id=\"$plan_id\"}[$__range]))",
+          "expr": "count((compass_keb_deprovisioning_result{plan_id=\"$plan_id\", error_category=~\"$error_category\", error_reason=~\"$error_reason\"} == 0) unless (compass_keb_deprovisioning_result{plan_id=\"$plan_id\", error_category=~\"$error_category\", error_reason=~\"$error_reason\"} offset $__range == 0)) or vector(0)",
           "hide": false,
           "interval": "",
           "legendFormat": "Failed",
           "refId": "C"
         },
         {
-          "expr": "sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range])) / (sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_deprovisioning_failed_total{plan_id=\"$plan_id\"}[$__range])) > 0 ) *100",
+          "expr": "sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range])) / (sum(increase(compass_keb_operations_deprovisioning_succeeded_total{plan_id=\"$plan_id\"}[$__range]) + increase(compass_keb_operations_deprovisioning_failed_total{plan_id=\"$plan_id\"}[$__range])) > 0 ) *100 or vector(0)",
           "hide": false,
           "interval": "",
           "legendFormat": "Success Rate",
@@ -872,7 +1144,7 @@
         "h": 5,
         "w": 2,
         "x": 18,
-        "y": 14
+        "y": 18
       },
       "id": 191,
       "interval": null,
@@ -941,7 +1213,7 @@
         "h": 5,
         "w": 4,
         "x": 20,
-        "y": 14
+        "y": 18
       },
       "id": 168,
       "options": {
@@ -998,7 +1270,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 19
+        "y": 46
       },
       "id": 193,
       "panels": [
@@ -1363,7 +1635,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 20
+        "y": 93
       },
       "id": 42,
       "panels": [
@@ -2044,7 +2316,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 94
       },
       "id": 38,
       "panels": [
@@ -2515,6 +2787,74 @@
         "queryValue": "",
         "skipUrlSync": false,
         "type": "custom"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": null,
+        "definition": "label_values({__name__=~\"compass_keb_provisioning_result|compass_keb_deprovisioning_result\", plan_id=~\"$plan_id\"}, error_category)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "error_category",
+        "query": {
+          "query": "label_values({__name__=~\"compass_keb_provisioning_result|compass_keb_deprovisioning_result\", plan_id=~\"$plan_id\"}, error_category)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": null,
+        "current": {
+          "selected": true,
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "datasource": null,
+        "definition": "label_values({__name__=~\"compass_keb_provisioning_result|compass_keb_deprovisioning_result\", plan_id=~\"$plan_id\", error_category=~\"$error_category\"}, error_reason)",
+        "description": null,
+        "error": null,
+        "hide": 0,
+        "includeAll": true,
+        "label": null,
+        "multi": true,
+        "name": "error_reason",
+        "query": {
+          "query": "label_values({__name__=~\"compass_keb_provisioning_result|compass_keb_deprovisioning_result\", plan_id=~\"$plan_id\", error_category=~\"$error_category\"}, error_reason)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Added variables `error_category` and `error_reason` which are dependent on the query of selected plan_id.
- Added pannel `Success Rate (All)`  to show the overall success rate (all plans) for provision and deprovision.
- Added pannel `Provision - Top 3 error category and reason ($plan_id)` to show the top 3 pair of error category&reason for provision.
- Added pannel `Deprovision - Top 3 error category and reason ($plan_id)` to show the top 3 pair of error category&reason for deprovision.
- Update the `Fail` section number of each `Provision/Deprovision ($plan_id)` panel depending on the selected error_category and error_reason values as well.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
