### PR TITLE
Log provisioner kubeconfig parameters

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -14,7 +14,7 @@ global:
       version: "PR-1746"
     kyma_environment_broker:
       dir:
-      version: "PR-1793"
+      version: "PR-1784"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1749"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

there were cases when kyma upgrade failed with using kubeconfig to an SKR from provisioner
```
"msg":"Process operation failed: failed to create BTP Operator input: invalid configuration: no configuration has been provided, try setting KUBERNETES_MASTER environment variable",
```

When debugging I have stumbled upon an interesting case when executing graphql query directly to provisioner. Sometimes it returns operational and valid kubeconfig, sometimes it returns nil
```
$ cat gql_runtime_status.bash
runtime_id=5ecffe9c-7663-4433-b813-705cf70179a0

curl 'localhost:3000/graphql' \
    -H 'Content-Type: application/json' \
    -H 'tenant: e449f875-b5b2-4485-b7c0-98725c0571bf' \
    --data-binary @- << EOF
{
  "query":"query {\n runtimeStatus(id: \"$runtime_id\") {\n runtimeConfiguration{kubeconfig}}}"
}
EOF
```
```
$ ./gql_runtime_status.bash | jq --raw-output '.data.runtimeStatus.runtimeConfiguration.kubeconfig'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2236    0  2111  100   125   4275    253 --:--:-- --:--:-- --:--:--  4535
apiVersion: v1
clusters:
- cluster:
    certificate-authority-data: **redacted**
    server: https://api.afadf6b.stage.kyma.ondemand.com
  name: shoot--kyma-stage--afadf6b
contexts:
- context:
    cluster: shoot--kyma-stage--afadf6b
    user: shoot--kyma-stage--afadf6b-token
  name: shoot--kyma-stage--afadf6b
current-context: shoot--kyma-stage--afadf6b
kind: Config
preferences: {}
users:
- name: shoot--kyma-stage--afadf6b-token
  user:
    token: **redacted**
```
```
$ ./gql_runtime_status.bash | jq '.data.runtimeStatus.runtimeConfiguration.kubeconfig'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   530  100   405  100   125     13      4  0:00:31  0:00:30  0:00:01   104
nil
```

the successful query takes a few ms, returns no error and working kubeconfig, the unsuccessful query takes 30 seconds, also returns no error and has `nil` as kubeconfig

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
