### PR TITLE
set EnableNatGateway boolean to true for Azure, AzureLite and AzureHA for upgrades

### DIFF
--- a/components/kyma-environment-broker/internal/process/input/builder.go
+++ b/components/kyma-environment-broker/internal/process/input/builder.go
@@ -2,12 +2,12 @@ package input
 
 import (
 	"fmt"
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"strings"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	cloudProvider "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provider"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/runtime"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/pkg/errors"

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1930"
+      version: "PR-1942"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1868"


### PR DESCRIPTION
As part of enabling NAT Gateway for Azure clusters, this PR sets the EnableNatGateway boolean to true for Azure, AzureLite, and AzureHA plans.

See for more information: https://github.com/kyma-project/kyma/issues/13553

When a partial payload is provided, Provisioner gets the missing information from the database with previously used data, and therefore only values that are different are changed and only providing EnableNatGateway should be sufficient.