### PR TITLE
bump gardener to 1.46.2

### DIFF
--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -3,14 +3,14 @@ module github.com/kyma-project/control-plane/components/kyma-metrics-collector
 go 1.17
 
 require (
-	github.com/gardener/gardener v1.46.1
+	github.com/gardener/gardener v1.46.2
 	github.com/gardener/gardener-extension-provider-aws v1.35.0
 	github.com/gardener/gardener-extension-provider-azure v1.27.0
 	github.com/gardener/gardener-extension-provider-gcp v1.22.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220513135217-f774e68b3bff
+	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220513175218-46e4288313ec
 	github.com/onsi/gomega v1.19.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -695,8 +695,8 @@ github.com/gardener/gardener v1.26.0/go.mod h1:BrVJl0J2c9a1KpUm9E1COMolNKFY5cp3G
 github.com/gardener/gardener v1.36.0/go.mod h1:aVEbZy2WybsuwfXfUFNfOYz1JOmMjEOeYbv+sN9PzE0=
 github.com/gardener/gardener v1.44.0/go.mod h1:y8f1w9u44YuDAowo3PWmR79LhUv4TeTTb/1dhAFbKzc=
 github.com/gardener/gardener v1.44.4/go.mod h1:y8f1w9u44YuDAowo3PWmR79LhUv4TeTTb/1dhAFbKzc=
-github.com/gardener/gardener v1.46.1 h1:obzyp7IAzwP/EB9B4DWiWcMCa7ohU1SLlmKFl3dnAFA=
-github.com/gardener/gardener v1.46.1/go.mod h1:BsQ9s0Ms5rU1IAS1doVceBGj4kNBhSMQKaDB4a2ba4k=
+github.com/gardener/gardener v1.46.2 h1:G5auN8JthqgzG/iiYVnHB1J8Sk0Pg+pQ6UvjX34PvZU=
+github.com/gardener/gardener v1.46.2/go.mod h1:BsQ9s0Ms5rU1IAS1doVceBGj4kNBhSMQKaDB4a2ba4k=
 github.com/gardener/gardener-extension-networking-calico v1.19.4/go.mod h1:i62aQOUURkhQrap9cNK1jNkZoxCb2o6iDeUYaoSt25g=
 github.com/gardener/gardener-extension-provider-aws v1.35.0 h1:9sQJSa9y7H6CmmWkJu2rf9ooqpaGYSon7yTWPSWO84k=
 github.com/gardener/gardener-extension-provider-aws v1.35.0/go.mod h1:KXDUHTz5JsD6uFVeVQ4XBAfoheA/QSHd0/HaQReptuE=
@@ -1409,8 +1409,8 @@ github.com/kyma-incubator/compass/components/system-broker v0.0.0-20220208132958
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f h1:xH0q+JC+JyIis3ljLPCZQNeDwpsfei54EEWrKE+KHSM=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-incubator/reconciler v0.0.0-20220419134630-9c42f9b41986/go.mod h1:/x7yd8gZei/mm/CgoxEToPvkkJIXKTb4DYVC8gcKn78=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220513135217-f774e68b3bff h1:ohGSrtia5XYVIq6aXEom1+Hg6HHJFHEtEG0Hp+vMrQc=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220513135217-f774e68b3bff/go.mod h1:KKuQfI5g6fArKHcp1Bh1afhU3giQG5PeeH4xQ9GWHm0=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220513175218-46e4288313ec h1:HiHkOFMqBvZGqG23JbLB5Z8gGWsQEPXfiBJIzeSKCAc=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220513175218-46e4288313ec/go.mod h1:KKuQfI5g6fArKHcp1Bh1afhU3giQG5PeeH4xQ9GWHm0=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8 h1:8im1YmVAcwDLVoLhvFFnqdQW8c2wsqX3uzdxS9GZkMc=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8/go.mod h1:OT4TJXzp5IIZrEkRksRazZ4vfLf9TxNYjPUGsPmQ+iY=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20200818080816-8c81ea09adc7/go.mod h1:LUlTpeBF6hz7DyOtROez1IjluZOrFFgJH9vx8/me5p8=

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1651"
     kyma_metrics_collector:
       dir:
-      version: "PR-1696"
+      version: "PR-1701"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
this PR bumps `gardener/gardener` to `1.46.2` to prevent potential security issues.