### PR TITLE
Fix getting last kyma version

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/upgrade_cluster_test.go
+++ b/components/kyma-environment-broker/cmd/broker/upgrade_cluster_test.go
@@ -109,4 +109,43 @@ func TestClusterUpgrade_UpgradeAfterUpdateWithNetworkPolicy(t *testing.T) {
 	disabled := true
 	suite.AssertDisabledNetworkFilterRuntimeState(i.RuntimeID, upgradeClusterOperationID, &disabled)
 	assert.Equal(suite.t, "CUSTOMER", *instance2.Parameters.ErsContext.LicenseType)
+
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id), `
+{
+	"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+	"plan_id": "4deee563-e5ec-4731-b9b1-53b42d855f0c",
+	"context": {
+		"globalaccount_id": "g-account-id",
+		"user_id": "jack.anvil@email.com"
+	},
+	"parameters": {
+		"autoScalerMin":15,
+		"autoScalerMax":25,
+		"maxSurge":13,
+		"maxUnavailable":6
+	}
+}`)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	upgradeOperationID := suite.DecodeOperationID(resp)
+	suite.FinishUpdatingOperationByProvisioner(upgradeOperationID)
+
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", id), `
+{
+	"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+	"plan_id": "4deee563-e5ec-4731-b9b1-53b42d855f0c",
+	"context": {
+		"globalaccount_id": "g-account-id",
+		"user_id": "jack.anvil@email.com"
+	},
+	"parameters": {
+		"autoScalerMin":14,
+		"autoScalerMax":25,
+		"maxSurge":13,
+		"maxUnavailable":6
+	}
+}`)
+	assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	upgradeOperationID = suite.DecodeOperationID(resp)
+	suite.FinishUpdatingOperationByProvisioner(upgradeOperationID)
+
 }

--- a/components/kyma-environment-broker/internal/runtimeversion/runtimeversion.go
+++ b/components/kyma-environment-broker/internal/runtimeversion/runtimeversion.go
@@ -33,11 +33,8 @@ func (rvc *RuntimeVersionConfigurator) ForUpdating(op internal.UpdatingOperation
 	if err != nil {
 		return nil, err
 	}
-	if r.ClusterSetup != nil && r.ClusterSetup.KymaConfig.Version != "" {
-		return internal.NewRuntimeVersionFromDefaults(r.ClusterSetup.KymaConfig.Version), nil
-	} else {
-		return internal.NewRuntimeVersionFromDefaults(r.KymaConfig.Version), nil
-	}
+
+	return internal.NewRuntimeVersionFromDefaults(r.GetKymaVersion()), nil
 }
 
 func (rvc *RuntimeVersionConfigurator) ForProvisioning(op internal.ProvisioningOperation) (*internal.RuntimeVersionData, error) {

--- a/components/kyma-environment-broker/internal/storage/driver/memory/runtime_state.go
+++ b/components/kyma-environment-broker/internal/storage/driver/memory/runtime_state.go
@@ -76,6 +76,9 @@ func (s *runtimeState) GetLatestWithKymaVersionByRuntimeID(runtimeID string) (in
 	}
 
 	for _, state := range states {
+		if state.KymaVersion != "" {
+			return state, nil
+		}
 		if state.ClusterSetup != nil && state.ClusterSetup.KymaConfig.Version != "" {
 			return state, nil
 		}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1915"
+      version: "PR-1930"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1868"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- fix getting last kyma version

The problem is that the code is looking for a runtime state with kyma version, but getting a version from such record uses different places than the filtering "where" statement.

The in memory implementation differs than SQL so unit tests were working fine

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
