### PR TITLE
bump gardener to 1.48.1 in KMC

### DIFF
--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -3,14 +3,14 @@ module github.com/kyma-project/control-plane/components/kyma-metrics-collector
 go 1.17
 
 require (
-	github.com/gardener/gardener v1.48.0
+	github.com/gardener/gardener v1.48.1
 	github.com/gardener/gardener-extension-provider-aws v1.36.0
 	github.com/gardener/gardener-extension-provider-azure v1.28.0
 	github.com/gardener/gardener-extension-provider-gcp v1.23.0
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kelseyhightower/envconfig v1.4.0
-	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220608092104-91820e8e9e7c
+	github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220609083303-1ef90c83d868
 	github.com/onsi/gomega v1.19.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.9.1

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -728,8 +728,9 @@ github.com/gardener/gardener v1.24.0/go.mod h1:Ka66bCr/+tUwkf2Ov4JDMEEvdeeGtHsCf
 github.com/gardener/gardener v1.26.0/go.mod h1:BrVJl0J2c9a1KpUm9E1COMolNKFY5cp3G278DY720FI=
 github.com/gardener/gardener v1.36.0/go.mod h1:aVEbZy2WybsuwfXfUFNfOYz1JOmMjEOeYbv+sN9PzE0=
 github.com/gardener/gardener v1.44.4/go.mod h1:y8f1w9u44YuDAowo3PWmR79LhUv4TeTTb/1dhAFbKzc=
-github.com/gardener/gardener v1.48.0 h1:OjE5o+GP9AZsDfBt2yGRvrZOngt8bLTUWoYoQ86limk=
 github.com/gardener/gardener v1.48.0/go.mod h1:SxHdXYy4GWEbaP4X4axADf1eqhtfizpYXsB/q7D1GsU=
+github.com/gardener/gardener v1.48.1 h1:8HHCbs9Zc9zSsSDzqtHtdGoLc9NiXiGQS7uLo7UEsJg=
+github.com/gardener/gardener v1.48.1/go.mod h1:SxHdXYy4GWEbaP4X4axADf1eqhtfizpYXsB/q7D1GsU=
 github.com/gardener/gardener-extension-networking-calico v1.19.4/go.mod h1:i62aQOUURkhQrap9cNK1jNkZoxCb2o6iDeUYaoSt25g=
 github.com/gardener/gardener-extension-provider-aws v1.36.0 h1:vBlCGtMNZVT5hh4W6erC1wc/IobGv9mgw7GCn+J2ilY=
 github.com/gardener/gardener-extension-provider-aws v1.36.0/go.mod h1:ZvBuRrUhzj/VzXjU3VbFRAT4yi7FJvv4JhHwj1JY+3U=
@@ -1476,8 +1477,8 @@ github.com/kyma-incubator/compass/components/system-broker v0.0.0-20220327143459
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f h1:xH0q+JC+JyIis3ljLPCZQNeDwpsfei54EEWrKE+KHSM=
 github.com/kyma-incubator/hydroform/install v0.0.0-20210525111154-8fe3a378654f/go.mod h1:/qouJL+g8Tsllh/VcxK1Li6NCyuqyXSlq1i9InKSZJk=
 github.com/kyma-incubator/reconciler v0.0.0-20220530112659-7c7730de8709/go.mod h1:Q2H0j8bODb1kn/e37Bv/pmZVixPokr6VvneuVHgb/7I=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220608092104-91820e8e9e7c h1:KlEX2DQadn52oPZHbjAd/NhnLLb5aTetKrYMk0UDfTg=
-github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220608092104-91820e8e9e7c/go.mod h1:Ty9peImIEioeHcxl9P9QcjhJ51/WNN62mywCFVDgKtE=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220609083303-1ef90c83d868 h1:Sj9daLXRx1NtVrJhOUwt3l6T8Af3alubhh5VaR95Fgw=
+github.com/kyma-project/control-plane/components/kyma-environment-broker v0.0.0-20220609083303-1ef90c83d868/go.mod h1:Ty9peImIEioeHcxl9P9QcjhJ51/WNN62mywCFVDgKtE=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220603085229-28da147ebbd5 h1:z4nKY/qrnFnHzzhv/N4abdOScL96g5YoWs8HNrSmIAA=
 github.com/kyma-project/control-plane/components/provisioner v0.0.0-20220603085229-28da147ebbd5/go.mod h1:PULtwdOm9SEX3gRUY9GoiHmNBOoq4tOg4BEUh3cY+SU=
 github.com/kyma-project/kyma/components/application-operator v0.0.0-20200818080816-8c81ea09adc7/go.mod h1:LUlTpeBF6hz7DyOtROez1IjluZOrFFgJH9vx8/me5p8=

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1651"
     kyma_metrics_collector:
       dir:
-      version: "PR-1765"
+      version: "PR-1768"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
bumps the dependency `gardener` to `v1.48.1` to prevent potential security vulnerabilities.