### PR TITLE
trace orchestration -s failed

### DIFF
--- a/components/kyma-environment-broker/internal/orchestration/handlers/orchestration_handler.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/orchestration_handler.go
@@ -236,6 +236,8 @@ func (h *orchestrationHandler) listOperations(w http.ResponseWriter, r *http.Req
 	var response commonOrchestration.OperationResponseList
 	switch o.Type {
 	case commonOrchestration.UpgradeKymaOrchestration:
+		fmt.Println("orchestrationID is:", orchestrationID)
+		fmt.Println("filter is:", filter)
 		operations, count, totalCount, err := h.operations.ListUpgradeKymaOperationsByOrchestrationID(orchestrationID, filter)
 		if err != nil {
 			h.log.Errorf("while getting operations: %v", err)

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -147,6 +147,7 @@ func (r readSession) GetOperationByID(opID string) (dbmodel.OperationDTO, dberr.
 }
 
 func (r readSession) ListOperations(filter dbmodel.OperationFilter) ([]dbmodel.OperationDTO, int, int, error) {
+	fmt.Println("readSession ListOperations", filter)
 	var operations []dbmodel.OperationDTO
 
 	stmt := r.session.Select("*").


### PR DESCRIPTION
add trace to troubleshooting the [kcp-cli "orchestration <orch_id> operations" failed to filter using "--state failed"](https://github.tools.sap/kyma/backlog/issues/2886)