### PR TITLE
Bring you own cluster - kubeconfig in base64 in request body

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -96,7 +96,7 @@ func TestProvisioning_OwnCluster(t *testing.T) {
 					},
 					"parameters": {
 						"name": "testing-cluster",
-						"kubeconfig":"kubeconfig-001",
+						"kubeconfig":"a3ViZWNvbmZpZy0wMDEK",
 "shootName": "sh1",
 "shootDomain": "sh1.avs.sap.nothing"
 					}

--- a/components/kyma-environment-broker/internal/broker/plans.go
+++ b/components/kyma-environment-broker/internal/broker/plans.go
@@ -395,6 +395,10 @@ func IsFreemiumPlan(planID string) bool {
 	}
 }
 
+func IsOwnClusterPlan(planID string) bool {
+	return planID == OwnClusterPlanID
+}
+
 func filter(items *[]interface{}, included map[string]interface{}) interface{} {
 	output := make([]interface{}, 0)
 	for i := 0; i < len(*items); i++ {

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/instance.go
@@ -345,10 +345,12 @@ func (s *Instance) toInstance(dto dbmodel.InstanceDTO) (internal.Instance, error
 	if err != nil {
 		return internal.Instance{}, errors.Wrap(err, "while decrypting parameters")
 	}
+
 	err = s.cipher.DecryptKubeconfig(&params)
 	if err != nil {
-		return internal.Instance{}, errors.Wrap(err, "while decrypting kubeconfig")
+		log.Warn("decrypting skipped because kubeconfig is in a plain text")
 	}
+
 	return internal.Instance{
 		InstanceID:                  dto.InstanceID,
 		RuntimeID:                   dto.RuntimeID,

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/operation.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/operation.go
@@ -942,14 +942,10 @@ func (s *operations) toOperation(dto *dbmodel.OperationDTO, existingOp internal.
 	if err != nil {
 		return internal.Operation{}, errors.Wrap(err, "while decrypting basic auth")
 	}
-	// temp hack to avoid errors while decrypting CAVEAT
-	if strings.Index(provisioningParameters.Parameters.Kubeconfig, "kind:") == -1 {
-		err = s.cipher.DecryptKubeconfig(&provisioningParameters)
-		if err != nil {
-			return internal.Operation{}, errors.Wrapf(err, "while decrypting kubeconfig starting with %s", provisioningParameters.Parameters.Kubeconfig[0:9])
-		}
-	} else {
-		log.Warn("decrypting skipped because kubeconfig is in plain text")
+
+	err = s.cipher.DecryptKubeconfig(&provisioningParameters)
+	if err != nil {
+		log.Warn("decrypting skipped because kubeconfig is in a plain text")
 	}
 
 	stages := make([]string, 0)

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2077"
+      version: "PR-2070"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Improvements in handling of bring own cluster plan

Changes proposed in this pull request:

- Masking kubeconfig before logging it
- Decoding kubeconfig - it should be base64 encoded in the request
- Decrypting kubeconfig conditionally - to support backward compatibility

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
