### PR TITLE
Bump gardener provider azure 2022may23

### DIFF
--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -5,12 +5,12 @@ go 1.17
 require (
 	github.com/gardener/gardener v1.47.0
 	github.com/gardener/gardener-extension-provider-aws v1.35.0
-	github.com/gardener/gardener-extension-provider-azure v1.27.0
+	github.com/gardener/gardener-extension-provider-azure v1.27.1
 	github.com/gardener/gardener-extension-provider-gcp v1.22.1
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220518111804-77afbe8f4180
+	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220520102227-40a402ed3c78
 	github.com/onsi/gomega v1.19.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -707,6 +707,8 @@ github.com/gardener/gardener-extension-provider-aws v1.35.0 h1:9sQJSa9y7H6CmmWkJ
 github.com/gardener/gardener-extension-provider-aws v1.35.0/go.mod h1:KXDUHTz5JsD6uFVeVQ4XBAfoheA/QSHd0/HaQReptuE=
 github.com/gardener/gardener-extension-provider-azure v1.27.0 h1:xmfOcPzwRQ6NPXA7LY+pEFmsUgYaQ8IzUu6TGh2sS+g=
 github.com/gardener/gardener-extension-provider-azure v1.27.0/go.mod h1:mzDhG8VGAwro2z7Ny0HnaJlKi20GAtVeBD6dQQBIpYY=
+github.com/gardener/gardener-extension-provider-azure v1.27.1 h1:Ik2hjZVshM1AnlmPyNHse6lJWMr8TEyvTqHYyjaY4lE=
+github.com/gardener/gardener-extension-provider-azure v1.27.1/go.mod h1:mzDhG8VGAwro2z7Ny0HnaJlKi20GAtVeBD6dQQBIpYY=
 github.com/gardener/gardener-extension-provider-gcp v1.22.1 h1:S57EKcx11t6OcfFkW+fqu3Ha6juxjXOh5hEFDZ8lBfs=
 github.com/gardener/gardener-extension-provider-gcp v1.22.1/go.mod h1:JQso52ey4E2v4cSHqmXu7fd+jL8fLGB9HgrulhA4cW0=
 github.com/gardener/gardener-resource-manager v0.10.0/go.mod h1:0pKTHOhvU91eQB0EYr/6Ymd7lXc/5Hi8P8tF/gpV0VQ=
@@ -1420,6 +1422,8 @@ github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f/g
 github.com/kyma-incubator/reconciler v0.0.0-20220419134630-9c42f9b41986/go.mod h1:/x7yd8gZei/mm/CgoxEToPvkkJIXKTb4DYVC8gcKn78=
 github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220518111804-77afbe8f4180 h1:fEwz/wRLGDw5umaZVF+oYdLRU+Ktc+IFRh3yj0Cs6yY=
 github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220518111804-77afbe8f4180/go.mod h1:KKuQfI5g6fArKHcp1Bh1afhU3giQG5PeeH4xQ9GWHm0=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220520102227-40a402ed3c78 h1:+JdW9irfTaxTN2JV44OaEUwlvjr8DopTYyte+Fr6+dc=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220520102227-40a402ed3c78/go.mod h1:N3JzIsMpCd2HsuvwXA/BOJu3l8H8/nhFk1DF84Sdl58=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8 h1:8im1YmVAcwDLVoLhvFFnqdQW8c2wsqX3uzdxS9GZkMc=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8/go.mod h1:OT4TJXzp5IIZrEkRksRazZ4vfLf9TxNYjPUGsPmQ+iY=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20200818080816-8c81ea09adc7/go.mod h1:LUlTpeBF6hz7DyOtROez1IjluZOrFFgJH9vx8/me5p8=

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -75,7 +75,7 @@ github.com/Azure/azure-sdk-for-go v42.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9mo
 github.com/Azure/azure-sdk-for-go v43.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v55.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v61.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v64.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v64.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-blob-go v0.7.0/go.mod h1:f9YQKtsG1nMisotuTPpO0tjNuEjKRYAcJU8/ydDI++4=
 github.com/Azure/azure-storage-blob-go v0.14.0/go.mod h1:SMqIBi+SuiQH32bvyjngEewEeXoPfKMgWlBDaYf6fck=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
@@ -99,7 +99,7 @@ github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyC
 github.com/Azure/go-autorest/autorest/adal v0.9.13/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/adal v0.9.14/go.mod h1:W/MM4U6nLxnIskrw4UwWzlHfGjwUS50aOsc/I3yuU8M=
 github.com/Azure/go-autorest/autorest/adal v0.9.18/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
-github.com/Azure/go-autorest/autorest/adal v0.9.19/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
+github.com/Azure/go-autorest/autorest/adal v0.9.20/go.mod h1:XVVeme+LZwABT8K5Lc3hA4nAe8LDBVle26gTrguhhPQ=
 github.com/Azure/go-autorest/autorest/azure/auth v0.4.2/go.mod h1:90gmfKdlmKgfjUpnCEpOJzsUEjrWDSLwHIG73tSXddM=
 github.com/Azure/go-autorest/autorest/azure/cli v0.3.1/go.mod h1:ZG5p860J94/0kI9mNJVoIoLgXcirM2gF5i2kWloofxw=
 github.com/Azure/go-autorest/autorest/date v0.1.0/go.mod h1:plvfp3oPSKwf2DNjlBjWF/7vwR+cUD/ELuzDCXwHUVA=
@@ -587,7 +587,7 @@ github.com/docker/docker v20.10.2+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05b
 github.com/docker/docker v20.10.9+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.11+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker v20.10.12+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
-github.com/docker/docker v20.10.14+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.16+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-events v0.0.0-20170721190031-9461782956ad/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
@@ -705,8 +705,6 @@ github.com/gardener/gardener v1.47.0/go.mod h1:JgQDOhOe7E8r6L+he46JBM5/NUwCKwfQ3
 github.com/gardener/gardener-extension-networking-calico v1.19.4/go.mod h1:i62aQOUURkhQrap9cNK1jNkZoxCb2o6iDeUYaoSt25g=
 github.com/gardener/gardener-extension-provider-aws v1.35.0 h1:9sQJSa9y7H6CmmWkJu2rf9ooqpaGYSon7yTWPSWO84k=
 github.com/gardener/gardener-extension-provider-aws v1.35.0/go.mod h1:KXDUHTz5JsD6uFVeVQ4XBAfoheA/QSHd0/HaQReptuE=
-github.com/gardener/gardener-extension-provider-azure v1.27.0 h1:xmfOcPzwRQ6NPXA7LY+pEFmsUgYaQ8IzUu6TGh2sS+g=
-github.com/gardener/gardener-extension-provider-azure v1.27.0/go.mod h1:mzDhG8VGAwro2z7Ny0HnaJlKi20GAtVeBD6dQQBIpYY=
 github.com/gardener/gardener-extension-provider-azure v1.27.1 h1:Ik2hjZVshM1AnlmPyNHse6lJWMr8TEyvTqHYyjaY4lE=
 github.com/gardener/gardener-extension-provider-azure v1.27.1/go.mod h1:mzDhG8VGAwro2z7Ny0HnaJlKi20GAtVeBD6dQQBIpYY=
 github.com/gardener/gardener-extension-provider-gcp v1.22.1 h1:S57EKcx11t6OcfFkW+fqu3Ha6juxjXOh5hEFDZ8lBfs=
@@ -1420,8 +1418,6 @@ github.com/kyma-incubator/compass/components/system-broker v0.0.0-20220208132958
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f h1:xH0q+JC+JyIis3ljLPCZQNeDwpsfei54EEWrKE+KHSM=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-incubator/reconciler v0.0.0-20220419134630-9c42f9b41986/go.mod h1:/x7yd8gZei/mm/CgoxEToPvkkJIXKTb4DYVC8gcKn78=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220518111804-77afbe8f4180 h1:fEwz/wRLGDw5umaZVF+oYdLRU+Ktc+IFRh3yj0Cs6yY=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220518111804-77afbe8f4180/go.mod h1:KKuQfI5g6fArKHcp1Bh1afhU3giQG5PeeH4xQ9GWHm0=
 github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220520102227-40a402ed3c78 h1:+JdW9irfTaxTN2JV44OaEUwlvjr8DopTYyte+Fr6+dc=
 github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220520102227-40a402ed3c78/go.mod h1:N3JzIsMpCd2HsuvwXA/BOJu3l8H8/nhFk1DF84Sdl58=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220420073630-1208b41756a8 h1:8im1YmVAcwDLVoLhvFFnqdQW8c2wsqX3uzdxS9GZkMc=
@@ -1467,7 +1463,7 @@ github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.3/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.10.5/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/lib/pq v1.10.6/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/libopenstorage/openstorage v1.0.0/go.mod h1:Sp1sIObHjat1BeXhfMqLZ14wnOzEhNx2YQedreMcUyc=
 github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de/go.mod h1:zAbeS9B/r2mtpb6U+EI2rYA5OAXxsYw6wTamcNW+zcE=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=


### PR DESCRIPTION
This PR bumps the used package `gardener/gardener-extension-provider-azure` to `v1.27.1` to prevent potential security issues.