### PR TITLE
add annotation for gardener-credentials secret allowing argoCD to skip

### DIFF
--- a/resources/kcp/charts/provisioner/templates/gardener-creds-secret.yaml
+++ b/resources/kcp/charts/provisioner/templates/gardener-creds-secret.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/resource-policy": {{ .Values.gardener.resourcePolicy }}
+    "argocd.argoproj.io/hook": {{ .Values.gardener.kubeconfigResourceHook }}
   labels:
     app: {{ .Chart.Name }}
     release: {{ .Release.Name }}

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -18,6 +18,7 @@ gardener:
   project: "" # Gardener project connected to SA
   kubeconfigPath: "/gardener/kubeconfig/kubeconfig"
   kubeconfig: "" # Base64 encoded Gardener SA key
+  kubeconfigResourceHook: Sync
   auditLogTenantConfigPath: "" # "/gardener/tenant/config"
   auditLogTenantConfigMapName: ""
   maintenanceWindowConfigPath: "" # "/gardener/maintenance/config"


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- add annotation "argocd.argoproj.io/hook" to  gardener-credentials secret , so we can control resourceHook via override
