### PR TITLE
Stop reporting error metrics from KMC if secrets or shoots are not found

### DIFF
--- a/components/kyma-metrics-collector/README.md
+++ b/components/kyma-metrics-collector/README.md
@@ -52,12 +52,12 @@ Kyma Metrics Collector comes with the following environment variables:
 - Run a deployment in a currently configured k8s cluster:
 >**NOTE:** In order to do this, you need a token from a secret `kcp-kyma-metrics-collector`.
 ```
-ko apply -f dev/  
+ko apply -f dev/
 ```
 
 - Resolve all dependencies:
 ```
-make gomod-vendor
+make resolve-local
 ```
 
 - Run tests:
@@ -78,7 +78,7 @@ make test-alerts
 ### Troubleshooting
 - Check logs:
 ```
-kubectl logs -l app=kyma-metrics-collector -n kcp-system -c kyma-metrics-collector -f
+kubectl logs -f -n kcp-system $(kubectl get po -n kcp-system -l 'app=kmc-dev' -oname) kmc-dev
 ```
 
 ### Data collection

--- a/components/kyma-metrics-collector/dev/deployment.yaml
+++ b/components/kyma-metrics-collector/dev/deployment.yaml
@@ -1,17 +1,16 @@
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app: kyma-metrics-collector
-  name: kyma-metrics-collector
+    app: kmc-dev
+  name: kmc-dev
   namespace: kcp-system
 spec:
   replicas: 1
   revisionHistoryLimit: 10
   selector:
     matchLabels:
-      app: kyma-metrics-collector
+      app: kmc-dev
   strategy:
     rollingUpdate:
       maxSurge: 25%
@@ -20,32 +19,46 @@ spec:
   template:
     metadata:
       labels:
-        app: kyma-metrics-collector
+        app: kmc-dev
     spec:
       containers:
-      - image: ko://github.com/kyma-project/control-plane/kyma-metrics-collector/cmd
+      - image: ko://github.com/kyma-project/control-plane/components/kyma-metrics-collector/cmd
         imagePullPolicy: Always
-        name: kyma-metrics-collector
+        name: kmc-dev
         args:
-          - "-log-level=debug"
+          - --scrape-interval=5m
+          - --worker-pool-size=5
+          - --log-level=debug
+          - --listen-addr=8080
+          - --gardener-namespace=garden-kyma-dev
         env:
-          - name: PUBLIC_CLOUD_SPECS
-            valueFrom:
-              configMapKeyRef:
-                name: public-cloud-specs
-                key: providers
-          - name: KEB_URL
-            value: http://kcp-kyma-environment-broker.kcp-system/runtimes
           - name: EDP_URL
-#           value: http://edp-mock.kcp-system:8080
+            value: http://edp-mock.kcp-system:8080
           - name: EDP_NAMESPACE
             value: kyma-dev
+          - name: EDP_TIMEOUT
+            value: 1s
+          - name: EDP_RETRY
+            value: "1"
           - name: EDP_DATASTREAM_NAME
             value: consumption-metrics-new-test
           - name: EDP_DATASTREAM_VERSION
             value: "1"
           - name: EDP_DATASTREAM_ENV
             value: dev
+          - name: KEB_URL
+            value: http://kcp-kyma-environment-broker.kcp-system/runtimes
+          - name: KEB_TIMEOUT
+            value: 30s
+          - name: KEB_RETRY_COUNT
+            value: "5"
+          - name: KEB_POLL_WAIT_DURATION
+            value: 10m
+          - name: PUBLIC_CLOUD_SPECS
+            valueFrom:
+              configMapKeyRef:
+                key: providers
+                name: kcp-kyma-metrics-collector-public-cloud-spec
         volumeMounts:
           - mountPath: /gardener
             name: gardener-kubeconfig
@@ -53,20 +66,25 @@ spec:
           - mountPath: /edp-credentials
             name: edp
             readOnly: true
+          - mountPath: /tmp
+            name: tmp
         ports:
         - containerPort: 8080
           name: http
           protocol: TCP
-
-        ## readiness and liveness probe
       restartPolicy: Always
       schedulerName: default-scheduler
+      serviceAccountName: kcp-kyma-metrics-collector
       terminationGracePeriodSeconds: 30
       volumes:
       - name: gardener-kubeconfig
         secret:
+          defaultMode: 420
           secretName: gardener-credentials
       - name: edp
         secret:
-          secretName: kyma-metrics-collector
-
+          defaultMode: 420
+          secretName: kcp-kyma-metrics-collector
+      - emptyDir: {}
+        name: tmp
+---

--- a/components/kyma-metrics-collector/pkg/gardener/secret/client_test.go
+++ b/components/kyma-metrics-collector/pkg/gardener/secret/client_test.go
@@ -53,10 +53,10 @@ func TestGet(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.BeNil())
 	g.Expect(k8sErrors.IsNotFound(err)).To(gomega.BeTrue())
 	// Test metric
