### PR TITLE
License type sync to KEB

### DIFF
--- a/tools/license_type_sync.bash
+++ b/tools/license_type_sync.bash
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+
+# script populating license type into KEB db
+# the input is taken from STDIN in format of instance_id:license_type
+# the script processes each entry in order serially and calls KEB service instance update endpoint
+#
+# usage:
+# ./license_type_sync.bash < ers_instances > log
+
+set -euo pipefail
+
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+KEB=localhost:8080
+KUBECTL_PORT_FORWARD_KEB=true
+
+for i in "$@"; do
+    case $i in
+        -k=*|-keb=*|--keb=*)
+            KEB="${i#*=}"
+            shift
+            ;;
+        -k|-keb|--keb)
+            KEB="$2"
+            shift 2
+            ;;
+        -p=*|-port-forward=*|--port-forward=*)
+            KUBECTL_PORT_FORWARD_KEB="${i#*=}"
+            shift
+            ;;
+        -p|-port-forward|--port-forward)
+            KUBECTL_PORT_FORWARD_KEB="$2"
+            shift 2
+            ;;
+    esac
+done
+
+echo "KEB address: $KEB"
+echo "kubectl port-forward KEB: $KUBECTL_PORT_FORWARD_KEB"
+echo ""
+
+function patch_license() {
+    local instance=$1
+    local license_type=${2//$'\n'/}
+    echo "patching instance '$instance' to license type '$license_type'"
+    curl -XPATCH "$KEB/oauth/v2/service_instances/$instance?accepts_incomplete=true" -i \
+        -H "X-Broker-API-Version: 2.14" \
+        -H "Content-Type: application/json" \
+        --data-binary @- << EOF
+{
+   "service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+   "context":{
+       "license_type": "$license_type"
+   }
+}
+EOF
+}
+
+if [[ "$KUBECTL_PORT_FORWARD_KEB" == true ]]; then
+    echo "Starting kubectl port-forward for KEB and sleeping for a little bit"
+    kubectl port-forward -nkcp-system deployment/kcp-kyma-environment-broker 8080:8080 &
+    sleep 5
+    echo "continue"
+    echo ""
+fi
+
+while read line; do
+    echo reading $line
+    readarray -d : -t split <<< ${line}
+    patch_license "${split[0]}" "${split[1]}"
+done


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

this provides a simple script along with the usage on how to synchronize ERS license type information to KEB via update instance endpoint. By default, it expects KUBECONFIG to be correctly set and port-forwards KEB database as a background process.

example usage:
```
$ ./license_type_sync.bash < ers_instances > log
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
