### PR TITLE
Kubeconfig field added to provisioning request

### DIFF
--- a/components/kyma-environment-broker/internal/broker/instance_create_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create_test.go
@@ -35,12 +35,13 @@ const (
 	subAccountID    = "3cb65e5b-e455-4799-bf35-be46e8f5a533"
 	userID          = "test@test.pl"
 
-	instanceID       = "d3d5dca4-5dc8-44ee-a825-755c2a3fb839"
-	otherInstanceID  = "87bfaeaa-48eb-40d6-84f3-3d5368eed3eb"
-	existOperationID = "920cbfd9-24e9-4aa2-aa77-879e9aabe140"
-	clusterName      = "cluster-testing"
-	region           = "eu"
-	brokerURL        = "example.com"
+	instanceID         = "d3d5dca4-5dc8-44ee-a825-755c2a3fb839"
+	otherInstanceID    = "87bfaeaa-48eb-40d6-84f3-3d5368eed3eb"
+	existOperationID   = "920cbfd9-24e9-4aa2-aa77-879e9aabe140"
+	clusterName        = "cluster-testing"
+	region             = "eu"
+	brokerURL          = "example.com"
+	kubeconfigContents = "apiVersion: v1\nkind: Config"
 )
 
 var enabledDashboardConfig dashboard.Config = dashboard.Config{Enabled: true, LandscapeURL: "https://dashboard.example.com"}
@@ -152,7 +153,7 @@ func TestProvision_Provision(t *testing.T) {
 		)
 
 		// when
-		kubeconfigEncoded := base64.StdEncoding.EncodeToString([]byte("apiVersion: v1\nkind: Config"))
+		kubeconfigEncoded := base64.StdEncoding.EncodeToString([]byte(kubeconfigContents))
 		response, err := provisionEndpoint.Provision(fixRequestContext(t, "req-region"), instanceID, domain.ProvisionDetails{
 			ServiceID:     serviceID,
 			PlanID:        planID,
@@ -163,6 +164,7 @@ func TestProvision_Provision(t *testing.T) {
 
 		// then
 		require.NoError(t, err)
+		// UUID with version 4 and variant 1 i.e RFC. 4122/DCE
 		assert.Regexp(t, "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-4[a-fA-F0-9]{3}-[8|9|aA|bB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$", response.OperationData)
 		assert.NotEqual(t, instanceID, response.OperationData)
 		assert.Regexp(t, `^https:\/\/dashboard\.example\.com\/\?kubeconfigID=`, response.DashboardURL)
@@ -180,7 +182,7 @@ func TestProvision_Provision(t *testing.T) {
 
 		kubeconfigParameter, err := base64.StdEncoding.DecodeString(operation.ProvisioningParameters.Parameters.Kubeconfig)
 		require.NoError(t, err)
-		assert.Regexp(t, `.*kind: Config$`, string(kubeconfigParameter))
+		assert.Equal(t, kubeconfigContents, string(kubeconfigParameter))
 
 		assert.Equal(t, fixDNSProviders(), operation.ShootDNSProviders)
 

--- a/components/kyma-environment-broker/internal/dto.go
+++ b/components/kyma-environment-broker/internal/dto.go
@@ -177,6 +177,8 @@ type ProvisioningParametersDTO struct {
 	//Provider - used in Trial plan to determine which cloud provider to use during provisioning
 	Provider *CloudProvider `json:"provider"`
 
+	Kubeconfig string `json:"kubeconfig"`
+
 	OIDC *OIDCConfigDTO `json:"oidc,omitempty"`
 }
 

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-1991"
+      version: "PR-2000"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

As a part of PoC we extend provisioning request with field (optional) containing encoded kubeconfig.
It should facilitate provisioning Kyma on cluster provided by the caller.

Changes proposed in this pull request:

- DTO with Kubeconfig field

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
