### PR TITLE
Fix setting failed state for suspend failed runtimes in /runtimes response

### DIFF
--- a/components/kyma-environment-broker/internal/runtime/converter.go
+++ b/components/kyma-environment-broker/internal/runtime/converter.go
@@ -215,11 +215,14 @@ func (c *converter) adjustRuntimeState(dto *pkg.RuntimeDTO) {
 		if dto.Status.Unsuspension == nil ||
 			(dto.Status.Unsuspension.Count > 0 && dto.Status.Unsuspension.Data[0].CreatedAt.Before(dto.Status.Suspension.Data[0].CreatedAt)) {
 
-			dto.Status.State = pkg.StateSuspended
-			if dto.Status.Suspension.Data[0].State == string(domain.InProgress) {
+			switch dto.Status.Suspension.Data[0].State {
+			case string(domain.InProgress):
 				dto.Status.State = pkg.StateDeprovisioning
+			case string(domain.Failed):
+				dto.Status.State = pkg.StateFailed
+			default:
+				dto.Status.State = pkg.StateSuspended
 			}
 		}
 	}
-
 }

--- a/components/kyma-environment-broker/internal/runtime/converter_test.go
+++ b/components/kyma-environment-broker/internal/runtime/converter_test.go
@@ -118,6 +118,34 @@ func TestConverting_Deprovisioning(t *testing.T) {
 	assert.Equal(t, runtime.StateDeprovisioning, dto.Status.State)
 }
 
+func TestConverting_DeprovisionFailed(t *testing.T) {
+	// given
+	instance := fixInstance()
+	svc := NewConverter("eu")
+
+	// when
+	dto, _ := svc.NewDTO(instance)
+	svc.ApplyProvisioningOperation(&dto, fixProvisioningOperation(domain.Succeeded, time.Now()))
+	svc.ApplyDeprovisioningOperation(&dto, fixDeprovisionOperation(domain.Failed, time.Now().Add(time.Second)))
+
+	// then
+	assert.Equal(t, runtime.StateFailed, dto.Status.State)
+}
+
+func TestConverting_SuspendFailed(t *testing.T) {
+	// given
+	instance := fixInstance()
+	svc := NewConverter("eu")
+
+	// when
+	dto, _ := svc.NewDTO(instance)
+	svc.ApplyProvisioningOperation(&dto, fixProvisioningOperation(domain.Succeeded, time.Now()))
+	svc.ApplySuspensionOperations(&dto, fixSuspensionOperation(domain.Failed, time.Now().Add(time.Second)))
+
+	// then
+	assert.Equal(t, runtime.StateFailed, dto.Status.State)
+}
+
 func TestConverting_SuspendedAndUpdated(t *testing.T) {
 	// given
 	instance := fixInstance()

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2117"
+      version: "PR-2125"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-1978"


### PR DESCRIPTION
**Description**

The `/runtimes` response' runtime state show "suspended" for suspension failed runtimes

```
{
  "data": [
    {
      "instanceID": "00EB1D6A-F5C1-47B1-837A-65A8CD512D82",
      "runtimeID": "63cc19d5-0005-4b72-8cc0-5709265cd2c7",
      "globalAccountID": "f3ef6db1-7a41-4a7a-96ab-a97ba4672de9",
      "subscriptionGlobalAccountID": "",
      "subAccountID": "9cdb4347-07ff-4b05-bbf3-ac0a8fef1672",
      "region": "ap-southeast-1",
      "subAccountRegion": "cf-ap21",
      "shootName": "c-1c8c5e3",
      "serviceClassID": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
      "serviceClassName": "kymaruntime",
      "servicePlanID": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
      "servicePlanName": "trial",
      "provider": "AWS",
      "status": {
        "createdAt": "2022-09-19T04:22:00.094931Z",
        "modifiedAt": "2022-10-04T01:25:23.294792Z",
        "expiredAt": "2022-10-04T01:15:23.043076Z",
        "state": "suspended",
        "provisioning": {
          "state": "succeeded",
          "description": "Operation created",
          "createdAt": "2022-09-19T04:22:00.087289Z",
          "updatedAt": "2022-09-19T04:43:06.478076Z",
          "operationID": "2ccdbf08-0a42-4c23-bc37-7e319b605972",
          "finishedStages": [
            "start",
            "create_runtime",
            "check_kyma",
            "post_actions"
          ],
          "runtimeVersion": "2.6.2"
        },
        "upgradingKyma": {
          "data": [
            {
              "state": "succeeded",
              "description": "Cluster configuration ready",
              "createdAt": "2022-09-23T12:29:47.735926Z",
              "updatedAt": "2022-09-23T12:45:27.448707Z",
              "operationID": "da32c419-54f1-4d01-b810-abaa7163e81f",
              "orchestrationID": "3aafd92c-8331-43c7-bf5f-5f60d1046d1a",
              "finishedStages": [],
              "runtimeVersion": "2.6.3"
            },
            {
              "state": "succeeded",
              "description": "Cluster configuration ready",
              "createdAt": "2022-09-21T07:13:35.484583Z",
              "updatedAt": "2022-09-21T07:38:38.9054Z",
              "operationID": "eaf6def7-12a0-465f-ae05-48eb52344343",
              "orchestrationID": "0c93ee06-640c-4bdf-8415-162b1980531c",
              "finishedStages": [],
              "runtimeVersion": "2.6.2"
            }
          ],
          "totalCount": 2,
          "count": 2
        },
        "suspension": {
          "data": [
            {
              "state": "failed",
              "description": "error while deleting avs internal evaluation",
              "createdAt": "2022-10-04T01:15:23.051612Z",
              "updatedAt": "2022-10-04T01:25:23.294792Z",
              "operationID": "2806d433-058f-4150-804f-617a6179c8c4",
              "finishedStages": [
                "Initialisation",
                "BTPOperator_Cleanup"
              ],
              "runtimeVersion": ""
            }
          ],
          "totalCount": 1,
          "count": 1
        }
      },
      "userID": "ilma.khan@sap.com",
      "avsInternalEvaluationID": 232935251,
      "kymaVersion": "2.6.3"
    }
  ],
  "count": 1,
  "totalCount": 1
}
```


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
