### PR TITLE
Require succeeded suspension to call unsuspension

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/check_runtime_step.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/check_runtime_step.go
@@ -51,7 +51,7 @@ func (s *CheckRuntimeStep) checkRuntimeStatus(operation internal.ProvisioningOpe
 	}
 
 	if operation.ProvisionerOperationID == "" {
-		msg := "Operation dos not contain Provisioner Operation ID"
+		msg := "Operation does not contain Provisioner Operation ID"
 		log.Error(msg)
 		return s.operationManager.OperationFailed(operation, msg, nil, log)
 	}

--- a/components/kyma-environment-broker/internal/process/update/check_step.go
+++ b/components/kyma-environment-broker/internal/process/update/check_step.go
@@ -51,7 +51,7 @@ func (s *CheckStep) checkRuntimeStatus(operation internal.UpdatingOperation, log
 	}
 
 	if operation.ProvisionerOperationID == "" {
-		msg := "Operation dos not contain Provisioner Operation ID"
+		msg := "Operation does not contain Provisioner Operation ID"
 		log.Error(msg)
 		return s.operationManager.OperationFailed(operation, msg, nil, log)
 	}

--- a/components/kyma-environment-broker/internal/process/upgrade_cluster/initialisation.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_cluster/initialisation.go
@@ -64,7 +64,7 @@ func NewInitialisationStep(os storage.Operations, ors storage.Orchestrations, pc
 }
 
 func (s *InitialisationStep) Name() string {
-	return "Upgrade_Kyma_Initialisation"
+	return "Upgrade_Cluster_Initialisation"
 }
 
 func (s *InitialisationStep) Run(operation internal.UpgradeClusterOperation, log logrus.FieldLogger) (internal.UpgradeClusterOperation, time.Duration, error) {

--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -1,6 +1,9 @@
 package suspension
 
 import (
+	"fmt"
+	"net/http"
+
 	"github.com/google/uuid"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -8,6 +11,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"github.com/pivotal-cf/brokerapi/v8/domain/apiresponses"
 	"github.com/sirupsen/logrus"
 )
 
@@ -82,6 +86,10 @@ func (h *ContextUpdateHandler) handleContextChange(newCtx internal.ERSContext, i
 		if lastDeprovisioning != nil && !lastDeprovisioning.Temporary {
 			l.Infof("Instance has a deprovisioning operation %s (%s), skipping unsuspension.", lastDeprovisioning.ID, lastDeprovisioning.State)
 			return false, nil
+		}
+		if lastDeprovisioning != nil && lastDeprovisioning.State == domain.Failed {
+			err := fmt.Errorf("Preceding suspension has failed, unable to reliably unsuspend")
+			return false, apiresponses.NewFailureResponse(err, http.StatusInternalServerError, "provisioning")
 		}
 		return true, h.unsuspend(instance, l)
 	} else {

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1947"
+      version: "PR-1953"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1868"


### PR DESCRIPTION
Managed kyma reports cases when unsuspension fails with the following error
```
"Operation dos not contain Provisioner Operation ID"
```
In the reported cases, the preceding suspensions for these cases failed as well. Additional symptoms are that the `RuntimeID` is the same before suspension as well as after. In all cases are log entries similar to these:

**Failure in unsuspending** happening on `2022-08-08T02:18:14Z`

<details>
  <summary>unsuspend log payload</summary>

```json
{
  "insertId": "kijpt7l3i1ua2wxq",
  "jsonPayload": {
    "operation": "0002a0d9-0d19-4378-93c8-ef13b6f90f99",
    "provisioning": "manager",
  --"instanceID": "0B83FC4F-731A-46D9-BECC-528FAD307DCB",
  --"runtimeID": "a23c1dd9-c231-4e6d-8760-87f0edcff56d",
    "stage": "create_runtime",
    "step": "Check_Runtime",
    "planID": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
    "msg": "Operation dos not contain Provisioner Operation ID",
    "level": "error"
  },
  "resource": {
    "type": "k8s_container",
    "labels": {
      "cluster_name": "kyma-mps-prod",
      "pod_name": "kcp-kyma-environment-broker-7d895c54cc-6n57w",
      "project_id": "sap-ti-dx-kyma-mps-prod",
      "location": "europe-west1",
      "namespace_name": "kcp-system",
      "container_name": "kyma-environment-broker"
    }
  },
--"timestamp": "2022-08-08T02:18:14Z",
  "severity": "ERROR",
  "labels": {
    "k8s-pod/service_istio_io/canonical-name": "kyma-environment-broker",
    "k8s-pod/security_istio_io/tlsMode": "istio",
    "k8s-pod/app_kubernetes_io/name": "kyma-environment-broker",
    "k8s-pod/pod-template-hash": "7d895c54cc",
    "compute.googleapis.com/resource_name": "gke-kyma-mps-prod-kyma-mps-prod-app-f-8e63c4fd-qhon",
    "k8s-pod/service_istio_io/canonical-revision": "latest",
    "k8s-pod/app_kubernetes_io/instance": "kcp"
  },
  "logName": "projects/sap-ti-dx-kyma-mps-prod/logs/stderr",
  "receiveTimestamp": "2022-08-08T02:18:18.465560576Z"
}
```

</details>


**Upgrade cluster** happening on `2022-07-26T11:57:23Z`, days before unsuspension with same `InstanceID` as well as `RuntimeID`

<details>
  <summary>upgrade log payload</summary> 

```json
{
  "insertId": "dv5xl1y9m3qb6ra2",
  "jsonPayload": {
    "level": "info",
  --"instanceID": "0B83FC4F-731A-46D9-BECC-528FAD307DCB",
    "operation": "750244e6-a733-48a0-9a5f-6464523abad3",
    "upgradeCluster": "manager",
    "msg": "call to provisioner returned Succeeded status",
  --"runtimeID": "a23c1dd9-c231-4e6d-8760-87f0edcff56d",
    "step": "Upgrade_Kyma_Initialisation"
  },
  "resource": {
    "type": "k8s_container",
    "labels": {
      "container_name": "kyma-environment-broker",
      "location": "europe-west1",
      "namespace_name": "kcp-system",
      "pod_name": "kcp-kyma-environment-broker-5686c4cb6-wglq2",
      "cluster_name": "kyma-mps-prod",
      "project_id": "sap-ti-dx-kyma-mps-prod"
    }
  },
--"timestamp": "2022-07-26T11:57:23Z",
  "severity": "INFO",
  "labels": {
    "k8s-pod/service_istio_io/canonical-name": "kyma-environment-broker",
    "k8s-pod/security_istio_io/tlsMode": "istio",
    "k8s-pod/app_kubernetes_io/name": "kyma-environment-broker",
    "compute.googleapis.com/resource_name": "gke-kyma-mps-prod-kyma-mps-prod-app-f-ab76fd88-w4bz",
    "k8s-pod/pod-template-hash": "5686c4cb6",
    "k8s-pod/app_kubernetes_io/instance": "kcp",
    "k8s-pod/service_istio_io/canonical-revision": "latest"
  },
  "logName": "projects/sap-ti-dx-kyma-mps-prod/logs/stderr",
  "receiveTimestamp": "2022-07-26T11:57:25.638408720Z"
}
```

</details>


This happens only when suspension fails and `RuntimeID` is not cleaned because KEB can't reliably guarantee the cluster has been deprovisioned and should prevent resource leaks. The unsuspension skips provisioning of new cluster because it still thinks the old cluster is usable (which KEB can't determine)
https://github.com/kyma-project/control-plane/blob/192bc81f941bcd0db754a86c2c6f3e1659f494de/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_step.go#L47-L50

And because no new operation got created in provisioner, KEB fails the operation on provisioner check
https://github.com/kyma-project/control-plane/blob/192bc81f941bcd0db754a86c2c6f3e1659f494de/components/kyma-environment-broker/internal/process/provisioning/check_runtime_step.go#L53-L57