### PR TITLE
Update btp-operator overrides on KEB update operation

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/runtimeversion"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
+	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/pivotal-cf/brokerapi/v8/domain/apiresponses"
 	"github.com/pkg/errors"
@@ -78,6 +79,23 @@ type BrokerSuiteTest struct {
 
 	t                   *testing.T
 	inputBuilderFactory input.CreatorForPlan
+
+	componentProvider componentProviderDecorated
+}
+
+type componentProviderDecorated struct {
+	componentProvider input.ComponentListProvider
+	decorator         map[string]v1alpha1.KymaComponent
+}
+
+func (s componentProviderDecorated) AllComponents(kymaVersion internal.RuntimeVersionData) ([]v1alpha1.KymaComponent, error) {
+	all, err := s.componentProvider.AllComponents(kymaVersion)
+	for i, c := range all {
+		if dc, found := s.decorator[c.Name]; found {
+			all[i] = dc
+		}
+	}
+	return all, err
 }
 
 func (s *BrokerSuiteTest) TearDown() {
@@ -104,8 +122,12 @@ func NewBrokerSuiteTest(t *testing.T) *BrokerSuiteTest {
 	componentListProvider := kebRuntime.NewComponentsListProvider(
 		path.Join("testdata", "managed-runtime-components.yaml"),
 		path.Join("testdata", "additional-runtime-components.yaml")).WithHTTPClient(fakeHTTPClient)
+	decoratedComponentListProvider := componentProviderDecorated{
+		componentProvider: componentListProvider,
+		decorator:         make(map[string]v1alpha1.KymaComponent),
+	}
 
-	inputFactory, err := input.NewInputBuilderFactory(optComponentsSvc, disabledComponentsProvider, componentListProvider, input.Config{
+	inputFactory, err := input.NewInputBuilderFactory(optComponentsSvc, disabledComponentsProvider, decoratedComponentListProvider, input.Config{
 		MachineImageVersion:         "253",
 		KubernetesVersion:           "1.18",
 		MachineImage:                "coreos",
@@ -158,7 +180,7 @@ func NewBrokerSuiteTest(t *testing.T) *BrokerSuiteTest {
 	updateManager := update.NewManager(db.Operations(), eventBroker, time.Hour, logs)
 	rvc := runtimeversion.NewRuntimeVersionConfigurator("", "", nil, db.RuntimeStates())
 	updateQueue := NewUpdateProcessingQueue(context.Background(), updateManager, 1, db, inputFactory, provisionerClient,
-		eventBroker, rvc, db.RuntimeStates(), componentListProvider, reconcilerClient, *cfg, fakeK8sClientProvider(fakeK8sSKRClient), logs)
+		eventBroker, rvc, db.RuntimeStates(), decoratedComponentListProvider, reconcilerClient, *cfg, fakeK8sClientProvider(fakeK8sSKRClient), logs)
 	updateQueue.SpeedUp(10000)
 	updateManager.SpeedUp(10000)
 
@@ -179,6 +201,7 @@ func NewBrokerSuiteTest(t *testing.T) *BrokerSuiteTest {
 		router:              mux.NewRouter(),
 		t:                   t,
 		inputBuilderFactory: inputFactory,
+		componentProvider:   decoratedComponentListProvider,
 	}
 
 	ts.CreateAPI(inputFactory, cfg, db, provisioningQueue, deprovisioningQueue, updateQueue, logs)

--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -10,6 +10,7 @@ import (
 	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
+	"github.com/kyma-project/kyma/components/kyma-operator/pkg/apis/installer/v1alpha1"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1749,6 +1750,62 @@ func TestUpdateSCMigrationSuccess(t *testing.T) {
 	time.Sleep(5 * time.Millisecond)
 	suite.FinishUpdatingOperationByReconciler(updateOperationID)
 	suite.WaitForOperationState(updateOperationID, domain.Succeeded)
+
+	// change component input (additional components) and see if it works with update operation
+	suite.componentProvider.decorator["btp-operator"] = v1alpha1.KymaComponent{
+		Name:      "btp-operator",
+		Namespace: "kyma-system",
+		Source:    &v1alpha1.ComponentSource{URL: "https://btp-operator/updated"},
+	}
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id), `
+{
+	"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+	"context": {
+		"globalaccount_id": "g-account-id",
+		"user_id": "john.smith@email.com",
+		"sm_operator_credentials": {
+			"clientid": "testClientID",
+			"clientsecret": "testClientSecret",
+			"sm_url": "https://service-manager.kyma.com",
+			"url": "https://test.auth.com",
+			"xsappname": "testXsappname"
+		},
+		"isMigration": true
+	}
+}`)
+
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	update2OperationID := suite.DecodeOperationID(resp)
+	time.Sleep(5 * time.Millisecond)
+	suite.FinishUpdatingOperationByReconciler(update2OperationID)
+	i, err = suite.db.Instances().GetByID(id)
+	assert.NoError(t, err, "getting instance after second update")
+	assert.True(t, i.InstanceDetails.SCMigrationTriggered, "instance SCMigrationTriggered after second update")
+	rsu3, err := suite.db.RuntimeStates().GetLatestWithReconcilerInputByRuntimeID(i.RuntimeID)
+	assert.NoError(t, err, "getting runtime after second update")
+	assert.NotEqual(t, rsu2.ID, rsu3.ID, "runtime_state ID from second call should differ runtime_state ID from third call")
+	assert.Equal(t, update2OperationID, rsu3.OperationID, "runtime state second update operation ID")
+	assert.ElementsMatch(t, rsu3.KymaConfig.Components, []*gqlschema.ComponentConfigurationInput{})
+	assert.ElementsMatch(t, componentNames(rsu3.ClusterSetup.KymaConfig.Components), []string{"ory", "monitoring", "btp-operator", "sc-migration"})
+	for _, c := range rsu3.ClusterSetup.KymaConfig.Components {
+		if c.Component == "btp-operator" {
+			exp := reconcilerApi.Component{
+				Component: "btp-operator",
+				Namespace: "kyma-system",
+				URL:       "https://btp-operator/updated",
+				Configuration: []reconcilerApi.Configuration{
+					{Key: "manager.secret.clientid", Value: "testClientID", Secret: true},
+					{Key: "manager.secret.clientsecret", Value: "testClientSecret", Secret: true},
+					{Key: "manager.secret.url", Value: "https://service-manager.kyma.com"},
+					{Key: "manager.secret.sm_url", Value: "https://service-manager.kyma.com"},
+					{Key: "manager.secret.tokenurl", Value: "https://test.auth.com"},
+					{Key: "cluster.id", Value: "cluster_id"},
+				},
+			}
+			assert.Equal(t, exp, c)
+		}
+	}
+
 }
 
 func TestUpdateSCMigrationRejection(t *testing.T) {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1561"
     kyma_environment_broker:
       dir:
-      version: "PR-1667"
+      version: "PR-1674"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1651"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For all components, when some input data changes, it is desired to go through Kyma upgrade. BTP operator will be the only exception because, for migration, it might be necessary to upgrade btp-operator component input data even on update operation when resolving upstream bugs when migration is still in progress.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
