### PR TITLE
Map last operation state to compliant OSB operation states

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1707"
     kyma_environment_broker:
       dir:
-      version: "PR-1685"
+      version: "PR-1710"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1651"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add mapStateToOSBCompliantState() to return OSB compliant operation states on last operation endpoint,
- add tests.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
