### PR TITLE
Always explicitly enable or disable network filter in KEB

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -674,7 +674,8 @@ func TestProvisioning_WithoutNetworkFilter(t *testing.T) {
 	instance := suite.GetInstance(iid)
 
 	// then
-	suite.AssertDisabledNetworkFilterForProvisioning(nil)
+	disabled := false
+	suite.AssertDisabledNetworkFilterForProvisioning(&disabled)
 	assert.Nil(suite.t, instance.Parameters.ErsContext.LicenseType)
 }
 

--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -71,6 +71,7 @@ func TestUpdate(t *testing.T) {
 
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
 
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -81,6 +82,7 @@ func TestUpdate(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
@@ -239,9 +241,11 @@ func TestUpdateWithNoOIDCParams(t *testing.T) {
 
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
 
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
-			OidcConfig: defaultOIDCConfig(),
+			OidcConfig:                    defaultOIDCConfig(),
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
@@ -299,6 +303,7 @@ func TestUpdateWithNoOidcOnUpdate(t *testing.T) {
 
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
 
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -309,6 +314,7 @@ func TestUpdateWithNoOidcOnUpdate(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
@@ -695,6 +701,7 @@ func TestUpdateDefaultAdminNotChanged(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -705,6 +712,7 @@ func TestUpdateDefaultAdminNotChanged(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -764,6 +772,7 @@ func TestUpdateDefaultAdminNotChangedWithCustomOIDC(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -774,6 +783,7 @@ func TestUpdateDefaultAdminNotChangedWithCustomOIDC(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -837,6 +847,7 @@ func TestUpdateDefaultAdminNotChangedWithOIDCUpdate(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -847,6 +858,7 @@ func TestUpdateDefaultAdminNotChangedWithOIDCUpdate(t *testing.T) {
 				UsernameClaim:  "new-username-claim",
 				UsernamePrefix: "->",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -903,6 +915,7 @@ func TestUpdateDefaultAdminOverwritten(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -913,6 +926,7 @@ func TestUpdateDefaultAdminOverwritten(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -970,6 +984,7 @@ func TestUpdateCustomAdminsNotChanged(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -980,6 +995,7 @@ func TestUpdateCustomAdminsNotChanged(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -1041,6 +1057,7 @@ func TestUpdateCustomAdminsNotChangedWithOIDCUpdate(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1051,6 +1068,7 @@ func TestUpdateCustomAdminsNotChangedWithOIDCUpdate(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -1109,6 +1127,7 @@ func TestUpdateCustomAdminsOverwritten(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1119,6 +1138,7 @@ func TestUpdateCustomAdminsOverwritten(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -1183,6 +1203,7 @@ func TestUpdateCustomAdminsOverwrittenWithOIDCUpdate(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1193,6 +1214,7 @@ func TestUpdateCustomAdminsOverwrittenWithOIDCUpdate(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins,
 	})
@@ -1252,6 +1274,7 @@ func TestUpdateCustomAdminsOverwrittenTwice(t *testing.T) {
 
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1262,6 +1285,7 @@ func TestUpdateCustomAdminsOverwrittenTwice(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins1,
 	})
@@ -1293,6 +1317,7 @@ func TestUpdateCustomAdminsOverwrittenTwice(t *testing.T) {
 	upgradeOperationID = suite.DecodeOperationID(resp)
 	suite.FinishUpdatingOperationByProvisioner(upgradeOperationID)
 
+	disabled = false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1303,6 +1328,7 @@ func TestUpdateCustomAdminsOverwrittenTwice(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "->",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: expectedAdmins2,
 	})
@@ -1367,6 +1393,7 @@ func TestUpdateAutoscalerParams(t *testing.T) {
 	min, max, surge, unav := 15, 25, 10, 7
 	// then
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1377,10 +1404,11 @@ func TestUpdateAutoscalerParams(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
-			AutoScalerMin:  &min,
-			AutoScalerMax:  &max,
-			MaxSurge:       &surge,
-			MaxUnavailable: &unav,
+			AutoScalerMin:                 &min,
+			AutoScalerMax:                 &max,
+			MaxSurge:                      &surge,
+			MaxUnavailable:                &unav,
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
@@ -1500,8 +1528,9 @@ func TestUpdateAutoscalerPartialSequence(t *testing.T) {
 	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
 	upgradeOperationID := suite.DecodeOperationID(resp)
 	suite.FinishUpdatingOperationByProvisioner(upgradeOperationID)
-	max := 15
 	suite.WaitForOperationState(upgradeOperationID, domain.Succeeded)
+	max := 15
+	disabled := false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1512,7 +1541,8 @@ func TestUpdateAutoscalerPartialSequence(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
-			AutoScalerMax: &max,
+			AutoScalerMax:                 &max,
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
@@ -1537,6 +1567,7 @@ func TestUpdateAutoscalerPartialSequence(t *testing.T) {
 	upgradeOperationID = suite.DecodeOperationID(resp)
 	suite.FinishUpdatingOperationByProvisioner(upgradeOperationID)
 	min := 14
+	disabled = false
 	suite.AssertShootUpgrade(upgradeOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -1547,7 +1578,8 @@ func TestUpdateAutoscalerPartialSequence(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
-			AutoScalerMin: &min,
+			AutoScalerMin:                 &min,
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})
@@ -2021,7 +2053,8 @@ func TestUpdateStoreNetworkFilterAndUpdate(t *testing.T) {
 	instance := suite.GetInstance(id)
 
 	// then
-	suite.AssertDisabledNetworkFilterForProvisioning(nil)
+	disabled := false
+	suite.AssertDisabledNetworkFilterForProvisioning(&disabled)
 	assert.Nil(suite.t, instance.Parameters.ErsContext.LicenseType)
 
 	// when
@@ -2051,7 +2084,7 @@ func TestUpdateStoreNetworkFilterAndUpdate(t *testing.T) {
 	instance2 := suite.GetInstance(id)
 	// license_type should be stored in the instance table for ERS context and future upgrades
 	// as well as sent to provisioner because the migration has not been triggered
-	disabled := true
+	disabled = true
 	suite.AssertDisabledNetworkFilterRuntimeState(instance.RuntimeID, updateOperationID, &disabled)
 	assert.Equal(suite.t, "CUSTOMER", *instance2.Parameters.ErsContext.LicenseType)
 	suite.FinishUpdatingOperationByProvisionerAndReconciler(updateOperationID)
@@ -2092,8 +2125,9 @@ func TestMultipleUpdateNetworkFilterPersisted(t *testing.T) {
 	instance := suite.GetInstance(id)
 
 	// then
-	suite.AssertDisabledNetworkFilterForProvisioning(nil)
-	suite.AssertDisabledNetworkFilterRuntimeState(instance.RuntimeID, opID, nil)
+	disabled := false
+	suite.AssertDisabledNetworkFilterForProvisioning(&disabled)
+	suite.AssertDisabledNetworkFilterRuntimeState(instance.RuntimeID, opID, &disabled)
 	assert.Nil(suite.t, instance.Parameters.ErsContext.LicenseType)
 
 	// when
@@ -2130,7 +2164,7 @@ func TestMultipleUpdateNetworkFilterPersisted(t *testing.T) {
 	suite.WaitForOperationState(updateOperation2ID, domain.Succeeded)
 	instance3 := suite.GetInstance(id)
 	assert.Equal(suite.t, "CUSTOMER", *instance3.Parameters.ErsContext.LicenseType)
-	disabled := true
+	disabled = true
 	suite.AssertDisabledNetworkFilterRuntimeState(instance.RuntimeID, updateOperation2ID, &disabled)
 }
 

--- a/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
+++ b/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
@@ -97,6 +97,7 @@ func TestClusterUpgradeUsesUpdatedAutoscalerParams(t *testing.T) {
 	require.NoError(t, err)
 
 	// then
+	disabled := false
 	suite.AssertShootUpgrade(upgradeKymaOperationID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			KubernetesVersion:   ptr.String("1.18"),
@@ -111,7 +112,8 @@ func TestClusterUpgradeUsesUpdatedAutoscalerParams(t *testing.T) {
 			EnableKubernetesVersionAutoUpdate:   ptr.Bool(false),
 			EnableMachineImageVersionAutoUpdate: ptr.Bool(false),
 
-			OidcConfig: defaultOIDCConfig(),
+			OidcConfig:                    defaultOIDCConfig(),
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"john.smith@email.com"},
 	})

--- a/components/kyma-environment-broker/internal/dto.go
+++ b/components/kyma-environment-broker/internal/dto.go
@@ -247,15 +247,19 @@ func UpdateERSContext(currentOperation, previousOperation ERSContext) ERSContext
 }
 
 func (e ERSContext) DisableEnterprisePolicyFilter() *bool {
+	// the provisioner and gardener API expects the feature to be enabled by disablement flag
+	// it feels counterintuitive but there is currently no plan in changing it, therefore
+	// following code is written the way it's written
+	disable := false
 	if e.LicenseType == nil {
-		return nil
+		return &disable
 	}
 	switch *e.LicenseType {
 	case "CUSTOMER", "PARTNER", "TRIAL":
-		disable := true
+		disable = true
 		return &disable
 	}
-	return nil
+	return &disable
 }
 
 func (e ERSContext) ERSUpdate() bool {

--- a/components/kyma-environment-broker/internal/fixture/fixture.go
+++ b/components/kyma-environment-broker/internal/fixture/fixture.go
@@ -323,14 +323,17 @@ func FixDNSProvidersConfig() gardener.DNSProvidersData {
 }
 
 func FixRuntimeState(id, runtimeID, operationID string) internal.RuntimeState {
+	disabled := false
 	return internal.RuntimeState{
-		ID:            id,
-		CreatedAt:     time.Now(),
-		RuntimeID:     runtimeID,
-		OperationID:   operationID,
-		KymaConfig:    gqlschema.KymaConfigInput{},
-		ClusterConfig: gqlschema.GardenerConfigInput{},
-		ClusterSetup:  nil,
+		ID:          id,
+		CreatedAt:   time.Now(),
+		RuntimeID:   runtimeID,
+		OperationID: operationID,
+		KymaConfig:  gqlschema.KymaConfigInput{},
+		ClusterConfig: gqlschema.GardenerConfigInput{
+			ShootNetworkingFilterDisabled: &disabled,
+		},
+		ClusterSetup: nil,
 	}
 }
 

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -30,6 +30,7 @@ func TestCreateRuntimeWithoutKyma_Run(t *testing.T) {
 	assert.NoError(t, err)
 
 	administrator := ""
+	disabled := false
 	provisionerInput := gqlschema.ProvisionRuntimeInput{
 		RuntimeInput: &gqlschema.RuntimeInput{
 			Name:        "dummy",
@@ -84,6 +85,7 @@ func TestCreateRuntimeWithoutKyma_Run(t *testing.T) {
 						},
 					},
 				},
+				ShootNetworkingFilterDisabled: &disabled,
 			},
 			Administrators: []string{administrator},
 		},

--- a/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step_test.go
+++ b/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step_test.go
@@ -55,6 +55,7 @@ func TestUpgradeShootStep_Run(t *testing.T) {
 	assert.Zero(t, d)
 	assert.True(t, cli.IsShootUpgraded("runtime-id"))
 	req, _ := cli.LastShootUpgrade("runtime-id")
+	disabled := false
 	assert.Equal(t, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			OidcConfig: &gqlschema.OIDCConfigInput{
@@ -65,6 +66,7 @@ func TestUpgradeShootStep_Run(t *testing.T) {
 				UsernameClaim:  "sub",
 				UsernamePrefix: "-",
 			},
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 		Administrators: []string{"test-user-id"},
 	}, req)

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step.go
@@ -137,6 +137,7 @@ func (s *UpgradeClusterStep) createUpgradeShootInput(operation internal.UpgradeC
 }
 
 func gardenerUpgradeInputToConfigInput(input gqlschema.UpgradeShootInput) *gqlschema.GardenerConfigInput {
+	disabled := false
 	result := &gqlschema.GardenerConfigInput{
 		MachineImage:                        input.GardenerConfig.MachineImage,
 		MachineImageVersion:                 input.GardenerConfig.MachineImageVersion,
@@ -146,6 +147,7 @@ func gardenerUpgradeInputToConfigInput(input gqlschema.UpgradeShootInput) *gqlsc
 		OidcConfig:                          input.GardenerConfig.OidcConfig,
 		EnableKubernetesVersionAutoUpdate:   input.GardenerConfig.EnableKubernetesVersionAutoUpdate,
 		EnableMachineImageVersionAutoUpdate: input.GardenerConfig.EnableMachineImageVersionAutoUpdate,
+		ShootNetworkingFilterDisabled:       &disabled,
 	}
 	if input.GardenerConfig.KubernetesVersion != nil {
 		result.KubernetesVersion = *input.GardenerConfig.KubernetesVersion

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/upgrade_cluster_step_test.go
@@ -57,6 +57,7 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 	assert.NotNil(t, provider)
 
 	provisionerClient := &provisionerAutomock.Client{}
+	disabled := false
 	provisionerClient.On("UpgradeShoot", fixGlobalAccountID, fixRuntimeID, gqlschema.UpgradeShootInput{
 		GardenerConfig: &gqlschema.GardenerUpgradeInput{
 			KubernetesVersion:                   ptr.String(fixKubernetesVersion),
@@ -68,6 +69,7 @@ func TestUpgradeKymaStep_Run(t *testing.T) {
 			MaxUnavailable:                      operation.ProvisioningParameters.Parameters.MaxUnavailable,
 			EnableKubernetesVersionAutoUpdate:   ptr.Bool(fixAutoUpdateKubernetesVersion),
 			EnableMachineImageVersionAutoUpdate: ptr.Bool(fixAutoUpdateMachineImageVersion),
+			ShootNetworkingFilterDisabled:       &disabled,
 			OidcConfig: &gqlschema.OIDCConfigInput{
 				ClientID:       expectedOIDC.ClientID,
 				GroupsClaim:    expectedOIDC.GroupsClaim,

--- a/components/kyma-environment-broker/internal/provisioner/client_test.go
+++ b/components/kyma-environment-broker/internal/provisioner/client_test.go
@@ -644,6 +644,7 @@ func (tqr testQueryResolver) RuntimeOperationStatus(_ context.Context, id string
 }
 
 func fixProvisionRuntimeInput() schema.ProvisionRuntimeInput {
+	disabled := false
 	return schema.ProvisionRuntimeInput{
 		RuntimeInput: &schema.RuntimeInput{
 			Name:        "test",
@@ -666,6 +667,7 @@ func fixProvisionRuntimeInput() schema.ProvisionRuntimeInput {
 						},
 					},
 				},
+				ShootNetworkingFilterDisabled: &disabled,
 			},
 		},
 		KymaConfig: &schema.KymaConfigInput{
@@ -679,6 +681,7 @@ func fixProvisionRuntimeInput() schema.ProvisionRuntimeInput {
 }
 
 func fixProvisionRuntimeInputWithoutDnsConfig() schema.ProvisionRuntimeInput {
+	disabled := false
 	return schema.ProvisionRuntimeInput{
 		RuntimeInput: &schema.RuntimeInput{
 			Name:        "test",
@@ -687,9 +690,10 @@ func fixProvisionRuntimeInputWithoutDnsConfig() schema.ProvisionRuntimeInput {
 		},
 		ClusterConfig: &schema.ClusterConfigInput{
 			GardenerConfig: &schema.GardenerConfigInput{
-				ProviderSpecificConfig: &schema.ProviderSpecificInput{},
-				Name:                   "abcd",
-				VolumeSizeGb:           ptr.Integer(50),
+				ProviderSpecificConfig:        &schema.ProviderSpecificInput{},
+				Name:                          "abcd",
+				VolumeSizeGb:                  ptr.Integer(50),
+				ShootNetworkingFilterDisabled: &disabled,
 			},
 		},
 		KymaConfig: &schema.KymaConfigInput{
@@ -721,15 +725,17 @@ func fixUpgradeRuntimeInput(kymaVersion string) schema.UpgradeRuntimeInput {
 }
 
 func fixUpgradeShootInput() schema.UpgradeShootInput {
+	disabled := false
 	return schema.UpgradeShootInput{
 		GardenerConfig: &schema.GardenerUpgradeInput{
-			KubernetesVersion:   &testKubernetesVersion,
-			MachineImage:        &testMachineImage,
-			MachineImageVersion: &testMachineImageVersion,
-			AutoScalerMin:       &testAutoScalerMin,
-			AutoScalerMax:       &testAutoScalerMax,
-			MaxSurge:            &testMaxSurge,
-			MaxUnavailable:      &testMaxUnavailable,
+			KubernetesVersion:             &testKubernetesVersion,
+			MachineImage:                  &testMachineImage,
+			MachineImageVersion:           &testMachineImageVersion,
+			AutoScalerMin:                 &testAutoScalerMin,
+			AutoScalerMax:                 &testAutoScalerMax,
+			MaxSurge:                      &testMaxSurge,
+			MaxUnavailable:                &testMaxUnavailable,
+			ShootNetworkingFilterDisabled: &disabled,
 		},
 	}
 }

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1870"
+      version: "PR-1890"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1842"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The initial requirement was worded as:
> Gardener sets Enterprise Policy Filter by default. Provisioner accepts Enterprise Policy Filter true/false value as an input (field in GraphQL) for cluster provisioning. On KEB side when license_type:CUSTOMER/PARTNER/TRIAL keep Filter OFF, if any other value FILTER ON.
3.1) if license_type is not persisted on KEB side then TURN ON FILTER, we treat those Kyma instances as SAP ones.

Previously this was satisfied by https://github.com/kyma-project/control-plane/pull/1735 together with https://github.com/kyma-project/control-plane/pull/1478. But after https://github.com/kyma-project/control-plane/pull/1746 reverted the defaulting, I think it's probably best to always explicitly set this flag in KEB without any expectations of default behaviour for provisioner or gardener.

I think the API design is a bit unfortunate and counter-intuitive, I provided my feedback to the authors but at the moment, it will remain as is https://github.com/kyma-project/control-plane/pull/1746#issuecomment-1148474996.

A human readable summary of the implementation:
- for TRIAL/CUSTOMER/PARTNER - set `DisableEnterpriseFilter` to `false` meaning filter is enabled
- for other values (including `nil` value) - set `DisableEnterpriseFilter` as `false` meaning filter is enabled