### PR TITLE
Add pagesize of 20 to list operations command

### DIFF
--- a/tools/cli/pkg/command/orchestration.go
+++ b/tools/cli/pkg/command/orchestration.go
@@ -306,11 +306,12 @@ func (cmd *OrchestrationCommand) Validate(args []string) error {
 }
 
 func (cmd *OrchestrationCommand) showOrchestrations() error {
+	cmd.listParams.PageSize = 20
 	srl, err := cmd.client.ListOrchestrations(cmd.listParams)
 	if err != nil {
 		return errors.Wrap(err, "while listing orchestrations")
 	}
-
+	cmd.listParams.PageSize = 0
 	switch {
 	case cmd.output == tableOutput:
 		tp, err := printer.NewTablePrinter(orchestrationColumns, false)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- list operations return a huge list of operations, which is impractical. We would like to limit the default number to 20.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
