### PR TITLE
Change Alpine version in Provisioner -  OpenSSL security vulnerability fix

### DIFF
--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -23,7 +23,7 @@ RUN go build -v -o main ./cmd/
 RUN mkdir /app && mv ./main /app/main
 RUN mv ./licenses /app/licenses
 
-FROM eu.gcr.io/kyma-project/external/alpine:3.15.4
+FROM eu.gcr.io/kyma-project/external/alpine:3.16.0
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.18.2-alpine3.15 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.18.2-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-1851"
     provisioner:
       dir:
-      version: "PR-1837"
+      version: "PR-1882"
     kyma_environments_subscription_cleanup_job:
       dir:
       version: "PR-1651"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
CVE - 2022 - 2097 vulnerability in Provisioner

Changes proposed in this pull request:

- change the Alpine version to 3.16 to avoid OpenSSL security vulnerability in the previous Alpine release


**Additional info**
[Link to reported CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-2097)
[Changes in Alpine 3.16, bumped OpenSSL to version 1.1.1q and 3.0.5 free from vulnerability](https://git.alpinelinux.org/aports/log/?h=3.16-stable&qt=grep&q=openssl)