### PR TITLE
enhancement: kubeconfig service slow start

### DIFF
--- a/components/kubeconfig-service/pkg/runtime/runtime.go
+++ b/components/kubeconfig-service/pkg/runtime/runtime.go
@@ -45,11 +45,11 @@ const ServiceAccount = "ServiceAccount"
 const Token = "token"
 
 var L2L3OperatorPolicyRule = map[string][]rbacv1.PolicyRule{
-	RUNTIME_ADMIN: []rbacv1.PolicyRule{
+	RUNTIME_ADMIN: {
 		rbacv1helpers.NewRule("*").Groups("*").Resources("*").RuleOrDie(),
 		rbacv1helpers.NewRule("*").URLs("*").RuleOrDie(),
 	},
-	RUNTIME_OPERATOR: []rbacv1.PolicyRule{
+	RUNTIME_OPERATOR: {
 		rbacv1helpers.NewRule("get", "list", "watch").Groups("*").Resources("*").RuleOrDie(),
 		rbacv1helpers.NewRule("get", "list", "watch").URLs("*").RuleOrDie(),
 	},
@@ -92,7 +92,7 @@ func NewRuntimeClient(kubeConfig []byte, userID string, L2L3OperatiorRole string
 	return &RuntimeClient{clientset, coreClientset, user, L2L3OperatiorRole, RollbackE}, nil
 }
 
-//kubeconfig access runtime, create sa and clusterrole and clusterrolebinding according to userID and l2L3OperatiorRole
+// kubeconfig access runtime, create sa and clusterrole and clusterrolebinding according to userID and l2L3OperatiorRole
 func (rtc *RuntimeClient) Run() (string, error) {
 	var resultE error
 	defer func() {
@@ -344,7 +344,7 @@ func (rtc *RuntimeClient) getServiceAccount(info *SAInfo) func() error {
 	}
 }
 
-//Clean service account and cluster role
+// Clean service account and cluster role
 func (rtc *RuntimeClient) Cleaner() error {
 	if len(rtc.RollbackE.Data) == 0 {
 		return nil

--- a/components/kubeconfig-service/pkg/runtime/runtime_kcp.go
+++ b/components/kubeconfig-service/pkg/runtime/runtime_kcp.go
@@ -36,7 +36,7 @@ Data:map[string]string
 
 const KcpNamespace string = "kcp-system"
 
-const ExpireTime time.Duration = 7 * 24 * time.Hour
+const ExpireTime time.Duration = 24 * time.Hour
 
 type JsonPatchType struct {
 	Op    string `json:"op"`

--- a/resources/oidc-kubeconfig-service/templates/deployment.yaml
+++ b/resources/oidc-kubeconfig-service/templates/deployment.yaml
@@ -72,9 +72,9 @@ spec:
             httpGet:
               path: /health/ready
               port: health
-            initialDelaySeconds: 5
-            timeoutSeconds: 1
-            periodSeconds: 2
+            initialDelaySeconds: {{ .Values.global.readinessProbe.initialDelaySeconds }}
+            timeoutSeconds: {{ .Values.global.readinessProbe.timeoutSeconds }}
+            periodSeconds: {{ .Values.global.readinessProbe.periodSeconds }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -14,12 +14,16 @@ global:
     initialDelaySeconds: 180
     timeoutSeconds: 1
     periodSeconds: 10
+  readinessProbe:
+    initialDelaySeconds: 60
+    timeoutSeconds: 1
+    periodSeconds: 10
 
 replicaCount: 1
 
 image:
   repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
-  tag: "PR-1795"
+  tag: "PR-1985"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
enhance the initialization process of kubeconfig service to solve slow-start problem

Changes proposed in this pull request:

- make readinessProbeDelay editable
- reduce expire time to 24 hours
- move ConfigMaps initialization to goroutine

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.tools.sap/kyma/backlog/issues/2801