### PR TITLE
Use runtime scheme per unit test thread

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -57,7 +57,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -103,7 +102,7 @@ func (s *BrokerSuiteTest) TearDown() {
 
 func NewBrokerSuiteTest(t *testing.T, version ...string) *BrokerSuiteTest {
 	ctx := context.Background()
-	sch := scheme.Scheme
+	sch := internal.NewSchemeForTests()
 	apiextensionsv1.AddToScheme(sch)
 	additionalKymaVersions := []string{"1.19", "1.20", "main", "2.0"}
 	additionalKymaVersions = append(additionalKymaVersions, version...)

--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/fixture"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
@@ -20,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -55,7 +55,7 @@ func TestRemoveServiceInstanceStep(t *testing.T) {
 		}}
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
 
-		scheme := scheme.Scheme
+		scheme := internal.NewSchemeForTests()
 		err := apiextensionsv1.AddToScheme(scheme)
 		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
@@ -104,7 +104,7 @@ func TestRemoveServiceInstanceStep(t *testing.T) {
 		}}
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
 
-		scheme := scheme.Scheme
+		scheme := internal.NewSchemeForTests()
 		err := apiextensionsv1.AddToScheme(scheme)
 		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 		obj, gvk, err := decoder.Decode(siCRD, nil, nil)
@@ -154,7 +154,7 @@ func TestRemoveServiceInstanceStep(t *testing.T) {
 		}}
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "kyma-system"}}
 
-		scheme := scheme.Scheme
+		scheme := internal.NewSchemeForTests()
 		err := apiextensionsv1.AddToScheme(scheme)
 		decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 		obj, gvk, err := decoder.Decode(siCRD, nil, nil)

--- a/components/kyma-environment-broker/internal/test_utils.go
+++ b/components/kyma-environment-broker/internal/test_utils.go
@@ -1,0 +1,17 @@
+package internal
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// KEB tests can run in parallel resulting in concurrent access to scheme maps
+// if the global scheme from client-go is used. For this reason, KEB tests each have
+// their own scheme.
+func NewSchemeForTests() *runtime.Scheme {
+	sch := runtime.NewScheme()
+	corev1.AddToScheme(sch)
+	apiextensionsv1.AddToScheme(sch)
+	return sch
+}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
I switched the runtime scheme in tests to use globally defined scheme in https://github.com/kyma-project/control-plane/pull/1974#discussion_r951331308, but this has introduced flakiness within the tests failing with:
```
fatal error: concurrent map read and map write
...
[0119] | /workspace/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/vendor/k8s.io/apimachinery/pkg/runtime/scheme.go:267 +0x1b5 fp=0xc000feb190 sp=0xc000feb0a0 pc=0x9a5b35
[0119] | sigs.k8s.io/controller-runtime/pkg/client/apiutil.GVKForObject({0x1c38fa8, 0xc0005265b0}, 0xc0005265b0)
...
```

the reason is that multiple tests can be run in parallel and they each initialize their own additional API groups.

This PR goes back to scheme per test so no concurrent map read/write can occur