### PR TITLE
Generic storage helper

### DIFF
--- a/components/kyma-environment-broker/internal/process/operation_manager.go
+++ b/components/kyma-environment-broker/internal/process/operation_manager.go
@@ -1,0 +1,129 @@
+package process
+
+import (
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
+	"github.com/pkg/errors"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+
+	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/sirupsen/logrus"
+)
+
+type OperationManager struct {
+	storage storage.Operations
+}
+
+func NewOperationManager(storage storage.Operations) *OperationManager {
+	return &OperationManager{storage: storage}
+}
+
+// OperationSucceeded marks the operation as succeeded and only repeats it if there is a storage error
+func (om *OperationManager) OperationSucceeded(operation internal.Operation, description string, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	op, repeat, _ := om.update(operation, domain.Succeeded, description, log)
+	// repeat in case of storage error
+	if repeat != 0 {
+		return op, repeat, nil
+	}
+
+	return op, 0, nil
+}
+
+// OperationFailed marks the operation as failed and only repeats it if there is a storage error
+func (om *OperationManager) OperationFailed(operation internal.Operation, description string, err error, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	op, repeat, _ := om.update(operation, domain.Failed, description, log)
+	// repeat in case of storage error
+	if repeat != 0 {
+		return op, repeat, nil
+	}
+
+	var retErr error
+	if err == nil {
+		// no exact err passed in
+		retErr = errors.New(description)
+	} else {
+		// keep the original err object for error categorizer
+		retErr = errors.Wrap(err, description)
+	}
+
+	return op, 0, retErr
+}
+
+// OperationSucceeded marks the operation as succeeded and only repeats it if there is a storage error
+func (om *OperationManager) OperationCanceled(operation internal.Operation, description string, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	op, repeat, _ := om.update(operation, orchestration.Canceled, description, log)
+	if repeat != 0 {
+		return op, repeat, nil
+	}
+
+	return op, 0, nil
+}
+
+// RetryOperation retries an operation for at maxTime in retryInterval steps and fails the operation if retrying failed
+func (om *OperationManager) RetryOperation(operation internal.Operation, errorMessage string, err error, retryInterval time.Duration, maxTime time.Duration, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	since := time.Since(operation.UpdatedAt)
+
+	log.Infof("Retry Operation was triggered with message: %s", errorMessage)
+	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
+	if since < maxTime {
+		return operation, retryInterval, nil
+	}
+	log.Errorf("Aborting after %s of failing retries", maxTime.String())
+	return om.OperationFailed(operation, errorMessage, err, log)
+}
+
+// UpdateOperation updates a given operation and handles conflict situation
+func (om *OperationManager) UpdateOperation(operation internal.Operation, update func(operation *internal.Operation), log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	update(&operation)
+	op, err := om.storage.UpdateOperation(operation)
+	switch {
+	case dberr.IsConflict(err):
+		{
+			op, err := om.storage.GetOperationByID(operation.ID)
+			if err != nil {
+				log.Errorf("while getting operation: %v", err)
+				return operation, 1 * time.Minute, err
+			}
+			update(op)
+			op, err = om.storage.UpdateOperation(*op)
+			if err != nil {
+				log.Errorf("while updating operation after conflict: %v", err)
+				return operation, 1 * time.Minute, err
+			}
+		}
+	case err != nil:
+		log.Errorf("while updating operation: %v", err)
+		return operation, 1 * time.Minute, err
+	}
+	return *op, 0, nil
+}
+
+// RetryOperationWithoutFail retries an operation for at maxTime in retryInterval steps and omits the operation if retrying failed
+func (om *OperationManager) RetryOperationWithoutFail(operation internal.Operation, description string, retryInterval, maxTime time.Duration, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	since := time.Since(operation.UpdatedAt)
+
+	log.Infof("Retry Operation was triggered with message: %s", description)
+	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
+	if since < maxTime {
+		return operation, retryInterval, nil
+	}
+	// update description to track failed steps
+	op, repeat, _ := om.update(operation, domain.InProgress, description, log)
+	if repeat != 0 {
+		return op, repeat, nil
+	}
+
+	log.Errorf("Omitting after %s of failing retries", maxTime.String())
+	return op, 0, nil
+}
+
+func (om *OperationManager) update(operation internal.Operation, state domain.LastOperationState, description string, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	return om.UpdateOperation(operation, func(operation *internal.Operation) {
+		operation.State = state
+		operation.Description = description
+	}, log)
+}

