### PR TITLE
Fix swallowing gardener client error in KEB

### DIFF
--- a/components/kyma-environment-broker/common/gardener/client.go
+++ b/components/kyma-environment-broker/common/gardener/client.go
@@ -84,7 +84,7 @@ func NewGardenerClusterConfig(kubeconfigPath string) (*restclient.Config, error)
 
 	gardenerClusterConfig, err := RESTConfig(rawKubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("")
+		return nil, fmt.Errorf("failed to create RESTConfig for Gardener client: %v", err)
 	}
 
 	return gardenerClusterConfig, nil

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2094"
+      version: "PR-2117"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The error when initiating `RESTConfig` for gardener client was being swallowed, this propagates the error for easier debugging.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
