### PR TITLE
bump build image in Dockerfile to golang1.19.2-alpine3.16 in KMC

### DIFF
--- a/components/kyma-metrics-collector/Dockerfile
+++ b/components/kyma-metrics-collector/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.19.1-alpine3.16 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.19.2-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/kyma-metrics-collector
 WORKDIR ${BASE_APP_DIR}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -17,7 +17,7 @@ global:
       version: "PR-1840"
     kyma_metrics_collector:
       dir:
-      version: "PR-2055"
+      version: "PR-2115"
     tests:
       provisioner:
         dir:


### PR DESCRIPTION
to prevent bugs and security issues.