### PR TITLE
n2-standard-48 restored since gardener allows this machine type at last

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -267,10 +267,7 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 
 	// awsHASchema := AWSHASchema(awsMachines, includeAdditionalParamsInSchema, false)
 
-	// TODO: restore slice in the line below when change introduced in https://github.wdf.sap.corp/kubernetes/landscape-setup/pull/4635 gets to production
-	//gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"}
-	// Till then n2-standard-48 is not supported by gardener which causes such occurrences as in https://github.tools.sap/kyma/backlog/issues/2790
-	gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32"}
+	gcpMachines := []string{"n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"}
 	gcpSchema := GCPSchema(gcpMachines, includeAdditionalParamsInSchema, false)
 
 	openStackMachines := []string{"m2.xlarge", "m1.2xlarge"}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1950"
+      version: "PR-1947"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1868"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Restoring n2-standard-48 as available machine type after gardener allows this type as well.

Changes proposed in this pull request:

- n2-standard-48 machine type added to available set of machines for GCP

**Related issue(s)**
Fixes https://github.tools.sap/kyma/backlog/issues/2790
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
