### PR TITLE
fixing go security vulnerabilities

### DIFF
--- a/components/kubeconfig-service/Dockerfile
+++ b/components/kubeconfig-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20220920-b10d5457 as builder
+FROM eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20221017-733bfd36 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/kubeconfig-service
 ENV CGO_ENABLED 0

--- a/components/kubeconfig-service/Makefile
+++ b/components/kubeconfig-service/Makefile
@@ -1,7 +1,7 @@
 APP_NAME = kubeconfig-service
 APP_PATH = components/kubeconfig-service
 ENTRYPOINT = cmd/generator/main.go
-BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:go1.18
+BUILDPACK = eu.gcr.io/kyma-project/test-infra/buildpack-golang:v20221017-733bfd36
 SCRIPTS_DIR = $(realpath $(shell pwd)/../..)/scripts
 
 export GO111MODULE=on

--- a/components/kubeconfig-service/go.mod
+++ b/components/kubeconfig-service/go.mod
@@ -99,6 +99,7 @@ replace (
 	k8s.io/cri-api => k8s.io/cri-api v0.25.2
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.25.2
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.25.2
+	k8s.io/kube-apiserver => k8s.io/kube-apiserver v0.25.2
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.25.2
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.25.2
 	k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.25.2


### PR DESCRIPTION
related task: https://github.tools.sap/kyma/backlog/issues/3052
using latest buildpack go image with go version 1.19.2