### PR TITLE
Reverting literals in switch clause to restore missing metrics

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/step_result.go
+++ b/components/kyma-environment-broker/internal/metrics/step_result.go
@@ -121,7 +121,7 @@ func (c *StepResultCollector) OnOperationStepProcessed(ctx context.Context, ev i
 	}
 
 	switch {
-	case stepProcessed.Operation.Type == internal.OperationTypeProvision:
+	case stepProcessed.Operation.Type == "provisioning":
 		provisioningStepProcessed := process.ProvisioningStepProcessed{
 			Operation:     internal.ProvisioningOperation{Operation: stepProcessed.Operation},
 			StepProcessed: stepProcessed.StepProcessed,

--- a/components/kyma-environment-broker/internal/metrics/step_result.go
+++ b/components/kyma-environment-broker/internal/metrics/step_result.go
@@ -130,7 +130,7 @@ func (c *StepResultCollector) OnOperationStepProcessed(ctx context.Context, ev i
 		if err != nil {
 			return err
 		}
-	case stepProcessed.Operation.Type == internal.OperationTypeDeprovision:
+	case stepProcessed.Operation.Type == "deprovisioning":
 		deprovisioningStepProcessed := process.DeprovisioningStepProcessed{
 			Operation:     internal.DeprovisioningOperation{Operation: stepProcessed.Operation},
 			StepProcessed: stepProcessed.StepProcessed,

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2017"
+      version: "PR-2037"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We changed "provisioning" literal to `internal.OperationTypeProvision` which is actually "provision".
Similar we changed "deprovisionig" to "deprovision"

Changes proposed in this pull request:

- Reverting to the "provisioning" literal 
- Reverting to the "deprovisioning" literal 

**Related issue(s)**
https://github.tools.sap/kyma/backlog/issues/2939

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
