### PR TITLE
Move getkubeconfig step before btp overrides step in the upgrade kyma…

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -922,6 +922,10 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 			cnd:    upgrade_kyma.ForKyma2,
 		},
 		{
+			weight: 2,
+			step:   upgrade_kyma.NewGetKubeconfigStep(db.Operations(), provisionerClient),
+		},
+		{
 			weight: 3,
 			cnd:    upgrade_kyma.WhenBTPOperatorCredentialsProvided,
 			step:   upgrade_kyma.NewBTPOperatorOverridesStep(db.Operations()),
@@ -940,14 +944,8 @@ func NewKymaOrchestrationProcessingQueue(ctx context.Context, db storage.BrokerS
 			disabled: cfg.Notification.Disabled,
 		},
 		{
-			weight: 9,
-			step:   upgrade_kyma.NewGetKubeconfigStep(db.Operations(), provisionerClient),
-			cnd:    upgrade_kyma.ForKyma2,
-		},
-		{
 			weight: 10,
 			step:   upgrade_kyma.NewApplyClusterConfigurationStep(db.Operations(), db.RuntimeStates(), reconcilerClient),
-			cnd:    upgrade_kyma.ForKyma2,
 		},
 	}
 	for _, step := range upgradeKymaSteps {

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1831"
+      version: "PR-1857"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1749"


### PR DESCRIPTION
… process

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
 - get kubeconfig step must be run before btp overrides step in the upgrade kyma process

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
