### PR TITLE
API for KEB tracing events

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/dashboard"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/edp"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/event"
+	eventshandler "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/events"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/health"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/httputil"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ias"
@@ -488,6 +489,7 @@ func createAPI(router *mux.Router, servicesConfig broker.ServicesConfig, planVal
 	respWriter := httputil.NewResponseWriter(logs, cfg.DevelopmentMode)
 	runtimesInfoHandler := appinfo.NewRuntimeInfoHandler(db.Instances(), db.Operations(), defaultPlansConfig, cfg.DefaultRequestRegion, respWriter)
 	router.Handle("/info/runtimes", runtimesInfoHandler)
+	router.Handle("/events", eventshandler.NewHandler(db.Events(), db.Instances()))
 }
 
 // queues all in progress operations by type

--- a/components/kyma-environment-broker/internal/events/handler.go
+++ b/components/kyma-environment-broker/internal/events/handler.go
@@ -1,0 +1,50 @@
+package events
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dbmodel"
+)
+
+type Handler struct {
+	e storage.Events
+	i storage.Instances
+}
+
+func NewHandler(e storage.Events, i storage.Instances) Handler {
+	return Handler{e, i}
+}
+
+func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	instanceId := r.URL.Query().Get("instance_id")
+	runtimeId := r.URL.Query().Get("runtime_id")
+	operationId := r.URL.Query().Get("operation_id")
+	if runtimeId != "" && instanceId == "" {
+		instances, _, _, err := h.i.List(dbmodel.InstanceFilter{RuntimeIDs: []string{runtimeId}})
+		if len(instances) == 0 {
+			http.Error(w, fmt.Sprintf("runtime_id=%v not found", runtimeId), 404)
+			return
+		}
+		if err != nil {
+			http.Error(w, err.Error(), 503)
+			return
+		}
+		instanceId = instances[0].InstanceID
+	}
+	events, err := h.e.ListEvents(dbmodel.EventFilter{InstanceID: instanceId, OperationID: operationId})
+	if err != nil {
+		http.Error(w, err.Error(), 503)
+		return
+	}
+	bytes, err := json.Marshal(events)
+	if err != nil {
+		http.Error(w, err.Error(), 503)
+		return
+	}
+	if _, err = w.Write(bytes); err != nil {
+		http.Error(w, err.Error(), 503)
+	}
+}

--- a/components/kyma-environment-broker/internal/storage/dbmodel/events.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/events.go
@@ -1,0 +1,26 @@
+package dbmodel
+
+import (
+	"time"
+)
+
+type EventLevel string
+
+const (
+	InfoEventLevel  EventLevel = "info"
+	ErrorEventLevel EventLevel = "error"
+)
+
+type EventDTO struct {
+	ID          string
+	Level       EventLevel
+	InstanceID  *string
+	OperationID *string
+	Message     string
+	CreatedAt   time.Time
+}
+
+type EventFilter struct {
+	InstanceID  string
+	OperationID string
+}

--- a/components/kyma-environment-broker/internal/storage/dbmodel/operation.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/operation.go
@@ -49,19 +49,3 @@ type InstanceERSContextStatsEntry struct {
 	LicenseType sql.NullString
 	Total       int
 }
-
-type EventLevel string
-
-const (
-	InfoEventLevel  EventLevel = "info"
-	ErrorEventLevel EventLevel = "error"
-)
-
-type EventDTO struct {
-	ID          string
-	Level       EventLevel
-	InstanceID  sql.NullString
-	OperationID sql.NullString
-	Message     string
-	CreatedAt   time.Time
-}

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/events/events.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/events/events.go
@@ -51,6 +51,15 @@ func Errorf(instanceID, operationID string, err error, format string, args ...st
 	ev.InsertEvent(dbmodel.ErrorEventLevel, fmt.Sprintf("%v: %v", fmt.Sprintf(format, args), err), instanceID, operationID)
 }
 
