### PR TITLE
Display machine type details in KEB catalog

### DIFF
--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -97,8 +97,8 @@ func OpenStackRegions() []string {
 	return []string{"eu-de-1", "ap-sa-1"}
 }
 
-func OpenStackSchema(machineTypes []string, additionalParams, update bool) *map[string]interface{} {
-	properties := NewProvisioningProperties(machineTypes, OpenStackRegions(), update)
+func OpenStackSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, OpenStackRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
 	if !update {
 		properties.AutoScalerMax.Default = 8
@@ -106,20 +106,20 @@ func OpenStackSchema(machineTypes []string, additionalParams, update bool) *map[
 	return createSchemaWithProperties(properties, additionalParams, update)
 }
 
-func GCPSchema(machineTypes []string, additionalParams, update bool) *map[string]interface{} {
-	return createSchema(machineTypes, GCPRegions(), additionalParams, update)
+func GCPSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+	return createSchema(machineTypesDisplay, machineTypes, GCPRegions(), additionalParams, update)
 }
 
-func AWSSchema(machineTypes []string, additionalParams, update bool) *map[string]interface{} {
-	return createSchema(machineTypes, AWSRegions(), additionalParams, update)
+func AWSSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+	return createSchema(machineTypesDisplay, machineTypes, AWSRegions(), additionalParams, update)
 }
 
-func AzureSchema(machineTypes []string, additionalParams, update bool) *map[string]interface{} {
-	return createSchema(machineTypes, AzureRegions(), additionalParams, update)
+func AzureSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+	return createSchema(machineTypesDisplay, machineTypes, AzureRegions(), additionalParams, update)
 }
 
-func AzureLiteSchema(machineTypes []string, additionalParams, update bool) *map[string]interface{} {
-	properties := NewProvisioningProperties(machineTypes, AzureRegions(), update)
+func AzureLiteSchema(machineTypesDisplay map[string]string, machineTypes []string, additionalParams, update bool) *map[string]interface{} {
+	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, AzureRegions(), update)
 	properties.AutoScalerMax.Maximum = 40
 
 	if !update {
@@ -172,8 +172,8 @@ func empty() *map[string]interface{} {
 	return &empty
 }
 
-func createSchema(machineTypes, regions []string, additionalParams, update bool) *map[string]interface{} {
-	properties := NewProvisioningProperties(machineTypes, regions, update)
+func createSchema(machineTypesDisplay map[string]string, machineTypes, regions []string, additionalParams, update bool) *map[string]interface{} {
+	properties := NewProvisioningProperties(machineTypesDisplay, machineTypes, regions, update)
 	return createSchemaWithProperties(properties, additionalParams, update)
 }
 
@@ -209,19 +209,58 @@ func createSchemaWith(properties interface{}, update bool) *map[string]interface
 // keep internal/hyperscaler/azure/config.go in sync with any changes to available zones
 func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditionalParamsInSchema bool) map[string]domain.ServicePlan {
 	awsMachines := []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge", "m6i.xlarge", "m6i.2xlarge", "m6i.4xlarge", "m6i.8xlarge", "m6i.12xlarge"}
+	awsMachinesDisplay := map[string]string{
+		// source: https://aws.amazon.com/ec2/instance-types/m5/
+		"m5.xlarge":   "m5.xlarge (4vCPU, 16GB RAM)",
+		"m5.2xlarge":  "m5.2xlarge (8vCPU, 32GB RAM)",
+		"m5.4xlarge":  "m5.4xlarge (16vCPU, 64GB RAM)",
+		"m5.8xlarge":  "m5.8xlarge (32vCPU, 128GB RAM)",
+		"m5.12xlarge": "m5.12xlarge (48vCPU, 192GB RAM)",
+		// source: https://aws.amazon.com/ec2/instance-types/m6i/
+		"m6i.xlarge":   "m6i.xlarge (4vCPU, 16GB RAM)",
+		"m6i.2xlarge":  "m6i.2xlarge (8vCPU, 32GB RAM)",
+		"m6i.4xlarge":  "m6i.4xlarge (16vCPU, 64GB RAM)",
+		"m6i.8xlarge":  "m6i.8xlarge (32vCPU, 128GB RAM)",
+		"m6i.12xlarge": "m6i.12xlarge (48vCPU, 192GB RAM)",
+	}
 
-	// awsHASchema := AWSHASchema(awsMachines, includeAdditionalParamsInSchema, false)
+	// awsHASchema := AWSHASchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, false)
 
+	// source: https://cloud.google.com/compute/docs/general-purpose-machines#e2_limitations
 	gcpMachines := []string{"n2-standard-4", "n2-standard-8", "n2-standard-16", "n2-standard-32", "n2-standard-48"}
-	gcpSchema := GCPSchema(gcpMachines, includeAdditionalParamsInSchema, false)
+	gcpMachinesDisplay := map[string]string{
+		"n2-standard-4":  "n2-standard-4 (4vCPU, 16GB RAM)",
+		"n2-standard-8":  "n2-standard-8 (8vCPU, 32GB RAM)",
+		"n2-standard-16": "n2-standard-16 (16vCPU, 64GB RAM)",
+		"n2-standard-32": "n2-standard-32 (32vCPU, 128GB RAM)",
+		"n2-standard-48": "n2-standard-48 (48vCPU, 192B RAM)",
+	}
+	gcpSchema := GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, false)
 
 	openStackMachines := []string{"g_c4_m16", "g_c8_m32"}
-	openstackSchema := OpenStackSchema(openStackMachines, includeAdditionalParamsInSchema, false)
+	openStackMachinesDisplay := map[string]string{
+		"g_c4_m16": "g_c4_m16 (4vCPU, 16GB RAM)",
+		"g_c8_m32": "g_c8_m32 (8vCPU, 32GB RAM)",
+	}
+	openstackSchema := OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, false)
 
+	// source: https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-sizes-specs#dv3-series
 	azureMachines := []string{"Standard_D4_v3", "Standard_D8_v3", "Standard_D16_v3", "Standard_D32_v3", "Standard_D48_v3", "Standard_D64_v3"}
-	azureSchema := AzureSchema(azureMachines, includeAdditionalParamsInSchema, false)
+	azureMachinesDisplay := map[string]string{
+		"Standard_D4_v3":  "Standard_D4_v3 (4vCPU, 16GB RAM)",
+		"Standard_D8_v3":  "Standard_D8_v3 (8vCPU, 32GB RAM)",
+		"Standard_D16_v3": "Standard_D16_v3 (16vCPU, 64GB RAM)",
+		"Standard_D32_v3": "Standard_D32_v3 (32vCPU, 128GB RAM)",
+		"Standard_D48_v3": "Standard_D48_v3 (48vCPU, 192GB RAM)",
+		"Standard_D64_v3": "Standard_D64_v3 (64vCPU, 256GB RAM)",
+	}
+	azureSchema := AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, false)
 
-	azureLiteSchema := AzureLiteSchema([]string{"Standard_D4_v3"}, includeAdditionalParamsInSchema, false)
+	azureLiteMachines := []string{"Standard_D4_v3"}
+	azureLiteMachinesDisplay := map[string]string{
+		"Standard_D4_v3": azureMachinesDisplay["Standard_D4_v3"],
+	}
+	azureLiteSchema := AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, false)
 	freemiumSchema := FreemiumSchema(provider, includeAdditionalParamsInSchema, false)
 	trialSchema := TrialSchema(includeAdditionalParamsInSchema, false)
 
@@ -229,14 +268,21 @@ func Plans(plans PlansConfig, provider internal.CloudProvider, includeAdditional
 	// when a machine type switch is introduced
 	// switch to m6 if m6 is available in all regions
 	awsCatalogMachines := []string{"m5.xlarge", "m5.2xlarge", "m5.4xlarge", "m5.8xlarge", "m5.12xlarge"}
-	awsCatalogSchema := AWSSchema(awsCatalogMachines, includeAdditionalParamsInSchema, false)
+	awsCatalogMachinesDisplay := map[string]string{
+		"m5.xlarge":   awsMachinesDisplay["m5.xlarge"],
+		"m5.2xlarge":  awsMachinesDisplay["m5.2xlarge"],
+		"m5.4xlarge":  awsMachinesDisplay["m5.4xlarge"],
+		"m5.8xlarge":  awsMachinesDisplay["m5.8xlarge"],
+		"m5.12xlarge": awsMachinesDisplay["m5.12xlarge"],
+	}
+	awsCatalogSchema := AWSSchema(awsCatalogMachinesDisplay, awsCatalogMachines, includeAdditionalParamsInSchema, false)
 
 	outputPlans := map[string]domain.ServicePlan{
-		AWSPlanID:       defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsCatalogSchema, AWSSchema(awsMachines, includeAdditionalParamsInSchema, true)),
-		GCPPlanID:       defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachines, includeAdditionalParamsInSchema, true)),
-		OpenStackPlanID: defaultServicePlan(OpenStackPlanID, OpenStackPlanName, plans, openstackSchema, OpenStackSchema(openStackMachines, includeAdditionalParamsInSchema, true)),
-		AzurePlanID:     defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachines, includeAdditionalParamsInSchema, true)),
-		AzureLitePlanID: defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema([]string{"Standard_D4_v3"}, includeAdditionalParamsInSchema, true)),
+		AWSPlanID:       defaultServicePlan(AWSPlanID, AWSPlanName, plans, awsCatalogSchema, AWSSchema(awsMachinesDisplay, awsMachines, includeAdditionalParamsInSchema, true)),
+		GCPPlanID:       defaultServicePlan(GCPPlanID, GCPPlanName, plans, gcpSchema, GCPSchema(gcpMachinesDisplay, gcpMachines, includeAdditionalParamsInSchema, true)),
+		OpenStackPlanID: defaultServicePlan(OpenStackPlanID, OpenStackPlanName, plans, openstackSchema, OpenStackSchema(openStackMachinesDisplay, openStackMachines, includeAdditionalParamsInSchema, true)),
+		AzurePlanID:     defaultServicePlan(AzurePlanID, AzurePlanName, plans, azureSchema, AzureSchema(azureMachinesDisplay, azureMachines, includeAdditionalParamsInSchema, true)),
+		AzureLitePlanID: defaultServicePlan(AzureLitePlanID, AzureLitePlanName, plans, azureLiteSchema, AzureLiteSchema(azureLiteMachinesDisplay, azureLiteMachines, includeAdditionalParamsInSchema, true)),
 		FreemiumPlanID:  defaultServicePlan(FreemiumPlanID, FreemiumPlanName, plans, freemiumSchema, FreemiumSchema(provider, includeAdditionalParamsInSchema, true)),
 		TrialPlanID:     defaultServicePlan(TrialPlanID, TrialPlanName, plans, trialSchema, TrialSchema(includeAdditionalParamsInSchema, true)),
 	}

