### PR TITLE
provisioner: add support for Azure multi AZ, having dedicated subnet per zone

### DIFF
--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -21,7 +21,8 @@ func Test_NewGardenerConfigFromJSON(t *testing.T) {
 	gcpConfigJSON := `{"zones":["fix-gcp-zone-1", "fix-gcp-zone-2"]}`
 	azureConfigJSON := `{"vnetCidr":"10.10.11.11/255", "zones":["fix-az-zone-1", "fix-az-zone-2"], "enableNatGateway":true, "idleConnectionTimeoutMinutes":4}`
 	azureNoZonesConfigJSON := `{"vnetCidr":"10.10.11.11/255"}`
-	awsConfigJSON := `{"vpcCidr":"10.10.11.11/255","awsZones":[{"name":"zone","publicCidr":"10.10.11.12/255","internalCidr":"10.10.11.13/255","workerCidr":"10.250.0.0/19"}]}
+	azureZoneSubnetsConfigJSON := `{"vnetCidr":"10.10.11.11/255", "azureZones":[{"name":1,"cidr":"10.10.11.12/255"}, {"name":2,"cidr":"10.10.11.13/255"}], "enableNatGateway":true, "idleConnectionTimeoutMinutes":4}`
+	awsConfigJSON := `{"vpcCidr":"10.10.11.11/255","awsZones":[{"name":"zone","publicCidr":"10.10.11.12/255","internalCidr":"10.10.11.13/255","workerCidr":"10.10.11.11/255"}]}
 `
 	singleZoneAwsConfigJSON := `{"zone":"zone","vpcCidr":"10.10.11.11/255","publicCidr":"10.10.11.12/255","internalCidr":"10.10.11.13/255"}`
 
@@ -59,6 +60,42 @@ func Test_NewGardenerConfigFromJSON(t *testing.T) {
 			expectedProviderSpecificConfig: gqlschema.AzureProviderConfig{VnetCidr: util.StringPtr("10.10.11.11/255")},
 		},
 		{
+			description: "should create Azure Gardener config when subnets per zone input passed",
+			jsonData:    azureZoneSubnetsConfigJSON,
+			expectedConfig: &AzureGardenerConfig{
+				ProviderSpecificConfig: ProviderSpecificConfig(azureZoneSubnetsConfigJSON),
+				input: &gqlschema.AzureProviderConfigInput{
+					VnetCidr: "10.10.11.11/255",
+					AzureZones: []*gqlschema.AzureZoneInput{
+						{
+							Name: 1,
+							Cidr: "10.10.11.12/255",
+						},
+						{
+							Name: 2,
+							Cidr: "10.10.11.13/255",
+						},
+					},
+					EnableNatGateway:             util.BoolPtr(true),
+					IdleConnectionTimeoutMinutes: util.IntPtr(4),
+				},
+			},
+			expectedProviderSpecificConfig: gqlschema.AzureProviderConfig{
+				VnetCidr: util.StringPtr("10.10.11.11/255"),
+				AzureZones: []*gqlschema.AzureZone{
+					{
+						Name: 1,
+						Cidr: "10.10.11.12/255",
+					},
+					{
+						Name: 2,
+						Cidr: "10.10.11.13/255",
+					},
+				},
+				EnableNatGateway:             util.BoolPtr(true),
+				IdleConnectionTimeoutMinutes: util.IntPtr(4)},
+		},
+		{
 			description: "should create AWS Gardener config",
 			jsonData:    awsConfigJSON,
 			expectedConfig: &AWSGardenerConfig{
@@ -69,7 +106,7 @@ func Test_NewGardenerConfigFromJSON(t *testing.T) {
 							Name:         "zone",
 							PublicCidr:   "10.10.11.12/255",
 							InternalCidr: "10.10.11.13/255",
-							WorkerCidr:   "10.250.0.0/19",
+							WorkerCidr:   "10.10.11.11/255",
 						},
 					},
 					VpcCidr: "10.10.11.11/255",
@@ -81,7 +118,7 @@ func Test_NewGardenerConfigFromJSON(t *testing.T) {
 						Name:         util.StringPtr("zone"),
 						PublicCidr:   util.StringPtr("10.10.11.12/255"),
 						InternalCidr: util.StringPtr("10.10.11.13/255"),
-						WorkerCidr:   util.StringPtr("10.250.0.0/19"),
+						WorkerCidr:   util.StringPtr("10.10.11.11/255"),
 					},
 				},
 				VpcCidr: util.StringPtr("10.10.11.11/255"),
@@ -98,7 +135,7 @@ func Test_NewGardenerConfigFromJSON(t *testing.T) {
 							Name:         "zone",
 							PublicCidr:   "10.10.11.12/255",
 							InternalCidr: "10.10.11.13/255",
-							WorkerCidr:   "10.250.0.0/19",
+							WorkerCidr:   "10.10.11.11/255",
 						},
 					},
 					VpcCidr: "10.10.11.11/255",
@@ -110,7 +147,7 @@ func Test_NewGardenerConfigFromJSON(t *testing.T) {
 						Name:         util.StringPtr("zone"),
 						PublicCidr:   util.StringPtr("10.10.11.12/255"),
 						InternalCidr: util.StringPtr("10.10.11.13/255"),
-						WorkerCidr:   util.StringPtr("10.250.0.0/19"),
+						WorkerCidr:   util.StringPtr("10.10.11.11/255"),
 					},
 				},
 				VpcCidr: util.StringPtr("10.10.11.11/255"),
@@ -147,6 +184,9 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 	azureNoZonesGardenerProvider, err := NewAzureGardenerConfig(fixAzureGardenerInput(nil, util.BoolPtr(false)))
 	require.NoError(t, err)
 
+	azureZoneSubnetsGardenerProvider, err := NewAzureGardenerConfig(fixAzureZoneSubnetsInput())
+	require.NoError(t, err)
+
 	awsGardenerProvider, err := NewAWSGardenerConfig(fixAWSGardenerInput())
 	require.NoError(t, err)
 
@@ -173,7 +213,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					CloudProfileName: "gcp",
 					Networking: gardener_types.Networking{
 						Type:  "calico",
-						Nodes: util.StringPtr("10.250.0.0/19"),
+						Nodes: util.StringPtr("10.10.10.10/255"),
 					},
 					SeedName:          util.StringPtr("eu"),
 					SecretBindingName: "gardener-secret",
@@ -245,7 +285,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					CloudProfileName: "az",
 					Networking: gardener_types.Networking{
 						Type:  "calico",
-						Nodes: util.StringPtr("10.250.0.0/19"),
+						Nodes: util.StringPtr("10.10.11.11/255"),
 					},
 					SeedName:          util.StringPtr("eu"),
 					SecretBindingName: "gardener-secret",
@@ -317,7 +357,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					CloudProfileName: "az",
 					Networking: gardener_types.Networking{
 						Type:  "calico",
-						Nodes: util.StringPtr("10.250.0.0/19"),
+						Nodes: util.StringPtr("10.10.11.11/255"),
 					},
 					SeedName:          util.StringPtr("eu"),
 					SecretBindingName: "gardener-secret",
@@ -332,6 +372,78 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						},
 						Workers: []gardener_types.Worker{
 							fixWorker(nil),
+						},
+					},
+					Purpose:           &purpose,
+					ExposureClassName: util.StringPtr("internet"),
+					Kubernetes: gardener_types.Kubernetes{
+						AllowPrivilegedContainers: util.BoolPtr(false),
+						Version:                   "1.15",
+						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
+							EnableBasicAuthentication: util.BoolPtr(false),
+							OIDCConfig:                gardenerOidcConfig(oidcConfig()),
+						},
+					},
+					Maintenance: &gardener_types.Maintenance{
+						AutoUpdate: &gardener_types.MaintenanceAutoUpdate{
+							KubernetesVersion:   true,
+							MachineImageVersion: false,
+						},
+					},
+					DNS: gardenerDnsConfig(dnsConfig()),
+					Extensions: []gardener_types.Extension{
+						{
+							Type: "shoot-dns-service",
+							ProviderConfig: &apimachineryRuntime.RawExtension{
+								Raw: []byte(`{"apiVersion":"service.dns.extensions.gardener.cloud/v1alpha1","dnsProviderReplication":{"enabled":true},"kind":"DNSConfig"}`),
+							},
+						},
+						{
+							Type: "shoot-cert-service",
+							ProviderConfig: &apimachineryRuntime.RawExtension{
+								Raw: []byte(`{"apiVersion":"service.cert.extensions.gardener.cloud/v1alpha1","shootIssuers":{"enabled":true},"kind":"CertConfig"}`),
+							},
+						},
+						{
+							Type:     ShootNetworkingFilterExtensionType,
+							Disabled: util.BoolPtr(true),
+						},
+					},
+				},
+			},
+		},
+		{description: "should convert to Shoot template with Azure provider when subnets per zone passed",
+			provider:       "az",
+			providerConfig: azureZoneSubnetsGardenerProvider,
+			expectedShootTemplate: &gardener_types.Shoot{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "cluster",
+					Namespace: "gardener-namespace",
+					Labels: map[string]string{
+						"account":    "account",
+						"subaccount": "sub-account",
+					},
+					Annotations: map[string]string{},
+				},
+				Spec: gardener_types.ShootSpec{
+					CloudProfileName: "az",
+					Networking: gardener_types.Networking{
+						Type:  "calico",
+						Nodes: util.StringPtr("10.10.11.11/255"),
+					},
+					SeedName:          util.StringPtr("eu"),
+					SecretBindingName: "gardener-secret",
+					Region:            "eu",
+					Provider: gardener_types.Provider{
+						Type: "azure",
+						ControlPlaneConfig: &apimachineryRuntime.RawExtension{
+							Raw: []byte(`{"kind":"ControlPlaneConfig","apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1"}`),
+						},
+						InfrastructureConfig: &apimachineryRuntime.RawExtension{
+							Raw: []byte(`{"kind":"InfrastructureConfig","apiVersion":"azure.provider.extensions.gardener.cloud/v1alpha1","networks":{"vnet":{"cidr":"10.10.11.11/255"},"zones":[{"name":1,"cidr":"10.10.11.12/255","natGateway":{"enabled":true,"idleConnectionTimeoutMinutes":4}},{"name":2,"cidr":"10.10.11.13/255","natGateway":{"enabled":true,"idleConnectionTimeoutMinutes":4}}]},"zoned":true}`),
+						},
+						Workers: []gardener_types.Worker{
+							fixWorker([]string{"1", "2"}),
 						},
 					},
 					Purpose:           &purpose,
@@ -389,7 +501,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					CloudProfileName: "aws",
 					Networking: gardener_types.Networking{
 						Type:  "calico",
-						Nodes: util.StringPtr("10.250.0.0/19"),
+						Nodes: util.StringPtr("10.10.11.11/255"),
 					},
 					SeedName:          util.StringPtr("eu"),
 					SecretBindingName: "gardener-secret",
@@ -629,6 +741,24 @@ func fixGCPGardenerInput(zones []string) *gqlschema.GCPProviderConfigInput {
 
 func fixAzureGardenerInput(zones []string, enableNAT *bool) *gqlschema.AzureProviderConfigInput {
 	return &gqlschema.AzureProviderConfigInput{VnetCidr: "10.10.11.11/255", Zones: zones, EnableNatGateway: enableNAT, IdleConnectionTimeoutMinutes: util.IntPtr(4)}
+}
+
+func fixAzureZoneSubnetsInput() *gqlschema.AzureProviderConfigInput {
+	return &gqlschema.AzureProviderConfigInput{
+		VnetCidr:                     "10.10.11.11/255",
+		EnableNatGateway:             util.BoolPtr(true),
+		IdleConnectionTimeoutMinutes: util.IntPtr(4),
+		AzureZones: []*gqlschema.AzureZoneInput{
+			{
+				Name: 1,
+				Cidr: "10.10.11.12/255",
+			},
+			{
+				Name: 2,
+				Cidr: "10.10.11.13/255",
+			},
+		},
+	}
 }
 
 func fixWorker(zones []string) gardener_types.Worker {

--- a/components/provisioner/internal/model/infrastructure/azure/infrastructure.go
+++ b/components/provisioner/internal/model/infrastructure/azure/infrastructure.go
@@ -26,10 +26,12 @@ type NetworkConfig struct {
 	// VNet indicates whether to use an existing VNet or create a new one.
 	VNet VNet `json:"vnet"`
 	// Workers is the worker subnet range to create (used for the VMs).
-	Workers string `json:"workers"`
+	// +optional
+	Workers *string `json:"workers,omitempty"`
 	// ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the worker subnet.
 	ServiceEndpoints []string    `json:"serviceEndpoints,omitempty"`
 	NatGateway       *NatGateway `json:"natGateway,omitempty"`
+	Zones            []Zone      `json:"zones,omitempty"`
 }
 
 // VNet contains information about the VNet and some related resources.
@@ -54,4 +56,17 @@ type NatGateway struct {
 	Enabled                      bool `json:"enabled"`
 	IdleConnectionTimeoutMinutes int  `json:"idleConnectionTimeoutMinutes"`
 	Zone                         int  `json:"zone,omitempty"`
+}
+
+type Zone struct {
+	// Name is the name of the zone and should match with the name the infrastructure provider is using for the zone.
+	Name int `json:"name"`
+	// CIDR is the CIDR range used for the zone's subnet.
+	CIDR string `json:"cidr"`
+	// ServiceEndpoints is a list of Azure ServiceEndpoints which should be associated with the zone's subnet.
+	// +optional
+	ServiceEndpoints []string `json:"serviceEndpoints,omitempty"`
+	// NatGateway contains the configuration for the NatGateway associated with this subnet.
+	// +optional
+	NatGateway *NatGateway `json:"natGateway,omitempty"`
 }

--- a/components/provisioner/internal/provider-config-migrator/migrator_db_integration_test.go
+++ b/components/provisioner/internal/provider-config-migrator/migrator_db_integration_test.go
@@ -207,3 +207,7 @@ func (c SingleZoneAWSGardenerConfig) EditShootConfig(_ model.GardenerConfig, _ *
 func (c SingleZoneAWSGardenerConfig) ExtendShootConfig(_ model.GardenerConfig, _ *gardener_types.Shoot) apperrors.AppError {
 	return nil
 }
+
+func (c SingleZoneAWSGardenerConfig) ValidateShootConfigChange(shoot *gardener_types.Shoot) apperrors.AppError {
+	return nil
+}

--- a/components/provisioner/internal/provider-config-migrator/migrator_db_integration_test.go
+++ b/components/provisioner/internal/provider-config-migrator/migrator_db_integration_test.go
@@ -192,6 +192,10 @@ type SingleZoneAWSGardenerConfig struct {
 	input *model.SingleZoneAWSProviderConfigInput `db:"-"`
 }
 
+func (c SingleZoneAWSGardenerConfig) NodeCIDR(model.GardenerConfig) string {
+	return c.input.VpcCidr
+}
+
 func (c SingleZoneAWSGardenerConfig) AsProviderSpecificConfig() gqlschema.ProviderSpecificConfig {
 	return nil
 }

--- a/components/provisioner/internal/provisioning/service.go
+++ b/components/provisioner/internal/provisioning/service.go
@@ -255,6 +255,11 @@ func (r *service) UpgradeGardenerShoot(runtimeID string, input gqlschema.Upgrade
 		gardenerConfig.ShootNetworkingFilterDisabled = shootNetworkingFilterDisabled
 	}
 
+	// Validate provider specific changes to the shoot
+	err = gardenerConfig.GardenerProviderConfig.ValidateShootConfigChange(&shoot)
+	if err != nil {
+		return &gqlschema.OperationStatus{}, err.Append("Invalid gardener provider config change")
+	}
 	txSession, dbErr := r.dbSessionFactory.NewSessionWithinTransaction()
 	if dbErr != nil {
 		return &gqlschema.OperationStatus{}, apperrors.Internal("Failed to start database transaction: %s", dbErr.Error())

--- a/components/provisioner/pkg/gqlschema/models_gen.go
+++ b/components/provisioner/pkg/gqlschema/models_gen.go
@@ -39,19 +39,31 @@ type AWSZoneInput struct {
 }
 
 type AzureProviderConfig struct {
-	VnetCidr                     *string  `json:"vnetCidr"`
-	Zones                        []string `json:"zones"`
-	EnableNatGateway             *bool    `json:"enableNatGateway"`
-	IdleConnectionTimeoutMinutes *int     `json:"idleConnectionTimeoutMinutes"`
+	VnetCidr                     *string      `json:"vnetCidr"`
+	Zones                        []string     `json:"zones"`
+	AzureZones                   []*AzureZone `json:"azureZones"`
+	EnableNatGateway             *bool        `json:"enableNatGateway"`
+	IdleConnectionTimeoutMinutes *int         `json:"idleConnectionTimeoutMinutes"`
 }
 
 func (AzureProviderConfig) IsProviderSpecificConfig() {}
 
 type AzureProviderConfigInput struct {
-	VnetCidr                     string   `json:"vnetCidr"`
-	Zones                        []string `json:"zones"`
-	EnableNatGateway             *bool    `json:"enableNatGateway"`
-	IdleConnectionTimeoutMinutes *int     `json:"idleConnectionTimeoutMinutes"`
+	VnetCidr                     string            `json:"vnetCidr"`
+	Zones                        []string          `json:"zones"`
+	AzureZones                   []*AzureZoneInput `json:"azureZones"`
+	EnableNatGateway             *bool             `json:"enableNatGateway"`
+	IdleConnectionTimeoutMinutes *int              `json:"idleConnectionTimeoutMinutes"`
+}
+
+type AzureZone struct {
+	Name int    `json:"name"`
+	Cidr string `json:"cidr"`
+}
+
+type AzureZoneInput struct {
+	Name int    `json:"name"`
+	Cidr string `json:"cidr"`
 }
 
 type ClusterConfigInput struct {

--- a/components/provisioner/pkg/gqlschema/schema.graphql
+++ b/components/provisioner/pkg/gqlschema/schema.graphql
@@ -56,6 +56,7 @@ type GCPProviderConfig {
 type AzureProviderConfig {
     vnetCidr: String
     zones: [String!]
+    azureZones: [AzureZone!]
     enableNatGateway: Boolean
     idleConnectionTimeoutMinutes: Int
 }
@@ -70,6 +71,11 @@ type OpenStackProviderConfig {
     floatingPoolName: String!
     cloudProfileName: String!
     loadBalancerProvider: String!
+}
+
+type AzureZone {
+    name: Int!
+    cidr: String!
 }
 
 type AWSZone {
@@ -264,7 +270,8 @@ input GCPProviderConfigInput {
 
 input AzureProviderConfigInput {
     vnetCidr: String!   # Classless Inter-Domain Routing for the Azure Virtual Network
-    zones: [String!]      # Zones in which to create the cluster
+    zones: [String!]      # Zones in which to create the cluster. DEPRECATED
+    azureZones: [AzureZoneInput!]! # Zones in which to create the cluster, with dedicated subnet and NAT Gateway per zone configuration
     enableNatGateway: Boolean # Enables NAT Gateway. Set to false by default
     idleConnectionTimeoutMinutes: Int # timeout for NAT Gateway. Used only if enableNatGateway is set to true. Default is 4 minutes
 }
@@ -286,6 +293,11 @@ input AWSZoneInput {
     publicCidr: String!     # Classless Inter-Domain Routing for the public subnet
     internalCidr: String!   # Classless Inter-Domain Routing for the private subnet
     workerCidr: String!     # Classless Inter-Domain Routing range for the nodes
+}
+
+input AzureZoneInput {
+    name: Int!                        # Name of the zone. Should match with the name the infrastructure provider is using for the zone.
+    cidr: String!                     # CIDR range used for the zone's subnet.
 }
 
 input KymaConfigInput {

--- a/components/provisioner/pkg/gqlschema/schema_gen.go
+++ b/components/provisioner/pkg/gqlschema/schema_gen.go
@@ -55,10 +55,16 @@ type ComplexityRoot struct {
 	}
 
 	AzureProviderConfig struct {
+		AzureZones                   func(childComplexity int) int
 		EnableNatGateway             func(childComplexity int) int
 		IdleConnectionTimeoutMinutes func(childComplexity int) int
 		VnetCidr                     func(childComplexity int) int
 		Zones                        func(childComplexity int) int
+	}
+
+	AzureZone struct {
+		Cidr func(childComplexity int) int
+		Name func(childComplexity int) int
 	}
 
 	ComponentConfiguration struct {
@@ -271,6 +277,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 
 		return e.complexity.AWSZone.WorkerCidr(childComplexity), true
 
+	case "AzureProviderConfig.azureZones":
+		if e.complexity.AzureProviderConfig.AzureZones == nil {
+			break
+		}
+
+		return e.complexity.AzureProviderConfig.AzureZones(childComplexity), true
+
 	case "AzureProviderConfig.enableNatGateway":
 		if e.complexity.AzureProviderConfig.EnableNatGateway == nil {
 			break
@@ -298,6 +311,20 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AzureProviderConfig.Zones(childComplexity), true
+
+	case "AzureZone.cidr":
+		if e.complexity.AzureZone.Cidr == nil {
+			break
+		}
+
+		return e.complexity.AzureZone.Cidr(childComplexity), true
+
+	case "AzureZone.name":
+		if e.complexity.AzureZone.Name == nil {
+			break
+		}
+
+		return e.complexity.AzureZone.Name(childComplexity), true
 
 	case "ComponentConfiguration.component":
 		if e.complexity.ComponentConfiguration.Component == nil {
@@ -1054,6 +1081,7 @@ type GCPProviderConfig {
 type AzureProviderConfig {
     vnetCidr: String
     zones: [String!]
+    azureZones: [AzureZone!]
     enableNatGateway: Boolean
     idleConnectionTimeoutMinutes: Int
 }
@@ -1068,6 +1096,11 @@ type OpenStackProviderConfig {
     floatingPoolName: String!
     cloudProfileName: String!
     loadBalancerProvider: String!
+}
+
+type AzureZone {
+    name: Int!
+    cidr: String!
 }
 
 type AWSZone {
@@ -1262,7 +1295,8 @@ input GCPProviderConfigInput {
 
 input AzureProviderConfigInput {
     vnetCidr: String!   # Classless Inter-Domain Routing for the Azure Virtual Network
-    zones: [String!]      # Zones in which to create the cluster
+    zones: [String!]      # Zones in which to create the cluster. DEPRECATED
+    azureZones: [AzureZoneInput!]! # Zones in which to create the cluster, with dedicated subnet and NAT Gateway per zone configuration
     enableNatGateway: Boolean # Enables NAT Gateway. Set to false by default
     idleConnectionTimeoutMinutes: Int # timeout for NAT Gateway. Used only if enableNatGateway is set to true. Default is 4 minutes
 }
@@ -1284,6 +1318,11 @@ input AWSZoneInput {
     publicCidr: String!     # Classless Inter-Domain Routing for the public subnet
     internalCidr: String!   # Classless Inter-Domain Routing for the private subnet
     workerCidr: String!     # Classless Inter-Domain Routing range for the nodes
+}
+
+input AzureZoneInput {
+    name: Int!                        # Name of the zone. Should match with the name the infrastructure provider is using for the zone.
+    cidr: String!                     # CIDR range used for the zone's subnet.
 }
 
 input KymaConfigInput {
@@ -1814,6 +1853,37 @@ func (ec *executionContext) _AzureProviderConfig_zones(ctx context.Context, fiel
 	return ec.marshalOString2ᚕstringᚄ(ctx, field.Selections, res)
 }
 
+func (ec *executionContext) _AzureProviderConfig_azureZones(ctx context.Context, field graphql.CollectedField, obj *AzureProviderConfig) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "AzureProviderConfig",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.AzureZones, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.([]*AzureZone)
+	fc.Result = res
+	return ec.marshalOAzureZone2ᚕᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneᚄ(ctx, field.Selections, res)
+}
+
 func (ec *executionContext) _AzureProviderConfig_enableNatGateway(ctx context.Context, field graphql.CollectedField, obj *AzureProviderConfig) (ret graphql.Marshaler) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -1874,6 +1944,74 @@ func (ec *executionContext) _AzureProviderConfig_idleConnectionTimeoutMinutes(ct
 	res := resTmp.(*int)
 	fc.Result = res
 	return ec.marshalOInt2ᚖint(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AzureZone_name(ctx context.Context, field graphql.CollectedField, obj *AzureZone) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "AzureZone",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Name, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(int)
+	fc.Result = res
+	return ec.marshalNInt2int(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) _AzureZone_cidr(ctx context.Context, field graphql.CollectedField, obj *AzureZone) (ret graphql.Marshaler) {
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	fc := &graphql.FieldContext{
+		Object:   "AzureZone",
+		Field:    field,
+		Args:     nil,
+		IsMethod: false,
+	}
+
+	ctx = graphql.WithFieldContext(ctx, fc)
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Cidr, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNString2string(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) _ComponentConfiguration_component(ctx context.Context, field graphql.CollectedField, obj *ComponentConfiguration) (ret graphql.Marshaler) {
@@ -5829,6 +5967,12 @@ func (ec *executionContext) unmarshalInputAzureProviderConfigInput(ctx context.C
 			if err != nil {
 				return it, err
 			}
+		case "azureZones":
+			var err error
+			it.AzureZones, err = ec.unmarshalNAzureZoneInput2ᚕᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneInputᚄ(ctx, v)
+			if err != nil {
+				return it, err
+			}
 		case "enableNatGateway":
 			var err error
 			it.EnableNatGateway, err = ec.unmarshalOBoolean2ᚖbool(ctx, v)
@@ -5838,6 +5982,30 @@ func (ec *executionContext) unmarshalInputAzureProviderConfigInput(ctx context.C
 		case "idleConnectionTimeoutMinutes":
 			var err error
 			it.IdleConnectionTimeoutMinutes, err = ec.unmarshalOInt2ᚖint(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		}
+	}
+
+	return it, nil
+}
+
+func (ec *executionContext) unmarshalInputAzureZoneInput(ctx context.Context, obj interface{}) (AzureZoneInput, error) {
+	var it AzureZoneInput
+	var asMap = obj.(map[string]interface{})
+
+	for k, v := range asMap {
+		switch k {
+		case "name":
+			var err error
+			it.Name, err = ec.unmarshalNInt2int(ctx, v)
+			if err != nil {
+				return it, err
+			}
+		case "cidr":
+			var err error
+			it.Cidr, err = ec.unmarshalNString2string(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -6686,10 +6854,44 @@ func (ec *executionContext) _AzureProviderConfig(ctx context.Context, sel ast.Se
 			out.Values[i] = ec._AzureProviderConfig_vnetCidr(ctx, field, obj)
 		case "zones":
 			out.Values[i] = ec._AzureProviderConfig_zones(ctx, field, obj)
+		case "azureZones":
+			out.Values[i] = ec._AzureProviderConfig_azureZones(ctx, field, obj)
 		case "enableNatGateway":
 			out.Values[i] = ec._AzureProviderConfig_enableNatGateway(ctx, field, obj)
 		case "idleConnectionTimeoutMinutes":
 			out.Values[i] = ec._AzureProviderConfig_idleConnectionTimeoutMinutes(ctx, field, obj)
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch()
+	if invalids > 0 {
+		return graphql.Null
+	}
+	return out
+}
+
+var azureZoneImplementors = []string{"AzureZone"}
+
+func (ec *executionContext) _AzureZone(ctx context.Context, sel ast.SelectionSet, obj *AzureZone) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, azureZoneImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	var invalids uint32
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("AzureZone")
+		case "name":
+			out.Values[i] = ec._AzureZone_name(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
+		case "cidr":
+			out.Values[i] = ec._AzureZone_cidr(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -7681,6 +7883,52 @@ func (ec *executionContext) unmarshalNAWSZoneInput2ᚕᚖgithubᚗcomᚋkymaᚑp
 	return res, nil
 }
 
+func (ec *executionContext) marshalNAzureZone2githubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZone(ctx context.Context, sel ast.SelectionSet, v AzureZone) graphql.Marshaler {
+	return ec._AzureZone(ctx, sel, &v)
+}
+
+func (ec *executionContext) marshalNAzureZone2ᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZone(ctx context.Context, sel ast.SelectionSet, v *AzureZone) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	return ec._AzureZone(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalNAzureZoneInput2githubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneInput(ctx context.Context, v interface{}) (AzureZoneInput, error) {
+	return ec.unmarshalInputAzureZoneInput(ctx, v)
+}
+
+func (ec *executionContext) unmarshalNAzureZoneInput2ᚕᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneInputᚄ(ctx context.Context, v interface{}) ([]*AzureZoneInput, error) {
+	var vSlice []interface{}
+	if v != nil {
+		if tmp1, ok := v.([]interface{}); ok {
+			vSlice = tmp1
+		} else {
+			vSlice = []interface{}{v}
+		}
+	}
+	var err error
+	res := make([]*AzureZoneInput, len(vSlice))
+	for i := range vSlice {
+		res[i], err = ec.unmarshalNAzureZoneInput2ᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneInput(ctx, vSlice[i])
+		if err != nil {
+			return nil, err
+		}
+	}
+	return res, nil
+}
+
+func (ec *executionContext) unmarshalNAzureZoneInput2ᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneInput(ctx context.Context, v interface{}) (*AzureZoneInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalNAzureZoneInput2githubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneInput(ctx, v)
+	return &res, err
+}
+
 func (ec *executionContext) unmarshalNBoolean2bool(ctx context.Context, v interface{}) (bool, error) {
 	return graphql.UnmarshalBoolean(v)
 }
@@ -8168,6 +8416,46 @@ func (ec *executionContext) unmarshalOAzureProviderConfigInput2ᚖgithubᚗcom�
 	}
 	res, err := ec.unmarshalOAzureProviderConfigInput2githubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureProviderConfigInput(ctx, v)
 	return &res, err
+}
+
+func (ec *executionContext) marshalOAzureZone2ᚕᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZoneᚄ(ctx context.Context, sel ast.SelectionSet, v []*AzureZone) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	ret := make(graphql.Array, len(v))
+	var wg sync.WaitGroup
+	isLen1 := len(v) == 1
+	if !isLen1 {
+		wg.Add(len(v))
+	}
+	for i := range v {
+		i := i
+		fc := &graphql.FieldContext{
+			Index:  &i,
+			Result: &v[i],
+		}
+		ctx := graphql.WithFieldContext(ctx, fc)
+		f := func(i int) {
+			defer func() {
+				if r := recover(); r != nil {
+					ec.Error(ctx, ec.Recover(ctx, r))
+					ret = nil
+				}
+			}()
+			if !isLen1 {
+				defer wg.Done()
+			}
+			ret[i] = ec.marshalNAzureZone2ᚖgithubᚗcomᚋkymaᚑprojectᚋcontrolᚑplaneᚋcomponentsᚋprovisionerᚋpkgᚋgqlschemaᚐAzureZone(ctx, sel, v[i])
+		}
+		if isLen1 {
+			f(i)
+		} else {
+			go f(i)
+		}
+
+	}
+	wg.Wait()
+	return ret
 }
 
 func (ec *executionContext) unmarshalOBoolean2bool(ctx context.Context, v interface{}) (bool, error) {

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -9,7 +9,7 @@ global:
       version: "4650dbfb"
     provisioner:
       dir:
-      version: "PR-1746"
+      version: "PR-1815"
     kyma_environment_broker:
       dir:
       version: "PR-1788"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- `.spec.networking.nodes` is configured provider specific way, as per suggestion from Gardener documentation. For Azure, it's the same as the VNET CIDR. For AWS, it's the VPC CIDR. For GCP, it's the Worker CIDR from GardenerConfig, which is used to configure the regional VPC subnet.
- `GardenerConfigInput` is extended to support specifying multiple Azure zones, using the [dedicated subnet per zone](https://github.com/gardener/gardener-extension-provider-azure/blob/master/docs/usage-as-end-user.md#infrastructureconfig-with-dedicated-subnets-per-zone) config which also enables zone redundant NAT Gateway. API change is backwards compatible with the current model, so both the old config input (single AZ zoned cluster) and the new config input (multi-AZ zoned cluster) is supported.
- Gardener config model code was adjusted to support both current and new (multi-AZ with subnets per zone) Azure configuration scheme

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
