### PR TITLE
reduce redention of reconciliation from 150 to 100

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -139,6 +139,6 @@ serviceMonitor:
 cleanerScript:
   enabled: false
   reconMaxAge: 4
-  reconKeepCount: 150
+  reconKeepCount: 100
   inventoryMaxAge: 4
   purgeOlderThan: 96h


### PR DESCRIPTION
**Description**

We agreed with SREs to reduce the reconciliation redention to 100 entires instead of 150.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
