### PR TITLE
update to go1.18.2 for kubeconfig-service

### DIFF
--- a/components/kubeconfig-service/Dockerfile
+++ b/components/kubeconfig-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18 as builder
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18.2 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/kubeconfig-service
 ENV CGO_ENABLED 0


### PR DESCRIPTION
fix protecode issue https://github.tools.sap/kyma/security-scans/issues/17529