### PR TITLE
Fix the wrong numbers on kcp-kyma-environment-broker-dashboard for upgraded clusters

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -1329,31 +1329,31 @@
           },
           "targets": [
             {
-          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) or vector(0)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) or vector(0)",
               "interval": "",
               "legendFormat": "Total",
               "refId": "A"
             },
             {
               "exemplar": false,
-          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) or vector(0)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Succeeded",
               "refId": "B"
             },
             {
-          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==0) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 0)) or vector(0)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==0) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 0)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Failed",
               "refId": "C"
             },
             {
-          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) / count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) * 100 or vector(0)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) / count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) * 100 or vector(0)",
               "hide": false,
               "interval": "",
-          "legendFormat": "Success Rate",
+              "legendFormat": "Success Rate",
               "refId": "D"
             }
           ],

--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -1301,7 +1301,7 @@
             "h": 5,
             "w": 7,
             "x": 0,
-            "y": 14
+            "y": 47
           },
           "id": 161,
           "options": {
@@ -1329,31 +1329,31 @@
           },
           "targets": [
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"})",
+          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) or vector(0)",
               "interval": "",
               "legendFormat": "Total",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1)",
+          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Succeeded",
               "refId": "B"
             },
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==0)",
+          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==0) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 0)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Failed",
               "refId": "C"
             },
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) / count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) * 100",
+          "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) / count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) * 100 or vector(0)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Final Success Rate",
+          "legendFormat": "Success Rate",
               "refId": "D"
             }
           ],
@@ -1362,7 +1362,6 @@
         },
         {
           "datasource": null,
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1384,16 +1383,15 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 4,
+            "w": 5,
             "x": 7,
-            "y": 14
+            "y": 47
           },
           "id": 184,
-          "interval": null,
           "options": {
             "colorMode": "value",
             "graphMode": "area",
-            "justifyMode": "center",
+            "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
@@ -1403,7 +1401,7 @@
               "values": false
             },
             "text": {},
-            "textMode": "value"
+            "textMode": "auto"
           },
           "pluginVersion": "7.4.0",
           "scopedVars": {
@@ -1415,36 +1413,34 @@
           },
           "targets": [
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==2)",
-              "instant": false,
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==2) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 2)) or vector(0)",
               "interval": "",
               "legendFormat": "In Progress",
               "refId": "A"
             },
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==3)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==3) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 3)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Pending",
               "refId": "B"
             },
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==4)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==4) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 4)) or vector(0)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Cancelling",
+              "legendFormat": "Canceling",
               "refId": "C"
             },
             {
-              "expr": "count(compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==5)",
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==5) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 5)) or vector(0)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Cancelled",
+              "legendFormat": "Canceled",
               "refId": "D"
             }
           ],
-          "title": "Upgrade Cluster  Progressing (${plan_id})",
-          "transformations": [],
+          "title": "Upgrade Cluster Progressing ($plan_id)",
           "type": "stat"
         },
         {
@@ -1471,8 +1467,8 @@
           "gridPos": {
             "h": 5,
             "w": 7,
-            "x": 11,
-            "y": 14
+            "x": 12,
+            "y": 47
           },
           "id": 182,
           "options": {
@@ -1500,31 +1496,31 @@
           },
           "targets": [
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"})",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range)) or vector(0)",
               "interval": "",
               "legendFormat": "Total",
               "refId": "A"
             },
             {
               "exemplar": false,
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==1)",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 1)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Succeeded",
               "refId": "B"
             },
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==0)",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==0) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 0)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Failed",
               "refId": "C"
             },
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==1) / count (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}) * 100",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 1)) / count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range)) * 100 or vector(0)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Fina Success Rate",
+              "legendFormat": "Success Rate",
               "refId": "D"
             }
           ],
@@ -1533,7 +1529,6 @@
         },
         {
           "datasource": null,
-          "description": "",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1555,16 +1550,15 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 4,
-            "x": 18,
-            "y": 14
+            "w": 5,
+            "x": 19,
+            "y": 47
           },
           "id": 185,
