### PR TITLE
enable slack notification on kcp o cmd

### DIFF
--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -150,8 +150,8 @@ func (keys *GlobalOptionsKey) KubeconfigAPIURL() string {
 }
 
 // SlackAPIURL gets the slack-api-url global parameter
-func (keys *GlobalOptionsKey) SlackAPIURL() string {
-	return viper.GetString(keys.slackAPIURL)
+func (keys *GlobalOptionsKey) SlackAPIURL() []string {
+	return viper.GetStringSlice(keys.slackAPIURL)
 }
 
 // GardenerKubeconfig gets the gardener-kubeconfig global parameter

--- a/tools/cli/pkg/command/upgrade_cluster.go
+++ b/tools/cli/pkg/command/upgrade_cluster.go
@@ -44,7 +44,7 @@ func (cmd *UpgradeClusterCommand) Validate() error {
 	if err != nil {
 		return err
 	}
-	if GlobalOpts.SlackAPIURL() == "" {
+	if len(GlobalOpts.SlackAPIURL()) == 0 {
 		fmt.Println("Note: Ignore sending slack notification when slackAPIURL is empty")
 	}
 	return nil
@@ -60,11 +60,14 @@ func (cmd *UpgradeClusterCommand) Run() error {
 	}
 	fmt.Println("OrchestrationID:", ur.OrchestrationID)
 
-	if !cmd.orchestrationParams.DryRun && GlobalOpts.SlackAPIURL() != "" {
+	if !cmd.orchestrationParams.DryRun && len(GlobalOpts.SlackAPIURL()) != 0 {
+
 		slack_title := `upgrade cluster`
-		slack_err := SendSlackNotification(slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
-		if slack_err != nil {
-			return errors.Wrap(slack_err, "while sending notification to slack")
+		for _, slack_url := range GlobalOpts.SlackAPIURL() {
+			slack_err := SendSlackNotification(slack_url, slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
+			if slack_err != nil {
+				return errors.Wrap(slack_err, "while sending notification to slack")
+			}
 		}
 	}
 	return nil

--- a/tools/cli/pkg/command/upgrade_kyma.go
+++ b/tools/cli/pkg/command/upgrade_kyma.go
@@ -59,11 +59,13 @@ func (cmd *UpgradeKymaCommand) Run() error {
 	}
 	fmt.Println("OrchestrationID:", ur.OrchestrationID)
 
-	if !cmd.orchestrationParams.DryRun && GlobalOpts.SlackAPIURL() != "" {
+	if !cmd.orchestrationParams.DryRun && len(GlobalOpts.SlackAPIURL()) != 0 {
 		slack_title := `upgrade kyma`
-		slack_err := SendSlackNotification(slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
-		if slack_err != nil {
-			return errors.Wrap(slack_err, "while sending notification to slack")
+		for _, slack_url := range GlobalOpts.SlackAPIURL() {
+			slack_err := SendSlackNotification(slack_url, slack_title, cmd.cobraCmd, "OrchestrationID:"+ur.OrchestrationID)
+			if slack_err != nil {
+				return errors.Wrap(slack_err, "while sending notification to slack")
+			}
 		}
 	}
 	return nil
@@ -87,7 +89,7 @@ func (cmd *UpgradeKymaCommand) Validate() error {
 		cmd.orchestrationParams.Kyma.Version = cmd.version
 	}
 
-	if GlobalOpts.SlackAPIURL() == "" {
+	if len(GlobalOpts.SlackAPIURL()) == 0 {
 		fmt.Println("Note: Ignore sending slack notification when slackAPIURL is empty")
 	}
 


### PR DESCRIPTION
1. Implement [kcp-cli orchestration sends Slack info message to multiple channels](https://github.tools.sap/kyma/backlog/issues/2621)
2. when its merged the `slack-api-url` in `kcp-dev.yaml` should change to:
```
slack-api-url: ["https://hooks.***", "https://hooks.***"]
```
