### PR TITLE
replace k8s.io/helm to 2.16.1 in go.mod

### DIFF
--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -73,7 +73,6 @@ replace (
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.12.1
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29
-
 	k8s.io/api => k8s.io/api v0.22.8
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.22.8
 	k8s.io/apimachinery => k8s.io/apimachinery v0.22.8
@@ -88,6 +87,8 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.22.8
 	k8s.io/cri-api => k8s.io/cri-api v0.22.8
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.22.8
+
+	k8s.io/helm => k8s.io/helm v2.16.1+incompatible
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.22.8
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.22.8
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.22.8

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -2977,8 +2977,6 @@ k8s.io/gengo v0.0.0-20201113003025-83324d819ded/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAE
 k8s.io/gengo v0.0.0-20201214224949-b6c5ce23f027/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/gengo v0.0.0-20210813121822-485abfe95c7c/go.mod h1:FiNAH4ZV3gBg2Kwh89tzAEV2be7d5xI0vBa/VySYy3E=
 k8s.io/heapster v1.2.0-beta.1/go.mod h1:h1uhptVXMwC8xtZBYsPXKVi8fpdlYkTs6k949KozGrM=
-k8s.io/helm v2.14.2+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
-k8s.io/helm v2.16.0+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/helm v2.16.1+incompatible/go.mod h1:LZzlS4LQBHfciFOurYBFkCMTaZ0D1l+p0teMg7TSULI=
 k8s.io/klog v0.0.0-20181102134211-b9b56d5dfc92/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.2.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1474"
     kyma_metrics_collector:
       dir:
-      version: "PR-1608"
+      version: "PR-1624"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
This PR adds a `replace` of `k8s.io/helm` to version `2.16.1` in KMC to prevent potential security vulnerabilities. 