### PR TITLE
Update gardener-creds-secret.yaml

### DIFF
--- a/resources/kcp/charts/provisioner/templates/gardener-creds-secret.yaml
+++ b/resources/kcp/charts/provisioner/templates/gardener-creds-secret.yaml
@@ -1,9 +1,11 @@
-{{- if eq .Values.gardener.manageSecrets true }}
+{{- if eq .Values.gardener.manageSecrets false }}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.gardener.secretName }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": {{ .Values.gardener.resourcePolicy }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -14,6 +14,7 @@ security:
   skipTLSCertificateVeryfication: false
 
 gardener:
+  resourcePolicy: keep
   project: "" # Gardener project connected to SA
   kubeconfigPath: "/gardener/kubeconfig/kubeconfig"
   kubeconfig: "" # Base64 encoded Gardener SA key


### PR DESCRIPTION
gardener-sa credential rotation is handled by SRE. there's already a cronJob implemented to do the rotation.
this part of provisioner can override the secret when helm chart is applied, hence the changes.
