### PR TITLE
Non-repetitive definition of build targets for CLI tools

### DIFF
--- a/tools/cli/Makefile
+++ b/tools/cli/Makefile
@@ -56,7 +56,7 @@ go-mod-check:
 errcheck:
 	errcheck -blank -asserts -ignorepkg '$$($(DIRS_TO_CHECK) | tr '\n' ',')' -ignoregenerated ./...
 
-build: build-windows-kcp build-windows-ers build-linux-kcp build-linux-ers build-darwin-kcp build-darwin-ers
+build: $(foreach TOOL,ers kcp,$(foreach OS,linux windows darwin,build-$(OS)-$(TOOL)))
 
 build-windows-%:
 	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o $(ARTIFACTS)/$*.exe $(CLI_FLAGS) cmd/$*/main.go


### PR DESCRIPTION
Followup to https://github.com/kyma-project/control-plane/pull/2053, this reduces repetitiveness of build target definitions.

The change is rather cosmetic, main goal is actually to trigger automated builds from https://github.com/kyma-project/test-infra/pull/6031 to check if they work ok.