### PR TITLE
Extend RMA reconciler permissions

### DIFF
--- a/resources/kcp/charts/component-reconcilers/charts/rma/templates/rbac.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma/templates/rbac.yaml
@@ -12,7 +12,13 @@ metadata:
   name: component-reconcilers-rma
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
+    resources: ["secrets", "serviceaccounts"]
+    verbs: ["*"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["clusterroles", "clusterrolebindings"]
+    verbs: ["*"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
     verbs: ["*"]
   - apiGroups: ["operator.victoriametrics.com"]
     resources: ["vmrules"]


### PR DESCRIPTION
**Description**

The extended permissions are needed for a change in runtime monitoring integration:
https://github.tools.sap/kyma/management-plane-config/pull/1590


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