+func (e *events) ListEvents(filter dbmodel.EventFilter) ([]dbmodel.EventDTO, error) {
+	if e != nil {
+		sess := e.NewReadSession()
+		return sess.ListEvents(filter)
+	} else {
+		return nil, fmt.Errorf("events are disabled")
+	}
+}
+
 func (e *events) InsertEvent(eventLevel dbmodel.EventLevel, message, instanceID, operationID string) {
 	if e != nil {
 		sess := e.NewWriteSession()

--- a/components/kyma-environment-broker/internal/storage/ext.go
+++ b/components/kyma-environment-broker/internal/storage/ext.go
@@ -112,4 +112,5 @@ type Updating interface {
 
 type Events interface {
 	InsertEvent(level dbmodel.EventLevel, message, instanceID, operationID string)
+	ListEvents(filter dbmodel.EventFilter) ([]dbmodel.EventDTO, error)
 }

--- a/components/kyma-environment-broker/internal/storage/postsql/factory.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/factory.go
@@ -50,6 +50,7 @@ type ReadSession interface {
 	GetLatestRuntimeStateWithReconcilerInputByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error)
 	GetLatestRuntimeStateWithKymaVersionByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error)
 	GetLatestRuntimeStateWithOIDCConfigByRuntimeID(runtimeID string) (dbmodel.RuntimeStateDTO, dberr.Error)
+	ListEvents(filter dbmodel.EventFilter) ([]dbmodel.EventDTO, error)
 }
 
 //go:generate mockery --name=WriteSession

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -685,6 +685,20 @@ func (r readSession) ListInstances(filter dbmodel.InstanceFilter) ([]dbmodel.Ins
 		nil
 }
 
+func (r readSession) ListEvents(filter dbmodel.EventFilter) ([]dbmodel.EventDTO, error) {
+	var events []dbmodel.EventDTO
+	stmt := r.session.Select("*").From("events")
+	if filter.InstanceID != "" {
+		stmt.Where(dbr.Eq("instance_id", filter.InstanceID))
+	}
+	if filter.OperationID != "" {
+		stmt.Where(dbr.Eq("operation_id", filter.OperationID))
+	}
+	stmt.OrderBy("created_at")
+	_, err := stmt.Load(&events)
+	return events, err
+}
+
 func (r readSession) getInstanceCount(filter dbmodel.InstanceFilter) (int, error) {
 	var res struct {
 		Total int

--- a/components/kyma-environment-broker/internal/storage/storage.go
+++ b/components/kyma-environment-broker/internal/storage/storage.go
@@ -16,6 +16,7 @@ type BrokerStorage interface {
 	Deprovisioning() Deprovisioning
 	Orchestrations() Orchestrations
 	RuntimeStates() RuntimeStates
+	Events() Events
 }
 
 const (
@@ -87,4 +88,8 @@ func (s storage) Orchestrations() Orchestrations {
 
 func (s storage) RuntimeStates() RuntimeStates {
 	return s.runtimeStates
+}
+
+func (s storage) Events() Events {
+	return s.events
 }

--- a/resources/kcp/charts/kyma-environment-broker/templates/authorization-policy.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/authorization-policy.yaml
@@ -144,6 +144,46 @@ spec:
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
 metadata:
+  name: istio-events
+  namespace: kcp-system
+spec:
+  action: ALLOW
+  rules:
+  - to:
+    - operation:
+        methods:
+        - GET
+        paths:
+        - /events
+    from:
+      - source:
+          requestPrincipals:
+          - {{ tpl .Values.oidc.issuer $ }}/*
+    when:
+    - key: request.auth.claims[groups]
+      values:
+      - {{ .Values.oidc.groups.admin }}
+      - {{ .Values.oidc.groups.operator }}
+  - to:
+    - operation:
+        methods:
+        - GET
+        paths:
+        - /events
+    from:
+    - source:
+        principals:
+{{- with .Values.runtimeAllowedPrincipals }}
+{{ tpl . $ | indent 10 }}
+{{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "kyma-env-broker.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+---
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
   name: istio-orchestrations
   namespace: kcp-system
 spec:
@@ -169,6 +209,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: {{ include "kyma-env-broker.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name }}
+      
 ---
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2143"
+      version: "PR-2114"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2135"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

This is a followup to KEB tracing events proposal in https://github.com/kyma-project/control-plane/pull/2094. Exposing events as a API with some basic filtering options in form of URL param `?instance_id=`, `?runtime_id=`, `?operation_id=`

<details>
<summary>example</summary>

state from the db:
```
broker=> select * from events where instance_id='test-jw231';
                  id                  | level | instance_id |             operation_id             |                          message                          |          created_at
--------------------------------------+-------+-------------+--------------------------------------+-----------------------------------------------------------+-------------------------------
 3b36a6f8-4cf9-44e7-998c-38cc1e60e352 | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [Starting]                               | 2022-10-05 07:07:25.313303+00
 23ef8cc2-35b1-4d2e-9f65-27dd561ecaf8 | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [Provision_Initialization]               | 2022-10-05 07:07:25.328905+00
 a3aa693d-a354-4a62-9a49-06a4f637d4ca | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [Resolve_Target_Secret]                  | 2022-10-05 07:07:25.495446+00
 41fb10d5-cba3-40bf-b2e7-aae2c6b965f1 | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [AVS_Create_Internal_Eval_Step]          | 2022-10-05 07:07:25.611217+00
 d6c2a580-5a9c-4ea8-9b77-f0d8b5ea1abb | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [EDP_Registration]                       | 2022-10-05 07:07:26.206864+00
 77188880-47b9-4c39-a133-c95e5919a92e | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [Overrides_From_Secrets_And_Config_Step] | 2022-10-05 07:07:27.195825+00
 c3d2a7ae-b5a3-48f6-80ea-9ddd6c6873be | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [BTPOperatorOverrides]                   | 2022-10-05 07:07:27.230103+00
 dfbd0890-c17f-4544-a212-709cc71e96be | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [Create_Runtime_Without_Kyma]            | 2022-10-05 07:07:27.235336+00
 98d6c6cf-37d1-4c42-b6ec-693027107f1a | info  | test-jw231  | 9298b370-af3d-46b6-9bdb-2ae814cdaf21 | processing step: [Check_Runtime]                          | 2022-10-05 07:07:38.589684+00
(9 rows)

```

query on a locally exposed KEB:
```
$ curl -XGET 'localhost:8080/info/events?instance_id=test-jw231' | jq '.'
[
  {
    "ID": "3b36a6f8-4cf9-44e7-998c-38cc1e60e352",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [Starting]",
    "CreatedAt": "2022-10-05T07:07:25.313303Z"
  },
  {
    "ID": "23ef8cc2-35b1-4d2e-9f65-27dd561ecaf8",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [Provision_Initialization]",
    "CreatedAt": "2022-10-05T07:07:25.328905Z"
  },
  {
    "ID": "a3aa693d-a354-4a62-9a49-06a4f637d4ca",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [Resolve_Target_Secret]",
    "CreatedAt": "2022-10-05T07:07:25.495446Z"
  },
  {
    "ID": "41fb10d5-cba3-40bf-b2e7-aae2c6b965f1",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [AVS_Create_Internal_Eval_Step]",
    "CreatedAt": "2022-10-05T07:07:25.611217Z"
  },
  {
    "ID": "d6c2a580-5a9c-4ea8-9b77-f0d8b5ea1abb",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [EDP_Registration]",
    "CreatedAt": "2022-10-05T07:07:26.206864Z"
  },
  {
    "ID": "77188880-47b9-4c39-a133-c95e5919a92e",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [Overrides_From_Secrets_And_Config_Step]",
    "CreatedAt": "2022-10-05T07:07:27.195825Z"
  },
  {
    "ID": "c3d2a7ae-b5a3-48f6-80ea-9ddd6c6873be",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [BTPOperatorOverrides]",
    "CreatedAt": "2022-10-05T07:07:27.230103Z"
  },
  {
    "ID": "dfbd0890-c17f-4544-a212-709cc71e96be",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [Create_Runtime_Without_Kyma]",
    "CreatedAt": "2022-10-05T07:07:27.235336Z"
  },
  {
    "ID": "98d6c6cf-37d1-4c42-b6ec-693027107f1a",
    "Level": "info",
    "InstanceID": "test-jw231",
    "OperationID": "9298b370-af3d-46b6-9bdb-2ae814cdaf21",
    "Message": "processing step: [Check_Runtime]",
    "CreatedAt": "2022-10-05T07:07:38.589684Z"
  }
]
```
</details>

Depends on:
- [x] https://github.com/kyma-project/control-plane/pull/2094

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
