### PR TITLE
bump gardener/gardener-extension-provider-azure

### DIFF
--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -5,12 +5,12 @@ go 1.17
 require (
 	github.com/gardener/gardener v1.46.0
 	github.com/gardener/gardener-extension-provider-aws v1.35.0
-	github.com/gardener/gardener-extension-provider-azure v1.26.3
+	github.com/gardener/gardener-extension-provider-azure v1.27.0
 	github.com/gardener/gardener-extension-provider-gcp v1.22.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220505103127-579766fa0061
+	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220506145327-f6d66a68863d
 	github.com/onsi/gomega v1.19.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -704,6 +704,8 @@ github.com/gardener/gardener-extension-provider-aws v1.35.0 h1:9sQJSa9y7H6CmmWkJ
 github.com/gardener/gardener-extension-provider-aws v1.35.0/go.mod h1:KXDUHTz5JsD6uFVeVQ4XBAfoheA/QSHd0/HaQReptuE=
 github.com/gardener/gardener-extension-provider-azure v1.26.3 h1:HrayB/xY/I4FMQK+WmhmwaYQkMy9wsblb/uw+Pa08fk=
 github.com/gardener/gardener-extension-provider-azure v1.26.3/go.mod h1:z+lv3weFbJ2CR+SAvII/mCj6Fwpm97capbWNMz1QJKY=
+github.com/gardener/gardener-extension-provider-azure v1.27.0 h1:xmfOcPzwRQ6NPXA7LY+pEFmsUgYaQ8IzUu6TGh2sS+g=
+github.com/gardener/gardener-extension-provider-azure v1.27.0/go.mod h1:mzDhG8VGAwro2z7Ny0HnaJlKi20GAtVeBD6dQQBIpYY=
 github.com/gardener/gardener-extension-provider-gcp v1.22.0 h1:yOt0FCaVv80qBBBB1f5nbuyDUCq3j6laSGYgribfE0g=
 github.com/gardener/gardener-extension-provider-gcp v1.22.0/go.mod h1:JQso52ey4E2v4cSHqmXu7fd+jL8fLGB9HgrulhA4cW0=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
@@ -719,6 +721,7 @@ github.com/gardener/machine-controller-manager v0.27.0/go.mod h1:zlIxuLQMtRO+aXO
 github.com/gardener/machine-controller-manager v0.33.0/go.mod h1:jxxE+mGgXwg4iPlCHTG4GtUfK2CcHA6yYoIIowoxOZU=
 github.com/gardener/machine-controller-manager v0.41.0/go.mod h1:43OABkCemMS6b35z3OprbfaT3p2HxKAZkJekjCO2T48=
 github.com/gardener/machine-controller-manager v0.42.0/go.mod h1:43OABkCemMS6b35z3OprbfaT3p2HxKAZkJekjCO2T48=
+github.com/gardener/machine-controller-manager v0.43.1/go.mod h1:oMaIZMJ0pU6Z8j885v4a4+wxkzC1mpoqfqDUH34SQ58=
 github.com/gardener/machine-controller-manager v0.44.1/go.mod h1:X3MKnVQ83ov7e8Ct0TxL+3PiTodGTc41klr6MbEuxxY=
 github.com/gardener/remedy-controller v0.6.0/go.mod h1:vh24JWDa9rjtCDGAI6hI7qvZYaMW/M21P2brKhkg47I=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -1412,6 +1415,8 @@ github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f/g
 github.com/kyma-incubator/reconciler v0.0.0-20220419134630-9c42f9b41986/go.mod h1:/x7yd8gZei/mm/CgoxEToPvkkJIXKTb4DYVC8gcKn78=
 github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220505103127-579766fa0061 h1:2XtpSJhWRUvQ5d3yxt4eSTEs60p1w5uws6kuVw5mYEQ=
 github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220505103127-579766fa0061/go.mod h1:qZ6O1eRp3HWmnNmBQ0+Fy+AQsuM0fSDRPnQKmu7QeFw=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220506145327-f6d66a68863d h1:fcbty1yFgEuqsM088K9rbQu9Pq8dhIVhqL48FLHV5uY=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220506145327-f6d66a68863d/go.mod h1:qZ6O1eRp3HWmnNmBQ0+Fy+AQsuM0fSDRPnQKmu7QeFw=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8 h1:8im1YmVAcwDLVoLhvFFnqdQW8c2wsqX3uzdxS9GZkMc=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8/go.mod h1:OT4TJXzp5IIZrEkRksRazZ4vfLf9TxNYjPUGsPmQ+iY=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20200818080816-8c81ea09adc7/go.mod h1:LUlTpeBF6hz7DyOtROez1IjluZOrFFgJH9vx8/me5p8=

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1651"
     kyma_metrics_collector:
       dir:
-      version: "PR-1664"
+      version: "PR-1673"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
This PR bumps `gardener/gardener-extension-provider-azure` to prevent potential security vulnerabilities. 