--- a/components/kyma-environment-broker/internal/broker/plans_schema.go
+++ b/components/kyma-environment-broker/internal/broker/plans_schema.go
@@ -60,13 +60,14 @@ type Type struct {
 
 	// Regex pattern to match against string type of fields.
 	// If not specified for strings user can pass empty string with whitespaces only.
-	Pattern         string        `json:"pattern,omitempty"`
-	Default         interface{}   `json:"default,omitempty"`
-	Example         interface{}   `json:"example,omitempty"`
-	Enum            []interface{} `json:"enum,omitempty"`
-	Items           []Type        `json:"items,omitempty"`
-	AdditionalItems *bool         `json:"additionalItems,omitempty"`
-	UniqueItems     *bool         `json:"uniqueItems,omitempty"`
+	Pattern         string            `json:"pattern,omitempty"`
+	Default         interface{}       `json:"default,omitempty"`
+	Example         interface{}       `json:"example,omitempty"`
+	Enum            []interface{}     `json:"enum,omitempty"`
+	EnumDisplayName map[string]string `json:"_enumDisplayName,omitempty"`
+	Items           []Type            `json:"items,omitempty"`
+	AdditionalItems *bool             `json:"additionalItems,omitempty"`
+	UniqueItems     *bool             `json:"uniqueItems,omitempty"`
 }
 
 type NameType struct {
@@ -96,7 +97,7 @@ func NameProperty() NameType {
 
 // NewProvisioningProperties creates a new properties for different plans
 // Note that the order of properties will be the same in the form on the website
-func NewProvisioningProperties(machineTypes []string, regions []string, update bool) ProvisioningProperties {
+func NewProvisioningProperties(machineTypesDisplay map[string]string, machineTypes, regions []string, update bool) ProvisioningProperties {
 
 	properties := ProvisioningProperties{
 		UpdateProperties: UpdateProperties{
@@ -120,8 +121,9 @@ func NewProvisioningProperties(machineTypes []string, regions []string, update b
 			Enum: ToInterfaceSlice(regions),
 		},
 		MachineType: &Type{
-			Type: "string",
-			Enum: ToInterfaceSlice(machineTypes),
+			Type:            "string",
+			Enum:            ToInterfaceSlice(machineTypes),
+			EnumDisplayName: machineTypesDisplay,
 		},
 	}
 

--- a/components/kyma-environment-broker/internal/broker/plans_test.go
+++ b/components/kyma-environment-broker/internal/broker/plans_test.go
@@ -15,13 +15,14 @@ import (
 
 func TestSchemaGenerator(t *testing.T) {
 	tests := []struct {
-		name           string
-		generator      func([]string, bool, bool) *map[string]interface{}
-		machineTypes   []string
-		file           string
-		updateFile     string
-		fileOIDC       string
-		updateFileOIDC string
+		name                string
+		generator           func(map[string]string, []string, bool, bool) *map[string]interface{}
+		machineTypes        []string
+		machineTypesDisplay map[string]string
+		file                string
+		updateFile          string
+		fileOIDC            string
+		updateFileOIDC      string
 	}{
 		{
 			name:           "AWS schema is correct",
@@ -42,13 +43,14 @@ func TestSchemaGenerator(t *testing.T) {
 			updateFileOIDC: "update-azure-schema-additional-params.json",
 		},
 		{
-			name:           "AzureLite schema is correct",
-			generator:      AzureLiteSchema,
-			machineTypes:   []string{"Standard_D4_v3"},
-			file:           "azure-lite-schema.json",
-			updateFile:     "update-azure-lite-schema.json",
-			fileOIDC:       "azure-lite-schema-additional-params.json",
-			updateFileOIDC: "update-azure-lite-schema-additional-params.json",
+			name:                "AzureLite schema is correct",
+			generator:           AzureLiteSchema,
+			machineTypes:        []string{"Standard_D4_v3"},
+			machineTypesDisplay: map[string]string{"Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"},
+			file:                "azure-lite-schema.json",
+			updateFile:          "update-azure-lite-schema.json",
+			fileOIDC:            "azure-lite-schema-additional-params.json",
+			updateFileOIDC:      "update-azure-lite-schema-additional-params.json",
 		},
 		{
 			name:           "GCP schema is correct",
@@ -70,7 +72,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Trial schema is correct",
-			generator: func(machines []string, additionalParams, update bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return TrialSchema(additionalParams, update)
 			},
 			machineTypes:   []string{},
@@ -81,7 +83,7 @@ func TestSchemaGenerator(t *testing.T) {
 		},
 		{
 			name: "Freemium schema is correct",
-			generator: func(machines []string, additionalParams, update bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return FreemiumSchema(internal.Azure, additionalParams, update)
 			},
 			machineTypes:   []string{},
@@ -93,7 +95,7 @@ func TestSchemaGenerator(t *testing.T) {
 
 		{
 			name: " schema is correct",
-			generator: func(machines []string, additionalParams, update bool) *map[string]interface{} {
+			generator: func(machinesDisplay map[string]string, machines []string, additionalParams, update bool) *map[string]interface{} {
 				return FreemiumSchema(internal.AWS, additionalParams, update)
 			},
 			machineTypes:   []string{},
@@ -105,16 +107,16 @@ func TestSchemaGenerator(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.generator(tt.machineTypes, false, false)
+			got := tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, false)
 			validateSchema(t, Marshal(got), tt.file)
 
-			got = tt.generator(tt.machineTypes, false, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, false, true)
 			validateSchema(t, Marshal(got), tt.updateFile)
 
-			got = tt.generator(tt.machineTypes, true, false)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, false)
 			validateSchema(t, Marshal(got), tt.fileOIDC)
 
-			got = tt.generator(tt.machineTypes, true, true)
+			got = tt.generator(tt.machineTypesDisplay, tt.machineTypes, true, true)
 			validateSchema(t, Marshal(got), tt.updateFileOIDC)
 		})
 	}

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema-additional-params.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema-additional-params.json
@@ -35,6 +35,9 @@
       "type": "integer"
     },
     "machineType": {
+      "_enumDisplayName": {
+        "Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"
+      },
       "enum": [
         "Standard_D4_v3"
       ],

--- a/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema.json
+++ b/components/kyma-environment-broker/internal/broker/testdata/azure-lite-schema.json
@@ -23,6 +23,9 @@
       "type": "integer"
     },
     "machineType": {
+      "_enumDisplayName": {
+        "Standard_D4_v3": "Standard_D4_v3 (4vCPU, 16GB RAM)"
+      },
       "enum": [
         "Standard_D4_v3"
       ],

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2015"
+      version: "PR-2028"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION


**Description**

It is requested that KEB catalog contains detais for machine types as described in:
```diff
51,54c63,67
<                         "n2-standard-8 (8vCPU, 32GB RAM)",
<                         "n2-standard-16 (16vCPU, 64GB RAM)",
<                         "n2-standard-32 (32vCPU, 128GB RAM)",
<                         "n2-standard-48 (48vCPU, 192GB RAM)"
---
>                         "n2-standard-4",
>                         "n2-standard-8",
>                         "n2-standard-16",
>                         "n2-standard-32",
>                         "n2-standard-48"
```
This PR uses `_enumDisplayName` SAP enhancement to OSB API as described in:
https://wiki.one.int.sap/wiki/pages/viewpage.action?spaceKey=CPC15N&title=%5BCookbook%5D+How+to+Render+a+Form+for+Input+Parameters#id-[Cookbook]HowtoRenderaFormforInputParameters-enumproperty

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
