### PR TITLE
Add replace dependency emicklei/restful with v3.8.0

### DIFF
--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -98,7 +98,7 @@ replace (
 )
 
 replace (
-	github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0
+	github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0 //this fixes cve-2022-1996
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.12.2
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898

--- a/components/kyma-metrics-collector/go.mod
+++ b/components/kyma-metrics-collector/go.mod
@@ -98,6 +98,7 @@ replace (
 )
 
 replace (
+	github.com/emicklei/go-restful => github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
 	github.com/prometheus/client_golang => github.com/prometheus/client_golang v1.12.2
 	golang.org/x/crypto => golang.org/x/crypto v0.0.0-20220518034528-6f7dac969898

--- a/components/kyma-metrics-collector/go.sum
+++ b/components/kyma-metrics-collector/go.sum
@@ -636,9 +636,7 @@ github.com/edsrzf/mmap-go v1.0.0/go.mod h1:YO35OhQPt3KJa3ryjFM5Bs14WD66h8eGKpfaB
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20191011121108-aa519ddbe484/go.mod h1:Ro8st/ElPeALwNFlcTpWmkr6IoMFfkjXAvTHpevnDsM=
 github.com/elazarl/goproxy/ext v0.0.0-20190711103511-473e67f1d7d2/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
-github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
-github.com/emicklei/go-restful v2.9.6+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
+github.com/emicklei/go-restful/v3 v3.8.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/emirpasic/gods v1.12.0/go.mod h1:YfzfFFoVP/catgzJb4IKIqXjX78Ha8FMSDh3ymbK86o=
 github.com/emirpasic/gods v1.12.1/go.mod h1:8tpGGwCnJ5H4r6BWwaV6OrWmMoPhUl5jm/FMNAnJvWQ=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1651"
     kyma_metrics_collector:
       dir:
-      version: "PR-1778"
+      version: "1789"
     tests:
       provisioner:
         dir:

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -26,7 +26,7 @@ global:
       version: "PR-1651"
     kyma_metrics_collector:
       dir:
-      version: "1789"
+      version: "PR-1789"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
this pr replaces all versions of the dependency `github.com/emicklei/restful` with `v3.8.0` for security concerns. 