### PR TITLE
BTP-Operator cleanup for suspensions

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -66,9 +66,9 @@ import (
 	"github.com/spf13/afero"
 	"github.com/vrischmann/envconfig"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	runtime2 "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -432,7 +432,7 @@ func k8sClientProvider(kcfg string) (client.Client, error) {
 		return nil, err
 	}
 
-	sch := runtime2.NewScheme()
+	sch := scheme.Scheme
 	apiextensionsv1.AddToScheme(sch)
 
 	k8sCli, err := client.New(restCfg, client.Options{
@@ -852,6 +852,10 @@ func NewDeprovisioningProcessingQueue(ctx context.Context, workersAmount int, de
 		weight   int
 		step     deprovisioning.Step
 	}{
+		{
+			weight: 1,
+			step:   deprovisioning.NewBTPOperatorCleanupStep(db.Operations(), provisionerClient, k8sClientProvider),
+		},
 		{
 			weight: 1,
 			step:   deprovisioning.NewAvsEvaluationsRemovalStep(avsDel, db.Operations(), externalEvalAssistant, internalEvalAssistant),

--- a/components/kyma-environment-broker/internal/fixture/fixture.go
+++ b/components/kyma-environment-broker/internal/fixture/fixture.go
@@ -17,6 +17,7 @@ const (
 	ServiceId                   = "47c9dcbf-ff30-448e-ab36-d3bad66ba281"
 	ServiceName                 = "kymaruntime"
 	PlanId                      = "4deee563-e5ec-4731-b9b1-53b42d855f0c"
+	TrialPlan                   = "7d55d31d-35ae-4438-bf13-6ffdfa107d9f"
 	PlanName                    = "azure"
 	GlobalAccountId             = "e8f7ec0a-0cd6-41f0-905d-5d1efa9fb6c4"
 	SubscriptionGlobalAccountID = ""
@@ -236,6 +237,15 @@ func FixProvisioningOperationWithProvider(operationId, instanceId string, provid
 func FixDeprovisioningOperation(operationId, instanceId string) internal.DeprovisioningOperation {
 	o := FixOperation(operationId, instanceId, internal.OperationTypeDeprovision)
 	o.Temporary = false
+	return internal.DeprovisioningOperation{
+		Operation: o,
+	}
+}
+
+func FixSuspensionOperation(operationId, instanceId string) internal.DeprovisioningOperation {
+	o := FixOperation(operationId, instanceId, internal.OperationTypeDeprovision)
+	o.Temporary = true
+	o.ProvisioningParameters.PlanID = TrialPlan
 	return internal.DeprovisioningOperation{
 		Operation: o,
 	}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provisioner"
@@ -49,6 +50,10 @@ func (s *BTPOperatorCleanupStep) Name() string {
 func (s *BTPOperatorCleanupStep) Run(operation internal.DeprovisioningOperation, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
 	if !operation.Temporary {
 		log.Info("cleanup executed only for suspensions")
+		return operation, 0, nil
+	}
+	if operation.ProvisioningParameters.PlanID != broker.TrialPlanID {
+		log.Info("cleanup executed only for trial plan")
 		return operation, 0, nil
 	}
 	if operation.RuntimeID == "" {

--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -1,0 +1,135 @@
+package deprovisioning
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/provisioner"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/sirupsen/logrus"
+	k8serrors2 "k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	btpOperatorGroup           = "services.cloud.sap.com"
+	btpOperatorApiVer          = "v1"
+	btpOperatorServiceInstance = "ServiceInstance"
+	btpOperatorBinding         = "ServiceBinding"
+)
+
+type BTPOperatorCleanupStep struct {
+	operationManager  *process.DeprovisionOperationManager
+	provisionerClient provisioner.Client
+	k8sClientProvider func(kcfg string) (client.Client, error)
+}
+
+func NewBTPOperatorCleanupStep(os storage.Operations, provisionerClient provisioner.Client, k8sClientProvider func(kcfg string) (client.Client, error)) *BTPOperatorCleanupStep {
+	return &BTPOperatorCleanupStep{
+		operationManager:  process.NewDeprovisionOperationManager(os),
+		provisionerClient: provisionerClient,
+		k8sClientProvider: k8sClientProvider,
+	}
+}
+
+func (s *BTPOperatorCleanupStep) Name() string {
+	return "BTPOperator_Cleanup"
+}
+
+func (s *BTPOperatorCleanupStep) Run(operation internal.DeprovisioningOperation, log logrus.FieldLogger) (internal.DeprovisioningOperation, time.Duration, error) {
+	if !operation.Temporary {
+		log.Info("cleanup executed only for suspensions")
+		return operation, 0, nil
+	}
+	if operation.RuntimeID == "" {
+		log.Info("instance has been deprovisioned already")
+		return operation, 0, nil
+	}
+	status, err := s.provisionerClient.RuntimeStatus(operation.ProvisioningParameters.ErsContext.GlobalAccountID, operation.RuntimeID)
+	if err != nil {
+		if s.isNotFoundErr(err) {
+			log.Info("instance not found in provisioner")
+			return operation, 0, nil
+		}
+		return handleError(s.Name(), operation, err, log, "call to provisioner RuntimeStatus failed")
+	}
+	if status.RuntimeConfiguration.Kubeconfig == nil {
+		err := kebError.NewTemporaryError("empty kubeconfig")
+		return handleError(s.Name(), operation, err, log, "provisioner returned empty kubeconfig")
+	}
+	k := *status.RuntimeConfiguration.Kubeconfig
+	hash := sha256.Sum256([]byte(k))
+	log.Infof("kubeconfig details length: %v, sha256: %v", len(k), string(hash[:]))
+	if len(k) < 10 {
+		err := kebError.NewTemporaryError("kubeconfig suspiciously small, requeuing")
+		return handleError(s.Name(), operation, err, log, "provisioner returned wrong kubeconfig")
+	}
+	cli, err := s.k8sClientProvider(k)
+	if err != nil {
+		err = kebError.AsTemporaryError(err, "failed to create k8s client from the kubeconfig")
+		return handleError(s.Name(), operation, err, log, "could not create a k8s client")
+	}
+	if err := s.deleteServiceBindingsAndInstances(cli, log); err != nil {
+		err = kebError.AsTemporaryError(err, "failed BTP operator resource cleanup")
+		return handleError(s.Name(), operation, err, log, "could not delete bindings and service instances")
+	}
+	return operation, 0, nil
+}
+
+func (s *BTPOperatorCleanupStep) deleteServiceBindingsAndInstances(k8sClient client.Client, log logrus.FieldLogger) error {
+	namespaces := corev1.NamespaceList{}
+	if err := k8sClient.List(context.Background(), &namespaces); err != nil {
+		return err
+	}
+	requeue := s.deleteResource(k8sClient, namespaces, schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorBinding}, log)
+	requeue = requeue || s.deleteResource(k8sClient, namespaces, schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorServiceInstance}, log)
+	if requeue {
+		return fmt.Errorf("waiting for resources to be deleted")
+	}
+	return nil
+}
+
+func (s *BTPOperatorCleanupStep) deleteResource(k8sClient client.Client, namespaces corev1.NamespaceList, gvk schema.GroupVersionKind, log logrus.FieldLogger) (requeue bool) {
+	listGvk := gvk
+	listGvk.Kind = gvk.Kind + "List"
+	stillExistingCount := 0
+	for _, ns := range namespaces.Items {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(listGvk)
+		if err := k8sClient.List(context.Background(), list, client.InNamespace(ns.Name)); err != nil {
+			log.Errorf("failed listing resource %v in namespace %v", gvk, ns.Name)
+			if k8serrors2.IsNoMatchError(err) {
+				// CRD doesn't exist anymore
+				return false
+			}
+			requeue = true
+		}
+		stillExistingCount += len(list.Items)
+	}
+	if stillExistingCount == 0 {
+		return
+	}
+	requeue = true
+	for _, ns := range namespaces.Items {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		if err := k8sClient.DeleteAllOf(context.Background(), obj, client.InNamespace(ns.Name)); err != nil {
+			log.Errorf("failed deleting resources %v in namespace %v", gvk, ns.Name)
+		}
+	}
+	return
+}
+
+func (s *BTPOperatorCleanupStep) isNotFoundErr(err error) bool {
+	return strings.Contains(err.Error(), "not found")
+}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup_test.go
@@ -1,0 +1,282 @@
+package deprovisioning
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/fixture"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var siCRD = []byte(`
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: serviceinstances.services.cloud.sap.com
+spec:
+  group: services.cloud.sap.com
+  names:
+    kind: ServiceInstance
+    listKind: ServiceInstanceList
+    plural: serviceinstances
+    singular: serviceinstance
+  scope: Namespaced
+`)
+
+func TestRemoveServiceInstanceStep(t *testing.T) {
+	t.Run("should remove all service instances and bindings from btp operator as part of trial suspension", func(t *testing.T) {
+		// given
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+		si := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "ServiceInstance",
+			"metadata": map[string]interface{}{
+				"name":      "test-instance",
+				"namespace": "kyma-system",
+			},
+		}}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+
+		scheme := scheme.Scheme
+		err := apiextensionsv1.AddToScheme(scheme)
+		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
+		fmt.Println(gvk)
+		require.NoError(t, err)
+
+		k8sCli := &fakeK8sClientWrapper{fake: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj, ns).Build()}
+		err = k8sCli.Create(context.TODO(), si)
+		require.NoError(t, err)
+
+		op := fixture.FixSuspensionOperation(fixOperationID, fixInstanceID)
+		op.State = "in progress"
+		fakeProvisionerClient := fakeProvisionerClient{}
+		step := NewBTPOperatorCleanupStep(ms.Operations(), fakeProvisionerClient, func(k string) (client.Client, error) { return k8sCli, nil })
+
+		// when
+		entry := log.WithFields(logrus.Fields{"step": "TEST"})
+		_, _, err = step.Run(op, entry)
+
+		// then
+		assert.NoError(t, err)
+
+		// given
+		emptySI := &unstructured.Unstructured{}
+		emptySI.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "services.cloud.sap.com",
+			Version: "v1",
+			Kind:    "ServiceInstance",
+		})
+
+		// then
+		assert.True(t, k8sCli.cleanupInstances)
+		assert.True(t, k8sCli.cleanupBindings)
+	})
+
+	t.Run("should skip btp-cleanup if not trial", func(t *testing.T) {
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+		si := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "ServiceInstance",
+			"metadata": map[string]interface{}{
+				"name":      "test-instance",
+				"namespace": "kyma-system",
+			},
+		}}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+
+		scheme := scheme.Scheme
+		err := apiextensionsv1.AddToScheme(scheme)
+		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
+		fmt.Println(gvk)
+		require.NoError(t, err)
+
+		k8sCli := &fakeK8sClientWrapper{fake: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj, ns).Build()}
+		err = k8sCli.Create(context.TODO(), si)
+		require.NoError(t, err)
+
+		op := fixture.FixSuspensionOperation(fixOperationID, fixInstanceID)
+		op.ProvisioningParameters.PlanID = broker.AWSPlanID
+		op.State = "in progress"
+		fakeProvisionerClient := fakeProvisionerClient{}
+		step := NewBTPOperatorCleanupStep(ms.Operations(), fakeProvisionerClient, func(k string) (client.Client, error) { return k8sCli, nil })
+
+		// when
+		entry := log.WithFields(logrus.Fields{"step": "TEST"})
+		_, _, err = step.Run(op, entry)
+
+		// then
+		assert.NoError(t, err)
+
+		// given
+		emptySI := &unstructured.Unstructured{}
+		emptySI.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "services.cloud.sap.com",
+			Version: "v1",
+			Kind:    "ServiceInstance",
+		})
+
+		// then
+		assert.False(t, k8sCli.cleanupInstances)
+		assert.False(t, k8sCli.cleanupBindings)
+	})
+
+	t.Run("should skip btp-cleanup if not suspension", func(t *testing.T) {
+		log := logrus.New()
+		ms := storage.NewMemoryStorage()
+		si := &unstructured.Unstructured{Object: map[string]interface{}{
+			"apiVersion": "apiextensions.k8s.io/v1",
+			"kind":       "ServiceInstance",
+			"metadata": map[string]interface{}{
+				"name":      "test-instance",
+				"namespace": "kyma-system",
+			},
+		}}
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
+
+		scheme := scheme.Scheme
+		err := apiextensionsv1.AddToScheme(scheme)
+		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
+		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
+		fmt.Println(gvk)
+		require.NoError(t, err)
+
+		k8sCli := &fakeK8sClientWrapper{fake: fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(obj, ns).Build()}
+		err = k8sCli.Create(context.TODO(), si)
+		require.NoError(t, err)
+
+		op := fixture.FixSuspensionOperation(fixOperationID, fixInstanceID)
+		op.State = "in progress"
+		op.Temporary = false
+		fakeProvisionerClient := fakeProvisionerClient{}
+		step := NewBTPOperatorCleanupStep(ms.Operations(), fakeProvisionerClient, func(k string) (client.Client, error) { return k8sCli, nil })
+
+		// when
+		entry := log.WithFields(logrus.Fields{"step": "TEST"})
+		_, _, err = step.Run(op, entry)
+
+		// then
+		assert.NoError(t, err)
+
+		// given
+		emptySI := &unstructured.Unstructured{}
+		emptySI.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "services.cloud.sap.com",
+			Version: "v1",
+			Kind:    "ServiceInstance",
+		})
+
+		// then
+		assert.False(t, k8sCli.cleanupInstances)
+		assert.False(t, k8sCli.cleanupBindings)
+	})
+}
+
+type fakeK8sClientWrapper struct {
+	fake             client.Client
+	cleanupInstances bool
+	cleanupBindings  bool
+}
+
+func (f *fakeK8sClientWrapper) Get(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+	return f.fake.Get(ctx, key, obj)
+}
+
+func (f *fakeK8sClientWrapper) List(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	if u, ok := list.(*unstructured.UnstructuredList); ok {
+		switch u.Object["kind"] {
+		case "ServiceBindingList":
+			f.cleanupBindings = true
+		case "ServiceInstanceList":
+			f.cleanupInstances = true
+		}
+	}
+	return f.fake.List(ctx, list, opts...)
+}
+
+func (f *fakeK8sClientWrapper) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	return f.fake.Create(ctx, obj, opts...)
+}
+
+func (f *fakeK8sClientWrapper) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	return f.fake.Delete(ctx, obj, opts...)
+}
+
+func (f *fakeK8sClientWrapper) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	return f.fake.Update(ctx, obj, opts...)
+}
+
+func (f *fakeK8sClientWrapper) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	return f.fake.Patch(ctx, obj, patch, opts...)
+}
+
+func (f *fakeK8sClientWrapper) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	return f.fake.DeleteAllOf(ctx, obj, opts...)
+}
+
+func (f *fakeK8sClientWrapper) Status() client.StatusWriter {
+	return f.fake.Status()
+}
+
+func (f *fakeK8sClientWrapper) Scheme() *runtime.Scheme {
+	return f.fake.Scheme()
+}
+
+func (f *fakeK8sClientWrapper) RESTMapper() meta.RESTMapper {
+	return f.fake.RESTMapper()
+}
+
+type fakeProvisionerClient struct{}
+
+func (f fakeProvisionerClient) ProvisionRuntime(accountID, subAccountID string, config gqlschema.ProvisionRuntimeInput) (gqlschema.OperationStatus, error) {
+	panic("not implemented")
+}
+
+func (f fakeProvisionerClient) DeprovisionRuntime(accountID, runtimeID string) (string, error) {
+	panic("not implemented")
+}
+
+func (f fakeProvisionerClient) UpgradeRuntime(accountID, runtimeID string, config gqlschema.UpgradeRuntimeInput) (gqlschema.OperationStatus, error) {
+	panic("not implemented")
+}
+
+func (f fakeProvisionerClient) UpgradeShoot(accountID, runtimeID string, config gqlschema.UpgradeShootInput) (gqlschema.OperationStatus, error) {
+	panic("not implemented")
+}
+
+func (f fakeProvisionerClient) ReconnectRuntimeAgent(accountID, runtimeID string) (string, error) {
+	panic("not implemented")
+}
+
+func (f fakeProvisionerClient) RuntimeOperationStatus(accountID, operationID string) (gqlschema.OperationStatus, error) {
+	panic("not implemented")
+}
+
+func (f fakeProvisionerClient) RuntimeStatus(accountID, runtimeID string) (gqlschema.RuntimeStatus, error) {
+	kubeconfig := "sample fake kubeconfig"
+	return gqlschema.RuntimeStatus{
+		RuntimeConfiguration: &gqlschema.RuntimeConfig{
+			Kubeconfig: &kubeconfig,
+		},
+	}, nil
+}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1969"
+      version: "PR-1974"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

After removing https://github.com/kyma-project/control-plane/pull/1956, it was identified that there is currently a need for SKR cleanup of BTP Operator resources by KEB for suspensions.

KEB doesn't currently have any built-in mechanism to mark the operation as failed while still going through all the steps of deprovisioning. As a result, if the suspension operation fails to cleanup BTP-Operator resources, the errors appear in logs only and after the 30 min timeout, the operation processing continues forward with next steps as if nothing was wrong. This may result in external resource leakage but the team consensus is that this is acceptable.