### PR TITLE
Allow to retrigger suspension of expired instance

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -2,9 +2,6 @@ package main
 
 import (
 	"fmt"
-	"net/http"
-	"testing"
-
 	"github.com/google/uuid"
 	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -12,6 +9,8 @@ import (
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"net/http"
+	"testing"
 )
 
 func TestUpdate(t *testing.T) {
@@ -162,6 +161,7 @@ func TestExpiration(t *testing.T) {
    }`)
 	opID := suite.DecodeOperationID(resp)
 	suite.processProvisioningAndReconcilingByOperationID(opID)
+	suite.WaitForOperationState(opID, domain.Succeeded)
 
 	// when
 	// OSB update:
@@ -179,6 +179,10 @@ func TestExpiration(t *testing.T) {
 		}
    }`)
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	suite.WaitForLastOperation(iid, domain.InProgress)
+	opID = suite.LastOperation(iid).ID
+	suite.FailDeprovisioningByReconciler(opID)
+	suite.FailDeprovisioningOperationByProvisioner(opID)
 	instance := suite.GetInstance(iid)
 	assert.True(suite.t, instance.IsExpired())
 
@@ -192,13 +196,33 @@ func TestExpiration(t *testing.T) {
            "globalaccount_id": "g-account-id",
            "user_id": "john.smith@email.com",
            "active": true
-       }
+       },
        "parameters": {
 			
 		}
    }`)
 	// expired instance does not support an update
-	assert.Equal(t, http.StatusUnprocessableEntity, resp.StatusCode)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	// when
+	// OSB update: retrigger suspension when lat suspension failed
+	resp = suite.CallAPI("PATCH", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+       "service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+       "plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
+       "context": {
+           "globalaccount_id": "g-account-id",
+           "user_id": "john.smith@email.com",
+           "active": false
+       },
+       "parameters": {
+			
+		}
+   }`)
+	// expired instance does not support an update
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	// we expect new suspension in progress operation (the last operation before is failed)
+	suite.WaitForLastOperation(iid, domain.InProgress)
 }
 
 func TestExpirationOfNonTrial(t *testing.T) {

--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	"net/http"
+	"testing"
+
 	"github.com/google/uuid"
 	reconcilerApi "github.com/kyma-incubator/reconciler/pkg/keb"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -9,8 +12,6 @@ import (
 	"github.com/pivotal-cf/brokerapi/v8/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"net/http"
-	"testing"
 )
 
 func TestUpdate(t *testing.T) {

--- a/components/kyma-environment-broker/internal/broker/instance_update.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update.go
@@ -100,7 +100,7 @@ func (b *UpdateEndpoint) Update(_ context.Context, instanceID string, details do
 	}
 	logger.Infof("Global account ID: %s active: %s", instance.GlobalAccountID, ptr.BoolAsString(ersContext.Active))
 	logger.Infof("Received context: %s", marshallRawContext(hideSensitiveDataFromRawContext(details.RawContext)))
-	//wasExpired := instance.IsExpired()
+
 	// If the param contains "expired" - then process expiration (save it in the instance)
 	instance, err = b.processExpirationParam(instance, details, ersContext, logger)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/broker/instance_update.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update.go
@@ -137,7 +137,7 @@ func (b *UpdateEndpoint) Update(_ context.Context, instanceID string, details do
 		instance.DashboardURL = dashboardURL
 	}
 
-	if b.processingEnabled && !instanceWasExpired {
+	if b.processingEnabled {
 		instance, suspendStatusChange, err := b.processContext(instance, details, lastProvisioningOperation, logger)
 		if err != nil {
 			return domain.UpdateServiceSpec{}, err

--- a/components/kyma-environment-broker/internal/broker/instance_update.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update.go
@@ -90,7 +90,6 @@ func (b *UpdateEndpoint) Update(_ context.Context, instanceID string, details do
 		logger.Errorf("unable to get instance: %s", err.Error())
 		return domain.UpdateServiceSpec{}, errors.New("unable to get instance")
 	}
-	instanceWasExpired := instance.IsExpired()
 	logger.Infof("Plan ID/Name: %s/%s", instance.ServicePlanID, PlanNamesMapping[instance.ServicePlanID])
 
 	var ersContext internal.ERSContext
@@ -101,7 +100,7 @@ func (b *UpdateEndpoint) Update(_ context.Context, instanceID string, details do
 	}
 	logger.Infof("Global account ID: %s active: %s", instance.GlobalAccountID, ptr.BoolAsString(ersContext.Active))
 	logger.Infof("Received context: %s", marshallRawContext(hideSensitiveDataFromRawContext(details.RawContext)))
-
+	//wasExpired := instance.IsExpired()
 	// If the param contains "expired" - then process expiration (save it in the instance)
 	instance, err = b.processExpirationParam(instance, details, ersContext, logger)
 	if err != nil {
@@ -145,7 +144,7 @@ func (b *UpdateEndpoint) Update(_ context.Context, instanceID string, details do
 
 		// NOTE: KEB currently can't process update parameters in one call along with context update
 		// this block makes it that KEB ignores any parameters updates if context update changed suspension state
-		if !suspendStatusChange {
+		if !suspendStatusChange && !instance.IsExpired() {
 			return b.processUpdateParameters(instance, details, lastProvisioningOperation, asyncAllowed, ersContext, logger)
 		}
 	}

--- a/components/kyma-environment-broker/internal/broker/instance_update_test.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update_test.go
@@ -182,9 +182,9 @@ func TestUpdateEndpoint_UpdateExpirationOfExpiredTrial(t *testing.T) {
 
 	// then
 
-	// we do not expect any action, handler won't be called
+	// we expect the handler is called. The handler is responsible to skip processing
 	assert.Equal(t, internal.ERSContext{
-		Active: nil,
+		Active: ptr.Bool(false),
 	}, handler.ersContext)
 
 	assert.Len(t, response.Metadata.Labels, 1)

--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -73,7 +73,6 @@ func (h *ContextUpdateHandler) handleContextChange(newCtx internal.ERSContext, i
 			return false, nil
 		}
 		if !isActivated {
-			l.Debugf("not activated, %s", lastDeprovisioning.State)
 			// instance is inactive and incoming context update is suspension - verify if KEB should retrigger the operation
 			if lastDeprovisioning.Temporary && (lastDeprovisioning.State == domain.Failed) {
 				l.Infof("Retriggering suspension for instance id %s", instance.InstanceID)

--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -44,10 +44,6 @@ func (h *ContextUpdateHandler) Handle(instance *internal.Instance, newCtx intern
 		"runtimeID":       instance.RuntimeID,
 		"globalAccountID": instance.GlobalAccountID,
 	})
-	if instance.IsExpired() {
-		l.Info("Expired instance cannot be unsuspended")
-		return false, nil
-	}
 
 	if !broker.IsTrialPlan(instance.ServicePlanID) {
 		l.Info("Context update for non-trial instance, skipping")
@@ -77,8 +73,9 @@ func (h *ContextUpdateHandler) handleContextChange(newCtx internal.ERSContext, i
 			return false, nil
 		}
 		if !isActivated {
+			l.Debugf("not activated, %s", lastDeprovisioning.State)
 			// instance is inactive and incoming context update is suspension - verify if KEB should retrigger the operation
-			if lastDeprovisioning.Temporary && lastDeprovisioning.State == domain.Failed {
+			if lastDeprovisioning.Temporary && (lastDeprovisioning.State == domain.Failed) {
 				l.Infof("Retriggering suspension for instance id %s", instance.InstanceID)
 				return true, h.suspend(instance, l)
 			}
@@ -129,6 +126,10 @@ func (h *ContextUpdateHandler) suspend(instance *internal.Instance, log logrus.F
 }
 
 func (h *ContextUpdateHandler) unsuspend(instance *internal.Instance, log logrus.FieldLogger) error {
+	if instance.IsExpired() {
+		log.Info("Expired instance cannot be unsuspended")
+		return nil
+	}
 	id := uuid.New().String()
 	operation, err := internal.NewProvisioningOperationWithID(id, instance.InstanceID, instance.Parameters)
 	operation.InstanceDetails, err = instance.GetInstanceDetails()

--- a/components/kyma-environment-broker/internal/suspension/handler.go
+++ b/components/kyma-environment-broker/internal/suspension/handler.go
@@ -44,6 +44,10 @@ func (h *ContextUpdateHandler) Handle(instance *internal.Instance, newCtx intern
 		"runtimeID":       instance.RuntimeID,
 		"globalAccountID": instance.GlobalAccountID,
 	})
+	if instance.IsExpired() {
+		l.Info("Expired instance cannot be unsuspended")
+		return false, nil
+	}
 
 	if !broker.IsTrialPlan(instance.ServicePlanID) {
 		l.Info("Context update for non-trial instance, skipping")

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2132"
+      version: "PR-2124"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- an expired instance could be "resuspended" if the last suspension has failed.
- the scenario is covered by the test: https://github.com/kyma-project/control-plane/blob/f00e19395114a801d65947d6aa9721e4d72cf69e/components/kyma-environment-broker/cmd/broker/update_test.go#L144

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