-          "interval": null,
           "options": {
             "colorMode": "value",
             "graphMode": "area",
-            "justifyMode": "center",
+            "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
               "calcs": [
@@ -1574,7 +1568,7 @@
               "values": false
             },
             "text": {},
-            "textMode": "value"
+            "textMode": "auto"
           },
           "pluginVersion": "7.4.0",
           "scopedVars": {
@@ -1586,36 +1580,34 @@
           },
           "targets": [
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==2)",
-              "instant": false,
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==2) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 2)) or vector(0)",
               "interval": "",
               "legendFormat": "In Progress",
               "refId": "A"
             },
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==3)",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==3) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 3)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Pending",
               "refId": "B"
             },
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==4)",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==4) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 4)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Cancelling",
               "refId": "C"
             },
             {
-              "expr": "count(compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==5)",
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==5) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 5)) or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Cancelled",
               "refId": "D"
             }
           ],
-          "title": "Upgrade Kyma  Progressing (${plan_id})",
-          "transformations": [],
+          "title": "Upgrade Kyma Progressing ($plan_id)",
           "type": "stat"
         }
       ],
@@ -1637,7 +1629,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 93
+        "y": 104
       },
       "id": 42,
       "panels": [
@@ -2318,7 +2310,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 105
       },
       "id": 38,
       "panels": [

--- a/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
+++ b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json
@@ -1272,7 +1272,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 52
       },
       "id": 193,
       "panels": [
@@ -1299,9 +1299,9 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 7,
+            "w": 8,
             "x": 0,
-            "y": 47
+            "y": 53
           },
           "id": 161,
           "options": {
@@ -1350,11 +1350,18 @@
               "refId": "C"
             },
             {
+              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==5) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 5)) or vector(0)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Canceled",
+              "refId": "D"
+            },
+            {
               "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 1)) / count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range)) * 100 or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Success Rate",
-              "refId": "D"
+              "refId": "E"
             }
           ],
           "title": "Upgrade Cluster ($plan_id)",
@@ -1383,9 +1390,9 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 5,
-            "x": 7,
-            "y": 47
+            "w": 4,
+            "x": 8,
+            "y": 53
           },
           "id": 184,
           "options": {
@@ -1431,13 +1438,6 @@
               "interval": "",
               "legendFormat": "Canceling",
               "refId": "C"
-            },
-            {
-              "expr": "count((compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"}==5) unless (compass_keb_upgrade_cluster_result{plan_id=\"$plan_id\"} offset $__range == 5)) or vector(0)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Canceled",
-              "refId": "D"
             }
           ],
           "title": "Upgrade Cluster Progressing ($plan_id)",
@@ -1466,9 +1466,9 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 7,
+            "w": 8,
             "x": 12,
-            "y": 47
+            "y": 53
           },
           "id": 182,
           "options": {
@@ -1517,11 +1517,18 @@
               "refId": "C"
             },
             {
+              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==5) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 5)) or vector(0)",
+              "hide": false,
+              "interval": "",
+              "legendFormat": "Canceled",
+              "refId": "D"
+            },
+            {
               "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==1) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 1)) / count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range)) * 100 or vector(0)",
               "hide": false,
               "interval": "",
               "legendFormat": "Success Rate",
-              "refId": "D"
+              "refId": "E"
             }
           ],
           "title": "Upgrade Kyma ($plan_id)",
@@ -1550,9 +1557,9 @@
           },
           "gridPos": {
             "h": 5,
-            "w": 5,
-            "x": 19,
-            "y": 47
+            "w": 4,
+            "x": 20,
+            "y": 53
           },
           "id": 185,
           "options": {
@@ -1596,15 +1603,8 @@
               "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==4) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 4)) or vector(0)",
               "hide": false,
               "interval": "",
-              "legendFormat": "Cancelling",
+              "legendFormat": "Canceling",
               "refId": "C"
-            },
-            {
-              "expr": "count((compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"}==5) unless (compass_keb_upgrade_kyma_result{plan_id=\"$plan_id\"} offset $__range == 5)) or vector(0)",
-              "hide": false,
-              "interval": "",
-              "legendFormat": "Cancelled",
-              "refId": "D"
             }
           ],
           "title": "Upgrade Kyma Progressing ($plan_id)",
@@ -1629,7 +1629,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 104
+        "y": 157
       },
       "id": 42,
       "panels": [
@@ -2310,7 +2310,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 105
+        "y": 158
       },
       "id": 38,
       "panels": [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed the wrong numbers on kcp-kyma-environment-broker-dashboard for upgraded kyma/cluster which was reported in backlog [#2415](https://github.tools.sap/kyma/backlog/issues/2415)


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
