### PR TITLE
KEB manages cluster-id in cluster-config ConfigMap in SKR

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -1258,6 +1258,11 @@ func (s *BrokerSuiteTest) fixExpectedComponentListWithSMOperator(opID string) []
 					Value:  "https://test.auth.com",
 					Secret: false,
 				},
+				{
+					Key:    "cluster.id",
+					Value:  "cluster_id",
+					Secret: false,
+				},
 			},
 		},
 	}
@@ -1269,5 +1274,7 @@ func mockBTPOperatorClusterID() {
 			return "cluster_id", nil
 		}
 	}
+	provisioning.ConfigMapGetter = mock
 	update.ConfigMapGetter = mock
+	upgrade_kyma.ConfigMapGetter = mock
 }

--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -1167,7 +1167,7 @@ func (s *BrokerSuiteTest) fixExpectedComponentListWithSMProxy(opID string) []rec
 
 // fixExpectedComponentListWithSMOperator provides a fixed components list for Service Management 2.0 - when `sm_operator_credentials`
 // object is provided: btp-opeartor component should be installed
-func (s *BrokerSuiteTest) fixExpectedComponentListWithSMOperator(opID string) []reconcilerApi.Component {
+func (s *BrokerSuiteTest) fixExpectedComponentListWithSMOperator(opID, smClusterID string) []reconcilerApi.Component {
 	return []reconcilerApi.Component{
 		{
 			URL:       "",
@@ -1260,7 +1260,7 @@ func (s *BrokerSuiteTest) fixExpectedComponentListWithSMOperator(opID string) []
 				},
 				{
 					Key:    "cluster.id",
-					Value:  "cluster_id",
+					Value:  smClusterID,
 					Secret: false,
 				},
 			},
@@ -1269,12 +1269,9 @@ func (s *BrokerSuiteTest) fixExpectedComponentListWithSMOperator(opID string) []
 }
 
 func mockBTPOperatorClusterID() {
-	mock := func(string) internal.ClusterIDGetter {
-		return func() (string, error) {
-			return "cluster_id", nil
-		}
+	mock := func(string) (string, error) {
+		return "cluster_id", nil
 	}
-	provisioning.ConfigMapGetter = mock
 	update.ConfigMapGetter = mock
 	upgrade_kyma.ConfigMapGetter = mock
 }

--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -677,7 +677,7 @@ func NewProvisioningProcessingQueue(ctx context.Context, provisionManager *provi
 		{
 			condition: provisioning.WhenBTPOperatorCredentialsProvided,
 			stage:     createRuntimeStageName,
-			step:      provisioning.NewBTPOperatorOverridesStep(),
+			step:      provisioning.NewBTPOperatorOverridesStep(db.Operations()),
 		},
 		{
 			condition: provisioning.ForKyma1,
@@ -956,7 +956,7 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 		{
 			weight: 3,
 			cnd:    upgrade_kyma.WhenBTPOperatorCredentialsProvided,
-			step:   upgrade_kyma.NewBTPOperatorOverridesStep(),
+			step:   upgrade_kyma.NewBTPOperatorOverridesStep(db.Operations()),
 		},
 		{
 			weight: 4,

--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -215,7 +215,6 @@ func TestProvisioningWithReconciler_HappyPath(t *testing.T) {
 func TestProvisioningWithReconcilerWithBTPOperator_HappyPath(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
-	mockBTPOperatorClusterID()
 	defer suite.TearDown()
 	iid := uuid.New().String()
 
@@ -259,11 +258,12 @@ func TestProvisioningWithReconcilerWithBTPOperator_HappyPath(t *testing.T) {
 		Region:          "eu-central-1",
 	})
 
+	op, _ := suite.db.Operations().GetProvisioningOperationByID(opID)
 	suite.AssertClusterKymaConfig(opID, reconcilerApi.KymaConfig{
 		Version:        "2.0",
 		Profile:        "Production",
 		Administrators: []string{"john.smith@email.com"},
-		Components:     suite.fixExpectedComponentListWithSMOperator(opID),
+		Components:     suite.fixExpectedComponentListWithSMOperator(opID, op.InstanceDetails.ServiceManagerClusterID),
 	})
 
 	suite.AssertClusterConfigWithKubeconfig(opID)

--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -215,6 +215,7 @@ func TestProvisioningWithReconciler_HappyPath(t *testing.T) {
 func TestProvisioningWithReconcilerWithBTPOperator_HappyPath(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
+	mockBTPOperatorClusterID()
 	defer suite.TearDown()
 	iid := uuid.New().String()
 

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -257,7 +257,8 @@ type InstanceDetails struct {
 	ClusterConfigurationVersion int64  `json:"cluster_configuration_version"`
 	Kubeconfig                  string `json:"-"`
 
-	SCMigrationTriggered bool `json:"migration_triggered"`
+	SCMigrationTriggered    bool   `json:"migration_triggered"`
+	ServiceManagerClusterID string `json:"sm_cluster_id"`
 }
 
 // ProvisioningOperation holds all information about provisioning operation

--- a/components/kyma-environment-broker/internal/process/provisioning/btp_operator_overrides.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/btp_operator_overrides.go
@@ -4,13 +4,21 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/sirupsen/logrus"
 )
 
-type BTPOperatorOverridesStep struct{}
+var ConfigMapGetter func(string) internal.ClusterIDGetter = internal.GetClusterIDWithKubeconfig
 
-func NewBTPOperatorOverridesStep() *BTPOperatorOverridesStep {
-	return &BTPOperatorOverridesStep{}
+type BTPOperatorOverridesStep struct {
+	operationManager *process.ProvisionOperationManager
+}
+
+func NewBTPOperatorOverridesStep(os storage.Operations) *BTPOperatorOverridesStep {
+	return &BTPOperatorOverridesStep{
+		operationManager: process.NewProvisionOperationManager(os),
+	}
 }
 
 func (s *BTPOperatorOverridesStep) Name() string {
@@ -18,7 +26,9 @@ func (s *BTPOperatorOverridesStep) Name() string {
 }
 
 func (s *BTPOperatorOverridesStep) Run(operation internal.ProvisioningOperation, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
-	internal.CreateBTPOperatorProvisionInput(operation.InputCreator, operation.ProvisioningParameters.ErsContext.SMOperatorCredentials)
+	if err := internal.CreateBTPOperatorProvisionInput(operation.InputCreator, operation.ProvisioningParameters.ErsContext.SMOperatorCredentials, ConfigMapGetter(operation.InstanceDetails.Kubeconfig)); err != nil {
+		return s.operationManager.OperationFailed(operation, "failed to create BTP Operator input", err, log)
+	}
 	operation.InputCreator.EnableOptionalComponent(internal.BTPOperatorComponentName)
 	return operation, 0, nil
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/btp_operator_overrides.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/btp_operator_overrides.go
@@ -3,13 +3,12 @@ package provisioning
 import (
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/sirupsen/logrus"
 )
-
-var ConfigMapGetter func(string) internal.ClusterIDGetter = internal.GetClusterIDWithKubeconfig
 
 type BTPOperatorOverridesStep struct {
 	operationManager *process.ProvisionOperationManager
@@ -26,9 +25,12 @@ func (s *BTPOperatorOverridesStep) Name() string {
 }
 
 func (s *BTPOperatorOverridesStep) Run(operation internal.ProvisioningOperation, log logrus.FieldLogger) (internal.ProvisioningOperation, time.Duration, error) {
-	if err := internal.CreateBTPOperatorProvisionInput(operation.InputCreator, operation.ProvisioningParameters.ErsContext.SMOperatorCredentials, ConfigMapGetter(operation.InstanceDetails.Kubeconfig)); err != nil {
-		return s.operationManager.OperationFailed(operation, "failed to create BTP Operator input", err, log)
+	clusterID := uuid.NewString()
+	overrides := internal.GetBTPOperatorProvisioningOverrides(operation.ProvisioningParameters.ErsContext.SMOperatorCredentials, clusterID)
+	f := func(op *internal.ProvisioningOperation) {
+		op.InstanceDetails.ServiceManagerClusterID = clusterID
 	}
+	operation.InputCreator.AppendOverrides(internal.BTPOperatorComponentName, overrides)
 	operation.InputCreator.EnableOptionalComponent(internal.BTPOperatorComponentName)
-	return operation, 0, nil
+	return s.operationManager.UpdateOperation(operation, f, log)
 }

--- a/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go
@@ -53,6 +53,10 @@ func (s *CreateClusterConfigurationStep) Run(operation internal.ProvisioningOper
 		log.Errorf("Unable to create cluster configuration: %s", err.Error())
 		return s.operationManager.OperationFailed(operation, "invalid operation data - cannot create cluster configuration", err, log)
 	}
+	if err := internal.CheckBTPCredsValid(clusterConfiguration); err != nil {
+		log.Errorf("Sanity check for BTP operator configuration failed: %s", err.Error())
+		return s.operationManager.OperationFailed(operation, "invalid BTP Operator configuration", err, log)
+	}
 
 	err = s.runtimeStateStorage.Insert(
 		internal.NewRuntimeStateWithReconcilerInput(clusterConfiguration.RuntimeID, operation.ID, &clusterConfiguration))

--- a/components/kyma-environment-broker/internal/process/update/apply_reconciler_configuration.go
+++ b/components/kyma-environment-broker/internal/process/update/apply_reconciler_configuration.go
@@ -33,6 +33,10 @@ func (s *ApplyReconcilerConfigurationStep) Name() string {
 }
 
 func (s *ApplyReconcilerConfigurationStep) Run(operation internal.UpdatingOperation, log logrus.FieldLogger) (internal.UpdatingOperation, time.Duration, error) {
+	if err := internal.CheckBTPCredsValid(*operation.LastRuntimeState.ClusterSetup); err != nil {
+		log.Errorf("Sanity check for BTP operator configuration failed: %s", err.Error())
+		return s.operationManager.OperationFailed(operation, "invalid BTP Operator configuration", err, log)
+	}
 	cluster := operation.LastRuntimeState.ClusterSetup
 	if err := s.runtimeStateStorage.Insert(internal.NewRuntimeStateWithReconcilerInput(cluster.RuntimeID, operation.ID, cluster)); err != nil {
 		log.Errorf("cannot insert runtimeState with reconciler payload: %s", err)

--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/btp_operator_overrides.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/btp_operator_overrides.go
@@ -36,9 +36,6 @@ func (s *BTPOperatorOverridesStep) Run(operation internal.UpgradeKymaOperation, 
 	}
 	creds := operation.ProvisioningParameters.ErsContext.SMOperatorCredentials
 	overrides := internal.GetBTPOperatorProvisioningOverrides(creds, clusterID)
-	f := func(op *internal.UpgradeKymaOperation) {
-		op.InstanceDetails.ServiceManagerClusterID = clusterID
-	}
 	operation.InputCreator.AppendOverrides(internal.BTPOperatorComponentName, overrides)
 	operation.InputCreator.EnableOptionalComponent(internal.BTPOperatorComponentName)
 	operation.InputCreator.DisableOptionalComponent(internal.ServiceManagerComponentName)
@@ -46,5 +43,11 @@ func (s *BTPOperatorOverridesStep) Run(operation internal.UpgradeKymaOperation, 
 	operation.InputCreator.DisableOptionalComponent(internal.ServiceCatalogComponentName)
 	operation.InputCreator.DisableOptionalComponent(internal.ServiceCatalogAddonsComponentName)
 	operation.InputCreator.DisableOptionalComponent(internal.SCMigrationComponentName)
+	if clusterID == operation.InstanceDetails.ServiceManagerClusterID {
+		return operation, 0, nil
+	}
+	f := func(op *internal.UpgradeKymaOperation) {
+		op.InstanceDetails.ServiceManagerClusterID = clusterID
+	}
 	return s.operationManager.UpdateOperation(operation, f, log)
 }

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1561"
     kyma_environment_broker:
       dir:
-      version: "PR-1674"
+      version: "PR-1676"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1651"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

https://github.com/kyma-project/control-plane/pull/1599 removed ClusterID from upgrade queue. This is actually required to be persisted and we can't send empty string to render the helm chart because reconciler does `helm template` first without any access to the cluster and then runs `kubectl apply` making the ClusterID different for every reconciliation.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