-	g.Expect(testutil.CollectAndCount(gardenercommons.TotalCalls, metricName)).Should(gomega.Equal(2))
+	g.Expect(testutil.CollectAndCount(gardenercommons.TotalCalls, metricName)).Should(gomega.Equal(1))
 	callsFailure, err := gardenercommons.TotalCalls.GetMetricWithLabelValues(gardenercommons.FailureStatusLabel, nonexistentShoot, gardenercommons.FailedGettingSecretLabel)
 	g.Expect(err).Should(gomega.BeNil())
-	g.Expect(testutil.ToFloat64(callsFailure)).Should(gomega.Equal(float64(1)))
+	g.Expect(testutil.ToFloat64(callsFailure)).Should(gomega.Equal(float64(0)))
 }
 
 func NewFakeClient(secret *corev1.Secret) (dynamic.ResourceInterface, error) {

--- a/components/kyma-metrics-collector/pkg/gardener/shoot/client_test.go
+++ b/components/kyma-metrics-collector/pkg/gardener/shoot/client_test.go
@@ -43,10 +43,10 @@ func TestGet(t *testing.T) {
 	g.Expect(err).ShouldNot(gomega.BeNil())
 	g.Expect(k8sErrors.IsNotFound(err)).To(gomega.BeTrue())
 	// Test metric
-	g.Expect(testutil.CollectAndCount(gardenercommons.TotalCalls, metricName)).Should(gomega.Equal(2))
+	g.Expect(testutil.CollectAndCount(gardenercommons.TotalCalls, metricName)).Should(gomega.Equal(1))
 	callsFailure, err := gardenercommons.TotalCalls.GetMetricWithLabelValues(gardenercommons.FailureStatusLabel, nonexistentShoot, gardenercommons.FailedGettingShootLabel)
 	g.Expect(err).Should(gomega.BeNil())
-	g.Expect(testutil.ToFloat64(callsFailure)).Should(gomega.Equal(float64(1)))
+	g.Expect(testutil.ToFloat64(callsFailure)).Should(gomega.Equal(float64(0)))
 }
 
 func NewFakeClient(shoot *gardenerv1beta1.Shoot) (dynamic.ResourceInterface, error) {

--- a/components/kyma-metrics-collector/pkg/logger/logger.go
+++ b/components/kyma-metrics-collector/pkg/logger/logger.go
@@ -35,6 +35,9 @@ const (
 	// KeyRequeue is used as named key for a log message which indicates that it will be requeued
 	KeyRequeue = "requeue"
 
+	// KeyShoot is used as a named key for a log message with shoot.
+	KeyShoot = "shoot"
+
 	// ValueFail is used as a value for a log message with failure.
 	ValueFail = "fail"
 

--- a/components/kyma-metrics-collector/pkg/process/process.go
+++ b/components/kyma-metrics-collector/pkg/process/process.go
@@ -80,6 +80,7 @@ func (p Process) generateRecordWithNewMetrics(identifier int, subAccountID strin
 		var secret *corev1.Secret
 		secret, err = p.SecretClient.Get(ctx, shootName)
 		if err != nil {
+			p.namedLogger().With(log.KeyError, err.Error()).With(log.KeyShoot, shootName).Error("Failed to get secret")
 			return
 		}
 
@@ -94,6 +95,7 @@ func (p Process) generateRecordWithNewMetrics(identifier int, subAccountID strin
 	var shoot *gardenerv1beta1.Shoot
 	shoot, err = p.ShootClient.Get(ctx, shootName)
 	if err != nil {
+		p.namedLogger().With(log.KeyError, err.Error()).With(log.KeyShoot, shootName).Error("Failed to get shoot")
 		return
 	}
 
@@ -391,7 +393,7 @@ func (p *Process) populateCacheAndQueue(runtimes *kebruntime.RuntimesPage) {
 				if err != nil {
 					p.namedLogger().With(log.KeyResult, log.ValueFail).With(log.KeyError, err.Error()).
 						With(log.KeySubAccountID, runtime.SubAccountID).With(log.KeyRuntimeID, runtime.RuntimeID).
-						Error("add subAccountID to cache hence skipping queueing it")
+						Error("Failed to add subAccountID to cache hence skipping queueing it")
 					continue
 				}
 				p.Queue.Add(runtime.SubAccountID)

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -17,7 +17,7 @@ global:
       version: "PR-1651"
     kyma_metrics_collector:
       dir:
-      version: "PR-1861"
+      version: "PR-1864"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Stop reporting error metrics from KMC if secrets or shoots are not found.
- Fix the development mode deployment.

**Related issue(s)**

- https://github.com/kyma-project/control-plane/issues/1640
