### PR TITLE
Remove build steps from makefiles

### DIFF
--- a/components/kyma-environment-broker/Makefile
+++ b/components/kyma-environment-broker/Makefile
@@ -17,7 +17,7 @@ include $(SCRIPTS_DIR)/generic_make_go.mk
 
 custom-verify: testing-with-database-network mod-verify go-mod-check check-fmt
 
-verify:: custom-verify build-image push-image
+verify:: custom-verify
 
 resolve-local:
 	GO111MODULE=on go mod vendor -v
@@ -81,28 +81,3 @@ testing-with-database-network:
 
 clean-up:
 	@docker network rm $(TESTING_DB_NETWORK) || true
-
-# overide build-image to build separate images - broker and cleanup jobs
-build-image:
-	docker build -t $(IMG_NAME) -f Dockerfile.keb .
-	docker build -t $(CLEANUP_IMG_NAME) -f Dockerfile.cleanup .
-	docker build -t $(SUBACCOUNT_CLEANUP_IMG_NAME) -f Dockerfile.sac .
-	docker build -t $(SUBSCRIPTION_CLEANUP_IMG_NAME) -f Dockerfile.scj .
-	docker build -t $(TRIAL_CLEANUP_IMG_NAME) -f Dockerfile.tcj .
-
-# overide push-image to push separate images - broker and cleanup jobs
-push-image:
-	docker tag $(IMG_NAME) $(IMG_NAME):$(TAG)
-	docker push $(IMG_NAME):$(TAG)
-
-	docker tag $(CLEANUP_IMG_NAME) $(CLEANUP_IMG_NAME):$(TAG)
-	docker push $(CLEANUP_IMG_NAME):$(TAG)
-
-	docker tag $(SUBACCOUNT_CLEANUP_IMG_NAME) $(SUBACCOUNT_CLEANUP_IMG_NAME):$(TAG)
-	docker push $(SUBACCOUNT_CLEANUP_IMG_NAME):$(TAG)
-
-	docker tag $(SUBSCRIPTION_CLEANUP_IMG_NAME) $(SUBSCRIPTION_CLEANUP_IMG_NAME):$(TAG)
-	docker push $(SUBSCRIPTION_CLEANUP_IMG_NAME):$(TAG)
-
-	docker tag $(TRIAL_CLEANUP_IMG_NAME) $(TRIAL_CLEANUP_IMG_NAME):$(TAG)
-	docker push $(TRIAL_CLEANUP_IMG_NAME):$(TAG)

--- a/scripts/generic_make_go.mk
+++ b/scripts/generic_make_go.mk
@@ -112,23 +112,17 @@ endef
 verify:: test check-imports check-fmt errcheck
 format:: imports fmt
 
-release: resolve dep-status verify build-image push-image
+release: resolve dep-status verify
 
-.PHONY: build-image push-image
-build-image: pull-licenses
-	docker build -t $(IMG_NAME) .
-push-image:
-	docker tag $(IMG_NAME) $(IMG_NAME):$(TAG)
-	docker push $(IMG_NAME):$(TAG)
 docker-create-opts:
 	@echo $(DOCKER_CREATE_OPTS)
 
 # Targets mounting sources to buildpack
-MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate pull-licenses gqlgen
+MOUNT_TARGETS = build resolve ensure dep-status check-imports imports check-fmt fmt errcheck vet generate gqlgen
 $(foreach t,$(MOUNT_TARGETS),$(eval $(call buildpack-mount,$(t))))
 
 # Builds new Docker image into Minikube's Docker Registry
-build-to-minikube: pull-licenses
+build-to-minikube:
 	@eval $$(minikube docker-env) && docker build -t $(IMG_NAME) .
 
 build-local:
@@ -184,12 +178,6 @@ check-gqlgen:
 		exit 1; \
 	fi;
 
-pull-licenses-local:
-ifdef LICENSE_PULLER_PATH
-	bash $(LICENSE_PULLER_PATH)
-else
-	mkdir -p licenses
-endif
 
 # Targets copying sources to buildpack
 COPY_TARGETS = test


### PR DESCRIPTION
In order to migrate build environments and split testing and building this PR removes building steps from Makefile targets. Building will be done with separate ProwJobs

