### PR TITLE
Register compass_keb_provisioning_result metrics to generic operations manager

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/metrics.go
+++ b/components/kyma-environment-broker/internal/metrics/metrics.go
@@ -24,6 +24,7 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 	sub.Subscribe(process.ProvisioningStepProcessed{}, stepResultCollector.OnProvisioningStepProcessed)
 	sub.Subscribe(process.DeprovisioningStepProcessed{}, stepResultCollector.OnDeprovisioningStepProcessed)
 	sub.Subscribe(process.OperationStepProcessed{}, stepResultCollector.OnOperationStepProcessed)
+	sub.Subscribe(process.OperationStepProcessed{}, opResultCollector.OnOperationStepProcessed)
 	sub.Subscribe(process.OperationSucceeded{}, opResultCollector.OnOperationSucceeded)
 	sub.Subscribe(process.OperationSucceeded{}, opDurationCollector.OnOperationSucceeded)
 }

--- a/components/kyma-environment-broker/internal/metrics/operation_result.go
+++ b/components/kyma-environment-broker/internal/metrics/operation_result.go
@@ -128,6 +128,28 @@ func (c *OperationResultCollector) OnUpgradeClusterStepProcessed(ctx context.Con
 	return nil
 }
 
+func (c *OperationResultCollector) OnOperationStepProcessed(ctx context.Context, ev interface{}) error {
+	e, ok := ev.(process.OperationStepProcessed)
+	if !ok {
+		return fmt.Errorf("expected OperationStepProcessed but got %+v", ev)
+	}
+
+	switch e.Operation.Type {
+	case internal.OperationTypeProvision:
+		return c.OnProvisioningStepProcessed(ctx, process.ProvisioningStepProcessed{
+			StepProcessed: e.StepProcessed,
+			Operation:     internal.ProvisioningOperation{Operation: e.Operation},
+		})
+	case internal.OperationTypeDeprovision:
+		return c.OnDeprovisioningStepProcessed(ctx, process.DeprovisioningStepProcessed{
+			StepProcessed: e.StepProcessed,
+			Operation:     internal.DeprovisioningOperation{Operation: e.Operation},
+		})
+	default:
+		return fmt.Errorf("expected OperationStep of types [%s, %s] but got %+v", internal.OperationTypeProvision, internal.OperationTypeDeprovision, e.Operation.Type)
+	}
+}
+
 func (c *OperationResultCollector) OnProvisioningSucceeded(ctx context.Context, ev interface{}) error {
 	provisioningSucceeded, ok := ev.(process.ProvisioningSucceeded)
 	if !ok {


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
https://github.com/kyma-project/control-plane/pull/1875 has introduced new operations processing manager with callbacks for most of the metrics but looks like `compass_keb_provisioning_result` got forgotten for steps processing. This adds the callback following the patterns set by #1875.

Queried on custom deployment shortly after provisioning call
```
$ curl localhost:8080/metrics | grep compass_keb_provisioning_result


  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  339# HELP compass_keb_provisioning_result Result of the provisioning 4200
k # TYPE compass_keb_provisioning_result gauge
 compass_keb_provisioning_result{error_category="",error_reason="",global_account_id="e449f875-b5b2-4485-b7c0-98725c0571bf",instance_id="test-jw225",operation_id="898515a1-cbe5-4ae5-97bc-4dd2ad874b6f",plan_id="7d55d31d-35ae-4438-bf13-6ffdfa107d9f"} 0
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