--- a/components/kyma-environment-broker/internal/process/operation_manager_test.go
+++ b/components/kyma-environment-broker/internal/process/operation_manager_test.go
@@ -1,0 +1,79 @@
+package process
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+)
+
+func Test_OperationManager_RetryOperationOnce(t *testing.T) {
+	// given
+	memory := storage.NewMemoryStorage()
+	operations := memory.Operations()
+	opManager := NewOperationManager(operations)
+	op := internal.Operation{}
+	op.UpdatedAt = time.Now()
+	retryInterval := time.Hour
+	errMsg := errors.New("ups ... ")
+
+	// this is required to avoid storage retries (without this statement there will be an error => retry)
+	err := operations.InsertOperation(op)
+	require.NoError(t, err)
+
+	// then - first call
+	op, when, err := opManager.RetryOperationOnce(op, errMsg.Error(), errMsg, retryInterval, fixLogger())
+
+	// when - first retry
+	assert.True(t, when > 0)
+	assert.Nil(t, err)
+
+	// then - second call
+	t.Log(op.UpdatedAt.String())
+	op.UpdatedAt = op.UpdatedAt.Add(-retryInterval - time.Second) // simulate wait of first retry
+	t.Log(op.UpdatedAt.String())
+	op, when, err = opManager.RetryOperationOnce(op, errMsg.Error(), errMsg, retryInterval, fixLogger())
+
+	// when - second call => no retry
+	assert.True(t, when == 0)
+	assert.NotNil(t, err)
+}
+
+func Test_OperationManager_RetryOperation(t *testing.T) {
+	// given
+	memory := storage.NewMemoryStorage()
+	operations := memory.Operations()
+	opManager := NewOperationManager(operations)
+	op := internal.Operation{}
+	op.UpdatedAt = time.Now()
+	retryInterval := time.Hour
+	errorMessage := "ups ... "
+	errOut := errors.New("error occurred")
+	maxtime := time.Hour * 3 // allow 2 retries
+
+	// this is required to avoid storage retries (without this statement there will be an error => retry)
+	err := operations.InsertOperation(op)
+	require.NoError(t, err)
+
+	// then - first call
+	op, when, err := opManager.RetryOperation(op, errorMessage, errOut, retryInterval, maxtime, fixLogger())
+
+	// when - first retry
+	assert.True(t, when > 0)
+	assert.Nil(t, err)
+
+	// then - second call
+	t.Log(op.UpdatedAt.String())
+	op.UpdatedAt = op.UpdatedAt.Add(-retryInterval - time.Second) // simulate wait of first retry
+	t.Log(op.UpdatedAt.String())
+	op, when, err = opManager.RetryOperation(op, errorMessage, errOut, retryInterval, maxtime, fixLogger())
+
+	// when - second call => retry
+	assert.True(t, when > 0)
+	assert.Nil(t, err)
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR introduces generic operations helper called `OperationManager`. 

Every type of operation
 * `ProvisioningOperation` 
 * `DeprovisioningOperation`
 * `UpgradeKymaOperation`
 * `UpgradeClusterOperation`
 * `UpdateOperation`

had their own implementation of set of database convenience methods in for of operation managers called:
 * `ProvisioningOperationManager`
 * `DeprovisioningOperationManager` 
 * `UpgradeKymaOperationManager`
 * `UpgradeClusterOperationManager`
 * `UpdatingOperationManager`

As part of the refactoring and simplification initiative, we would like to unify this approach to avoid code duplication. Given each manager evolved later slightly differently, I selected subset of following functions
  * `UpdateOperation` and its derivatives `OperationFailed`, `OperationCanceled`, `OperationSucceeded`
  * `RetryOperation` along with `RetryOperationWithoutFail` and `RetryOperationOnce`
 
And I decided to skip following:
  * `InsertOperation` - this was implemented only for deprovisioning manager and is essentially just calling storage to insert deprovisioning operation 
  * `SimpleUpdateOperation` - in provisioning and update manager but marked as `DEPRECATED` in both
  * `HandleError` - this was only implemented in provisioning manager and it seems redundant as it only calls the `OperationFailed` 

**Depends on** 
- [x] https://github.com/kyma-project/control-plane/pull/1872