### PR TITLE
Remove rafter component from main e2e test template

### DIFF
--- a/tools/reconciler/e2e-test/template-kyma-main.json
+++ b/tools/reconciler/e2e-test/template-kyma-main.json
@@ -144,16 +144,6 @@
         ]
       },
       {
-        "component": "rafter",
-        "namespace": "kyma-system",
-        "configuration": [
-          {
-            "key": "global.domainName",
-            "value": "example.com"
-          }
-        ]
-      },
-      {
         "component": "helm-broker",
         "namespace": "kyma-system",
         "configuration": [


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
`Rafter` is no longer part of kyma main. This PR removes the component entry in the e2e test template for main test to allow the test job `nightly-main-reconciler-e2e` to pass successfully.
- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/5616
https://github.com/kyma-project/kyma/issues/13155