### PR TITLE
Aggregate error from operation manager when marking operation as failed

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/check_runtime_removal_step_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/check_runtime_removal_step_test.go
@@ -58,6 +58,6 @@ func TestCheckRuntimeRemovalStep_ProvisionerFailed(t *testing.T) {
 	op, _, err := svc.Run(dOp, log)
 
 	// then
-	require.NoError(t, err)
+	require.Error(t, err)
 	assert.Equal(t, domain.Failed, op.State)
 }

--- a/components/kyma-environment-broker/internal/process/operation_manager.go
+++ b/components/kyma-environment-broker/internal/process/operation_manager.go
@@ -4,11 +4,10 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
-
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
 
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/sirupsen/logrus"
@@ -29,7 +28,15 @@ func (om *OperationManager) OperationSucceeded(operation internal.Operation, des
 
 // OperationFailed marks the operation as failed and returns status of the operation's update
 func (om *OperationManager) OperationFailed(operation internal.Operation, description string, err error, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
-	return om.update(operation, domain.Failed, description, log)
+	op, t, updateErr := om.update(operation, domain.Failed, description, log)
+	retErr := fmt.Errorf("operation failed")
+	if err != nil {
+		retErr = fmt.Errorf("%v: %w", retErr, err)
+	}
+	if updateErr != nil {
+		retErr = fmt.Errorf("%v: %w", retErr, updateErr)
+	}
+	return op, t, retErr
 }
 
 // OperationCanceled marks the operation as canceled and returns status of the operation's update

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2046"
+      version: "PR-2069"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The `OperationManager` was swallowing errors from steps executions and only returning errors when storage update itself failed which resulted in metrics for failed operations no longer contained `LastError` categorization. This bugifx should address the problem.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
