### PR TITLE
enhancement: increase initialDelaySeconds for kubeconfig-service

### DIFF
--- a/resources/oidc-kubeconfig-service/templates/deployment.yaml
+++ b/resources/oidc-kubeconfig-service/templates/deployment.yaml
@@ -65,9 +65,9 @@ spec:
             httpGet:
               path: /health/ready
               port: health
-            initialDelaySeconds: 30
-            timeoutSeconds: 1
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.global.livenessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.global.livenessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.global.livenessProbe.periodSeconds }}
           readinessProbe:
             httpGet:
               path: /health/ready

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -10,6 +10,10 @@ global:
     gateway:
       name: "kyma-gateway"
       namespace: "kyma-system"
+  livenessProbe:
+    initialDelaySeconds: 180
+    timeoutSeconds: 1
+    periodSeconds: 10
 
 replicaCount: 1
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- increase initialDelaySeconds for oidc-kubeconfig-service from 30s to 180s
