### PR TITLE
Allow authenticated access to KEB /runtimes to specified principals

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/authorization-policy.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/authorization-policy.yaml
@@ -123,6 +123,19 @@ spec:
       values:
       - {{ .Values.oidc.groups.admin }}
       - {{ .Values.oidc.groups.operator }}
+  - to:
+    - operation:
+        methods:
+        - GET
+        paths:
+        - /runtimes
+    from:
+    - source:
+        principals:
+{{- with .Values.runtimeAllowedPrincipals }}
+{{ tpl . $ | indent 10 }}
+{{- end }}
+
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ include "kyma-env-broker.name" . }}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -222,6 +222,9 @@ oidc:
 kebClient:
   scope: "broker:write cld:read"
 
+runtimeAllowedPrincipals: |-
+  - cluster.local/ns/kcp-system/sa/kcp-kyma-metrics-collector
+
 environmentsCleanup:
   schedule: "0 0 * * *"
   maxAge: "24h"


### PR DESCRIPTION

**Description**

Allow authenticated access to KEB /runtimes to specified principals. 
KMC and mop-agent will have to be allowed to use the API.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
