### PR TITLE
Delete oauth2 config from required list of params

### DIFF
--- a/tools/cli/pkg/command/options.go
+++ b/tools/cli/pkg/command/options.go
@@ -120,8 +120,7 @@ func SetGlobalOpts(cmd *cobra.Command) {
 
 // ValidateGlobalOpts checks the presence of the required global configuration parameters
 func ValidateGlobalOpts() error {
-	var reqGlobalOpts = []string{GlobalOpts.oidcIssuerURL, GlobalOpts.oidcClientID, GlobalOpts.kebAPIURL,
-		GlobalOpts.mothershipAPIURL, GlobalOpts.oauth2IssuerURL, GlobalOpts.oauth2ClientID, GlobalOpts.oauth2ClientSecret}
+	var reqGlobalOpts = []string{GlobalOpts.oidcIssuerURL, GlobalOpts.oidcClientID, GlobalOpts.kebAPIURL, GlobalOpts.mothershipAPIURL}
 	var missingGlobalOpts []string
 	for _, opt := range reqGlobalOpts {
 		if viper.GetString(opt) == "" {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- I have made Oauth2 related parameters optional. 

Reason: 
Deprovision command uses oauth2 to send the request and thus we had previously added oauth2 related configs to cli. One of the configs is a secret value. That secret value should be added manually by the cli user. The problem about this setup is that, we have just realized developers do not have access to secret resources in mps-stage and mps-prod. 

I am going to initiate a discussion to come up with a solution. In the meantime, I need to make oauth2 related config optional in order not to cause any problems. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

`See also #1691`
`See also #1692`
`See also`  https://github.tools.sap/kyma/documentation/pull/244