### PR TITLE
Revert KEB operation manager to legacy error wrapping

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2049"
+      version: "PR-2072"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

https://github.com/kyma-project/control-plane/pull/2069 used [post go 1.13 error wrapping](https://go.dev/blog/go1.13-errors) which is not yet supported by metrics error unwrapping. Reverting to use https://github.com/pkg/errors and KEB should deprecate the package as a whole, it's not possible to do it gradually.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
