### PR TITLE
Fix missing quote around .Values.gardener.kubernetesVersion

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -319,7 +319,7 @@ spec:
             - name: APP_KUBECONFIG_ALLOW_ORIGINS
               value: "{{ .Values.kubeconfig.allowOrigins }}"
             - name: APP_PROVISIONER_KUBERNETES_VERSION
-              value: {{ .Values.gardener.kubernetesVersion }}
+              value: "{{ .Values.gardener.kubernetesVersion }}"
             - name: APP_PROVISIONER_MACHINE_IMAGE
               value: {{ .Values.gardener.machineImage }}
             - name: APP_PROVISIONER_MACHINE_IMAGE_VERSION


### PR DESCRIPTION
**Description**

Partial kubernetes versions (e.g. major.minor: 1.23) can be configured in Gardener, however KEB chart doesn't support it as helm will convert the input value from string to a float number automatically. 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
