### PR TITLE
temporarily removed n2-standard-48

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -267,7 +267,10 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 
 	// awsHASchema := AWSHASchema(awsMachines, includeAdditionalParamsInSchema, false)
 
-	gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"}
+	// TODO: restore slice in the line below when changed introduced in https://github.wdf.sap.corp/kubernetes/landscape-setup/pull/4635 gets to production
+	//gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"}
+	// Till then n2-standard-48 is not supported by gardener which causes such occurrences as in https://github.tools.sap/kyma/backlog/issues/2790
+	gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32"}
 	gcpSchema := GCPSchema(gcpMachines, includeAdditionalParamsInSchema, false)
 
 	openStackMachines := []string{"m2.xlarge", "m1.2xlarge"}

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -267,7 +267,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 
 	// awsHASchema := AWSHASchema(awsMachines, includeAdditionalParamsInSchema, false)
 
-	// TODO: restore slice in the line below when changed introduced in https://github.wdf.sap.corp/kubernetes/landscape-setup/pull/4635 gets to production
+	// TODO: restore slice in the line below when change introduced in https://github.wdf.sap.corp/kubernetes/landscape-setup/pull/4635 gets to production
 	//gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"}
 	// Till then n2-standard-48 is not supported by gardener which causes such occurrences as in https://github.tools.sap/kyma/backlog/issues/2790
 	gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32"}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1890"
+      version: "PR-1897"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1868"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Due to discrepancy between GCP machine types in KEB and in Gardener selection of n2-standard-48 causes error since Gardener do not allow this machine type. See https://github.tools.sap/kyma/backlog/issues/2790
https://github.wdf.sap.corp/kubernetes/landscape-setup/pull/4635 introduced missing machine type to Gardener but it will take up to two weeks till the change reaches productions. 
So temporarily we remove n2-standard-48 and we will restore it when the new version of Gardener is on production.

Changes proposed in this pull request:

- Removal of n2-standard-48 GCP machine type

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/2790
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
