### PR TITLE
Fix pre-main-control-plane-reconciler-e2e-latest-release

### DIFF
--- a/tools/reconciler/e2e-test/template-kyma-2-4-x.json
+++ b/tools/reconciler/e2e-test/template-kyma-2-4-x.json
@@ -124,16 +124,6 @@
         ]
       },
       {
-        "component": "rafter",
-        "namespace": "kyma-system",
-        "configuration": [
-          {
-            "key": "global.domainName",
-            "value": "example.com"
-          }
-        ]
-      },
-      {
         "component": "cluster-users",
         "namespace": "kyma-system",
         "configuration": [


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Removed `rafter` from 2.4.x template

**Related PR(s)**
https://github.com/kyma-project/control-plane/pull/1829
