### PR TITLE
Feature/upgrade in future maintenance window

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/broker_suite_test.go
@@ -804,7 +804,7 @@ func (s *BrokerSuiteTest) DecodeOrchestrationID(resp *http.Response) string {
 	return upgradeResponse.OrchestrationID
 }
 
-func (s *BrokerSuiteTest) DecodeLastUpgradeKymaOperationIDFromOrchestration(resp *http.Response) (string, error) {
+func (s *BrokerSuiteTest) DecodeLastUpgradeKymaOperationFromOrchestration(resp *http.Response) (*orchestration.OperationResponse, error) {
 	m, err := ioutil.ReadAll(resp.Body)
 	s.Log(string(m))
 	require.NoError(s.t, err)
@@ -813,10 +813,19 @@ func (s *BrokerSuiteTest) DecodeLastUpgradeKymaOperationIDFromOrchestration(resp
 	require.NoError(s.t, err)
 
 	if operationsList.TotalCount == 0 || len(operationsList.Data) == 0 {
-		return "", errors.New("no operations found for given orchestration")
+		return nil, errors.New("no operations found for given orchestration")
 	}
 
-	return operationsList.Data[len(operationsList.Data)-1].OperationID, nil
+	return &operationsList.Data[len(operationsList.Data)-1], nil
+}
+
+func (s *BrokerSuiteTest) DecodeLastUpgradeKymaOperationIDFromOrchestration(resp *http.Response) (string, error) {
+	operation, err := s.DecodeLastUpgradeKymaOperationFromOrchestration(resp)
+	if err == nil {
+		return operation.OperationID, err
+	} else {
+		return "", err
+	}
 }
 
 func (s *BrokerSuiteTest) DecodeLastUpgradeClusterOperationIDFromOrchestration(orchestrationID string) (string, error) {

--- a/components/kyma-environment-broker/cmd/broker/orchestration_test.go
+++ b/components/kyma-environment-broker/cmd/broker/orchestration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 )
@@ -78,7 +79,7 @@ func fixOrchestrationParams(runtimeID string) orchestration.Parameters {
 		},
 		Strategy: orchestration.StrategySpec{
 			Type:     orchestration.ParallelStrategy,
-			Schedule: orchestration.Immediate,
+			Schedule: time.Now().Format(time.RFC3339),
 			Parallel: orchestration.ParallelStrategySpec{Workers: 1},
 		},
 		DryRun:     false,

--- a/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
+++ b/components/kyma-environment-broker/cmd/broker/upgrade_kyma_test.go
@@ -154,8 +154,8 @@ func TestKymaUpgradeScheduledToFutureMaintenanceWindow(t *testing.T) {
 {
 	"strategy": {
 		"type": "parallel",
-		"schedule": "maintenanceWindow",
-		"scheduleAfter":"%s",
+		"schedule": "%s",
+		"maintenanceWindow":true,
 		"parallel": {
 			"workers": 1
 		}

--- a/components/kyma-environment-broker/common/orchestration/client_test.go
+++ b/components/kyma-environment-broker/common/orchestration/client_test.go
@@ -290,8 +290,9 @@ func TestClient_UpgradeKyma(t *testing.T) {
 				},
 			},
 			Strategy: StrategySpec{
-				Type:     ParallelStrategy,
-				Schedule: MaintenanceWindow,
+				Type:              ParallelStrategy,
+				Schedule:          time.Now().Format(time.RFC3339),
+				MaintenanceWindow: true,
 				Parallel: ParallelStrategySpec{
 					Workers: 2,
 				},

--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -108,9 +108,10 @@ type ParallelStrategySpec struct {
 
 // StrategySpec is the strategy part common for all orchestration trigger/status API
 type StrategySpec struct {
-	Type     StrategyType         `json:"type"`
-	Schedule ScheduleType         `json:"schedule,omitempty"`
-	Parallel ParallelStrategySpec `json:"parallel,omitempty"`
+	Type          StrategyType         `json:"type"`
+	Schedule      ScheduleType         `json:"schedule,omitempty"`
+	ScheduleAfter time.Time            `json:"scheduleAfter,omitempty"`
+	Parallel      ParallelStrategySpec `json:"parallel,omitempty"`
 }
 
 // TargetSpec is the targets part common for all orchestration trigger/status API

--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -98,6 +98,7 @@ type ScheduleType string
 
 const (
 	Immediate         ScheduleType = "immediate"
+	Now               ScheduleType = "now"
 	MaintenanceWindow ScheduleType = "maintenanceWindow"
 )
 
@@ -108,10 +109,11 @@ type ParallelStrategySpec struct {
 
 // StrategySpec is the strategy part common for all orchestration trigger/status API
 type StrategySpec struct {
-	Type          StrategyType         `json:"type"`
-	Schedule      ScheduleType         `json:"schedule,omitempty"`
-	ScheduleAfter time.Time            `json:"scheduleAfter,omitempty"`
-	Parallel      ParallelStrategySpec `json:"parallel,omitempty"`
+	Type              StrategyType `json:"type"`
+	Schedule          string       `json:"schedule,omitempty"`
+	ScheduleTime      time.Time
+	MaintenanceWindow bool                 `json:"maintenanceWindow,omitempty"`
+	Parallel          ParallelStrategySpec `json:"parallel,omitempty"`
 }
 
 // TargetSpec is the targets part common for all orchestration trigger/status API

--- a/components/kyma-environment-broker/common/orchestration/strategies/parallel.go
+++ b/components/kyma-environment-broker/common/orchestration/strategies/parallel.go
@@ -208,8 +208,7 @@ func (p *ParallelOrchestrationStrategy) updateMaintenanceWindow(execID string, o
 	var duration time.Duration
 	id := op.ID
 
-	switch strategy.Schedule {
-	case orchestration.MaintenanceWindow:
+	if strategy.MaintenanceWindow {
 		// if time window for this operation has finished, we requeue and reprocess on next time window
 		if !op.MaintenanceWindowEnd.IsZero() && op.MaintenanceWindowEnd.Before(time.Now()) {
 			if p.rescheduleDelay > 0 {
@@ -231,8 +230,9 @@ func (p *ParallelOrchestrationStrategy) updateMaintenanceWindow(execID string, o
 		}
 
 		duration = time.Until(op.MaintenanceWindowBegin)
-
-	case orchestration.Immediate:
+	} else {
+		p.executor.Reschedule(id, strategy.ScheduleTime, strategy.ScheduleTime)
+		duration = time.Until(strategy.ScheduleTime)
 	}
 
 	return duration, nil

--- a/components/kyma-environment-broker/common/orchestration/strategies/parallel_test.go
+++ b/components/kyma-environment-broker/common/orchestration/strategies/parallel_test.go
@@ -48,7 +48,7 @@ func TestNewParallelOrchestrationStrategy_Immediate(t *testing.T) {
 	}
 
 	// when
-	id, err := s.Execute(ops, orchestration.StrategySpec{Schedule: orchestration.Immediate, Parallel: orchestration.ParallelStrategySpec{Workers: 2}})
+	id, err := s.Execute(ops, orchestration.StrategySpec{Schedule: time.Now().Format(time.RFC3339), Parallel: orchestration.ParallelStrategySpec{Workers: 2}})
 
 	// then
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestNewParallelOrchestrationStrategy_MaintenanceWindow(t *testing.T) {
 	}
 
 	// when
-	id, err := s.Execute(ops, orchestration.StrategySpec{Schedule: orchestration.MaintenanceWindow, Parallel: orchestration.ParallelStrategySpec{Workers: 2}})
+	id, err := s.Execute(ops, orchestration.StrategySpec{Schedule: "imideate", MaintenanceWindow: true, Parallel: orchestration.ParallelStrategySpec{Workers: 2}})
 
 	// then
 	assert.NoError(t, err)
@@ -100,7 +100,7 @@ func TestNewParallelOrchestrationStrategy_Reschedule(t *testing.T) {
 	}
 
 	// when
-	id, err := s.Execute(ops, orchestration.StrategySpec{Schedule: orchestration.MaintenanceWindow, Parallel: orchestration.ParallelStrategySpec{Workers: 2}})
+	id, err := s.Execute(ops, orchestration.StrategySpec{Schedule: "now", MaintenanceWindow: true, Parallel: orchestration.ParallelStrategySpec{Workers: 2}})
 
 	// then
 	assert.NoError(t, err)

--- a/components/kyma-environment-broker/internal/orchestration/handlers/cluster_handler.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/cluster_handler.go
@@ -56,8 +56,21 @@ func (h *clusterHandler) createOrchestration(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	// defaults strategy if not specified to Parallel with Immediate schedule
-	defaultOrchestrationStrategy(&params.Strategy)
+	// validate deprecated parameteter `maintenanceWindow`
+	err = ValidateDeprecatedParameters(params)
+	if err != nil {
+		h.log.Errorf("found deprecated value: %v", err)
+		httputil.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrapf(err, "found deprecated value"))
+		return
+	}
+
+	// validate `schedule` field
+	err = ValidateScheduleParameter(&params)
+	if err != nil {
+		h.log.Errorf("found deprecated value: %v", err)
+		httputil.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrapf(err, "found deprecated value"))
+		return
+	}
 
 	now := time.Now()
 	o := internal.Orchestration{

--- a/components/kyma-environment-broker/internal/orchestration/handlers/cluster_handler_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/cluster_handler_test.go
@@ -30,6 +30,9 @@ func TestClusterHandler_AttachRoutes(t *testing.T) {
 					},
 				},
 			},
+			Strategy: orchestration.StrategySpec{
+				Schedule: "now",
+			},
 		}
 		p, err := json.Marshal(&params)
 		require.NoError(t, err)

--- a/components/kyma-environment-broker/internal/orchestration/handlers/handlers.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/handlers.go
@@ -1,6 +1,9 @@
 package handlers
 
 import (
+	"fmt"
+	"time"
+
 	"github.com/gorilla/mux"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process"
@@ -40,21 +43,27 @@ func validateTarget(spec orchestration.TargetSpec) error {
 	return nil
 }
 
-func defaultOrchestrationStrategy(spec *orchestration.StrategySpec) {
-	if spec.Parallel.Workers == 0 {
-		spec.Parallel.Workers = 1
+// ValidateDeprecatedParameters cheks if `maintenanceWindow` parameter is used as schedule.
+func ValidateDeprecatedParameters(params orchestration.Parameters) error {
+	if params.Strategy.Schedule == string(orchestration.MaintenanceWindow) {
+		return fmt.Errorf("{\"strategy\":{\"schedule\": \"maintenanceWindow\"} is deprecated use {\"strategy\":{\"MaintenanceWindow\": true} instead")
 	}
+	return nil
+}
 
-	switch spec.Type {
-	case orchestration.ParallelStrategy:
+// ValidateScheduleParameter cheks if the schedule parameter is valid.
+func ValidateScheduleParameter(params *orchestration.Parameters) error {
+	switch params.Strategy.Schedule {
+	case "immediate":
+	case "now":
+		params.Strategy.ScheduleTime = time.Now()
 	default:
-		spec.Type = orchestration.ParallelStrategy
+		parsedTime, err := time.Parse(time.RFC3339, params.Strategy.Schedule)
+		if err == nil {
+			params.Strategy.ScheduleTime = parsedTime
+		} else {
+			return fmt.Errorf("the schedule filed does not contain 'imediate'/'now' nor is a date: %w", err)
+		}
 	}
-
-	switch spec.Schedule {
-	case orchestration.MaintenanceWindow:
-	case orchestration.Immediate:
-	default:
-		spec.Schedule = orchestration.Immediate
-	}
+	return nil
 }

--- a/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler.go
@@ -74,8 +74,21 @@ func (h *kymaHandler) createOrchestration(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	// defaults strategy if not specified to Parallel with Immediate schedule
-	defaultOrchestrationStrategy(&params.Strategy)
+	// validate deprecated parameteter `maintenanceWindow`
+	err = ValidateDeprecatedParameters(params)
+	if err != nil {
+		h.log.Errorf("found deprecated value: %v", err)
+		httputil.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrapf(err, "found deprecated value"))
+		return
+	}
+
+	// validate `schedule` field
+	err = ValidateScheduleParameter(&params)
+	if err != nil {
+		h.log.Errorf("found deprecated value: %v", err)
+		httputil.WriteErrorResponse(w, http.StatusBadRequest, errors.Wrapf(err, "found deprecated value"))
+		return
+	}
 
 	now := time.Now()
 	o := internal.Orchestration{

--- a/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/kyma_handler_test.go
@@ -42,6 +42,9 @@ func TestKymaHandler_AttachRoutes(t *testing.T) {
 			Kyma: &orchestration.KymaParameters{
 				Version: "",
 			},
+			Strategy: orchestration.StrategySpec{
+				Schedule: "now",
+			},
 		}
 		p, err := json.Marshal(&params)
 		require.NoError(t, err)

--- a/components/kyma-environment-broker/internal/orchestration/handlers/orchestration_handler_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/handlers/orchestration_handler_test.go
@@ -914,7 +914,7 @@ func TestStatusRetryHandler_AttachRoutes(t *testing.T) {
 
 		orchestrationID := "orchestration-" + fixID
 		operationIDs := []string{"id-2"}
-		err := db.Orchestrations().Insert(internal.Orchestration{OrchestrationID: orchestrationID, State: orchestration.Failed, Type: orchestration.UpgradeKymaOrchestration, Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{Schedule: orchestration.MaintenanceWindow}}})
+		err := db.Orchestrations().Insert(internal.Orchestration{OrchestrationID: orchestrationID, State: orchestration.Failed, Type: orchestration.UpgradeKymaOrchestration, Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{Schedule: time.Now().Format(time.RFC3339), MaintenanceWindow: true}}})
 		require.NoError(t, err)
 
 		err = fixFailedOrchestrationOperations(db, orchestrationID, orchestration.UpgradeKymaOrchestration)

--- a/components/kyma-environment-broker/internal/orchestration/manager/manager.go
+++ b/components/kyma-environment-broker/internal/orchestration/manager/manager.go
@@ -177,11 +177,11 @@ func (m *orchestrationManager) NewOperationForPendingRetrying(o *internal.Orches
 			windowEnd := time.Time{}
 			days := []string{}
 
-			if o.State == orchestration.Pending && o.Parameters.Strategy.Schedule == orchestration.MaintenanceWindow {
-				windowBegin, windowEnd, days = resolveMaintenanceWindowTime(r, policy, o.Parameters.Strategy.ScheduleAfter)
+			if o.State == orchestration.Pending && o.Parameters.Strategy.MaintenanceWindow {
+				windowBegin, windowEnd, days = resolveMaintenanceWindowTime(r, policy, o.Parameters.Strategy.ScheduleTime)
 			}
-			if o.State == orchestration.Retrying && o.Parameters.RetryOperation.Immediate && o.Parameters.Strategy.Schedule == orchestration.MaintenanceWindow {
-				windowBegin, windowEnd, days = resolveMaintenanceWindowTime(r, policy, o.Parameters.Strategy.ScheduleAfter)
+			if o.State == orchestration.Retrying && o.Parameters.RetryOperation.Immediate && o.Parameters.Strategy.MaintenanceWindow {
+				windowBegin, windowEnd, days = resolveMaintenanceWindowTime(r, policy, o.Parameters.Strategy.ScheduleTime)
 			}
 
 			r.MaintenanceWindowBegin = windowBegin
@@ -528,7 +528,7 @@ func (m *orchestrationManager) sendNotificationCreate(o *internal.Orchestration,
 			for _, op := range operations {
 				startDate := ""
 				endDate := ""
-				if o.Parameters.Strategy.Schedule == orchestration.MaintenanceWindow {
+				if o.Parameters.Strategy.MaintenanceWindow {
 					startDate = op.Runtime.MaintenanceWindowBegin.String()
 					endDate = op.Runtime.MaintenanceWindowEnd.String()
 				} else {

--- a/components/kyma-environment-broker/internal/orchestration/manager/upgrade_cluster_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/manager/upgrade_cluster_test.go
@@ -98,7 +98,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			Parameters: orchestration.Parameters{
 				Strategy: orchestration.StrategySpec{
 					Type:     orchestration.ParallelStrategy,
-					Schedule: orchestration.Immediate,
+					Schedule: time.Now().Format(time.RFC3339),
 				},
 			},
 		})
@@ -207,7 +207,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			Parameters: orchestration.Parameters{
 				Strategy: orchestration.StrategySpec{
 					Type:     orchestration.ParallelStrategy,
-					Schedule: orchestration.Immediate,
+					Schedule: time.Now().Format(time.RFC3339),
 				}},
 		}
 		err = store.Orchestrations().Insert(givenO)
@@ -251,7 +251,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			State:           orchestration.Canceling,
 			Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{
 				Type:     orchestration.ParallelStrategy,
-				Schedule: orchestration.Immediate,
+				Schedule: time.Now().Format(time.RFC3339),
 			}},
 		})
 
@@ -307,7 +307,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			Type:            orchestration.UpgradeClusterOrchestration,
 			Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{
 				Type:     orchestration.ParallelStrategy,
-				Schedule: orchestration.Immediate,
+				Schedule: time.Now().Format(time.RFC3339),
 				Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 			}},
 		})
@@ -408,7 +408,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 				Parameters: orchestration.Parameters{
 					Strategy: orchestration.StrategySpec{
 						Type:     orchestration.ParallelStrategy,
-						Schedule: orchestration.Immediate,
+						Schedule: time.Now().Format(time.RFC3339),
 						Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 					},
 					Targets: orchestration.TargetSpec{
@@ -500,7 +500,7 @@ func TestUpgradeClusterManager_Execute(t *testing.T) {
 			Type:            orchestration.UpgradeClusterOrchestration,
 			Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{
 				Type:     orchestration.ParallelStrategy,
-				Schedule: orchestration.Immediate,
+				Schedule: time.Now().Format(time.RFC3339),
 				Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 			}},
 		})

--- a/components/kyma-environment-broker/internal/orchestration/manager/upgrade_kyma_test.go
+++ b/components/kyma-environment-broker/internal/orchestration/manager/upgrade_kyma_test.go
@@ -107,7 +107,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 			Parameters: orchestration.Parameters{
 				Strategy: orchestration.StrategySpec{
 					Type:     orchestration.ParallelStrategy,
-					Schedule: orchestration.Immediate,
+					Schedule: time.Now().Format(time.RFC3339),
 				},
 			},
 		})
@@ -216,7 +216,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 			Parameters: orchestration.Parameters{
 				Strategy: orchestration.StrategySpec{
 					Type:     orchestration.ParallelStrategy,
-					Schedule: orchestration.Immediate,
+					Schedule: time.Now().Format(time.RFC3339),
 				}},
 		}
 		err = store.Orchestrations().Insert(givenO)
@@ -260,7 +260,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 			State:           orchestration.Canceling,
 			Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{
 				Type:     orchestration.ParallelStrategy,
-				Schedule: orchestration.Immediate,
+				Schedule: time.Now().Format(time.RFC3339),
 			}},
 		})
 
@@ -328,7 +328,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 			Parameters: orchestration.Parameters{
 				Strategy: orchestration.StrategySpec{
 					Type:     orchestration.ParallelStrategy,
-					Schedule: orchestration.Immediate,
+					Schedule: time.Now().Format(time.RFC3339),
 					Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 				},
 				RetryOperation: orchestration.RetryOperationParameters{
@@ -405,7 +405,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 			Type:            orchestration.UpgradeKymaOrchestration,
 			Parameters: orchestration.Parameters{Strategy: orchestration.StrategySpec{
 				Type:     orchestration.ParallelStrategy,
-				Schedule: orchestration.Immediate,
+				Schedule: time.Now().Format(time.RFC3339),
 				Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 			}},
 		})
@@ -500,7 +500,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 				Parameters: orchestration.Parameters{
 					Strategy: orchestration.StrategySpec{
 						Type:     orchestration.ParallelStrategy,
-						Schedule: orchestration.Immediate,
+						Schedule: time.Now().Format(time.RFC3339),
 						Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 					},
 					Kyma: &orchestration.KymaParameters{Version: ""},
@@ -612,7 +612,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 				Parameters: orchestration.Parameters{
 					Strategy: orchestration.StrategySpec{
 						Type:     orchestration.ParallelStrategy,
-						Schedule: orchestration.Immediate,
+						Schedule: time.Now().Format(time.RFC3339),
 						Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 					},
 					Kyma: &orchestration.KymaParameters{Version: ""},
@@ -723,7 +723,7 @@ func TestUpgradeKymaManager_Execute(t *testing.T) {
 				Parameters: orchestration.Parameters{
 					Strategy: orchestration.StrategySpec{
 						Type:     orchestration.ParallelStrategy,
-						Schedule: orchestration.Immediate,
+						Schedule: time.Now().Format(time.RFC3339),
 						Parallel: orchestration.ParallelStrategySpec{Workers: 2},
 					},
 					Kyma: &orchestration.KymaParameters{Version: ""},

--- a/tools/cli/pkg/command/taskrun.go
+++ b/tools/cli/pkg/command/taskrun.go
@@ -133,7 +133,7 @@ func (cmd *TaskRunCommand) Run(args []string) error {
 	strategy := strategies.NewParallelOrchestrationStrategy(mgr, cmd.log, 0)
 	execID, err := strategy.Execute(operations, orchestration.StrategySpec{
 		Type:     orchestration.ParallelStrategy,
-		Schedule: orchestration.Immediate,
+		Schedule: string(orchestration.Immediate),
 		Parallel: orchestration.ParallelStrategySpec{Workers: cmd.parallelism},
 	})
 	if err != nil {

--- a/tools/cli/pkg/command/upgrade.go
+++ b/tools/cli/pkg/command/upgrade.go
@@ -17,7 +17,7 @@ type UpgradeCommand struct {
 	targetExcludeInputs []string
 	strategy            string
 	schedule            string
-	scheduleAfter       string
+	maintenancewindow   bool
 	orchestrationParams orchestration.Parameters
 }
 
@@ -25,6 +25,7 @@ var scheduleInputToParam = map[string]orchestration.ScheduleType{
 	"":                  "",
 	"immediate":         "immediate",
 	"maintenancewindow": "maintenanceWindow",
+	"now":               "now",
 }
 
 // NewUpgradeCmd constructs the upgrade command and all subcommands under the upgrade command
@@ -46,8 +47,8 @@ func (cmd *UpgradeCommand) SetUpgradeOpts(cobraCmd *cobra.Command) {
 	SetRuntimeTargetOpts(cobraCmd, &cmd.targetInputs, &cmd.targetExcludeInputs)
 	cobraCmd.Flags().StringVar(&cmd.strategy, "strategy", string(orchestration.ParallelStrategy), "Orchestration strategy to use.")
 	cobraCmd.Flags().IntVar(&cmd.orchestrationParams.Strategy.Parallel.Workers, "parallel-workers", 1, "Number of parallel workers to use in parallel orchestration strategy. By default the amount of workers will be auto-selected on control plane server side.")
-	cobraCmd.Flags().StringVar(&cmd.schedule, "schedule", "", "Orchestration schedule to use. Possible values: \"immediate\", \"maintenancewindow\". By default the schedule will be auto-selected on control plane server side.")
-	cobraCmd.Flags().StringVar(&cmd.scheduleAfter, "scheduleAfter", "", "If schedule is \"maintenancewindow\", a window after this date (2006-01-01) is picked.")
+	cobraCmd.Flags().BoolVarP(&cmd.maintenancewindow, "maintenancewindow", "", false, "Schedule the upgrade in the next possible maintenancewindow after 'schedule'. (default: false)")
+	cobraCmd.Flags().StringVar(&cmd.schedule, "schedule", "", "Orchestration schedule to use. Possible values: \"immediate\", \"now\" or a date (2006-01-01) . By default the schedule will be auto-selected on control plane server side.")
 	cobraCmd.Flags().BoolVar(&cmd.orchestrationParams.DryRun, "dry-run", false, "Perform the orchestration without executing the actual upgrade operations for the Runtimes. The details can be obtained using the \"kcp orchestrations\" command.")
 }
 
@@ -60,16 +61,22 @@ func (cmd *UpgradeCommand) ValidateTransformUpgradeOpts() error {
 
 	// Validate schedule
 	if scheduleParam, ok := scheduleInputToParam[cmd.schedule]; ok {
-		cmd.orchestrationParams.Strategy.Schedule = scheduleParam
+		// TODO Remove schedule type maintenancewindow
+		if scheduleParam == scheduleInputToParam["maintenancewindow"] {
+			return fmt.Errorf("the schedule type '%s' is deprecated, please use the option '--maintenancewindow' instead", scheduleParam)
+		}
+		cmd.orchestrationParams.Strategy.Schedule = cmd.schedule
+	} else if _, err := time.Parse(time.RFC3339, cmd.schedule); err == nil {
+		cmd.orchestrationParams.Strategy.Schedule = cmd.schedule
 	} else {
 		return fmt.Errorf("invalid value for schedule: %s. Check kcp upgrade --help for more information", cmd.schedule)
 	}
 
 	// Validate schedule
-	if scheduleAfterParam, err := time.Parse("2006-12-31", string(cmd.scheduleAfter)); err != nil {
-		cmd.orchestrationParams.Strategy.ScheduleAfter = scheduleAfterParam
+	if _, err := time.Parse("2006-12-31", string(cmd.schedule)); err != nil {
+		cmd.orchestrationParams.Strategy.Schedule = string(cmd.schedule)
 	} else {
-		return fmt.Errorf("invalid value for scheduleAfter: %s. Check kcp upgrade --help for more information", cmd.scheduleAfter)
+		return fmt.Errorf("invalid value for scheduleAfter: %s. Check kcp upgrade --help for more information", cmd.schedule)
 	}
 
 	// Validate strategy type

--- a/tools/cli/pkg/command/upgrade.go
+++ b/tools/cli/pkg/command/upgrade.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -16,6 +17,7 @@ type UpgradeCommand struct {
 	targetExcludeInputs []string
 	strategy            string
 	schedule            string
+	scheduleAfter       string
 	orchestrationParams orchestration.Parameters
 }
 
@@ -44,7 +46,8 @@ func (cmd *UpgradeCommand) SetUpgradeOpts(cobraCmd *cobra.Command) {
 	SetRuntimeTargetOpts(cobraCmd, &cmd.targetInputs, &cmd.targetExcludeInputs)
 	cobraCmd.Flags().StringVar(&cmd.strategy, "strategy", string(orchestration.ParallelStrategy), "Orchestration strategy to use.")
 	cobraCmd.Flags().IntVar(&cmd.orchestrationParams.Strategy.Parallel.Workers, "parallel-workers", 1, "Number of parallel workers to use in parallel orchestration strategy. By default the amount of workers will be auto-selected on control plane server side.")
-	cobraCmd.Flags().StringVar(&cmd.schedule, "schedule", "immediate", "Orchestration schedule to use. Possible values: \"immediate\", \"maintenancewindow\". By default the schedule will be auto-selected on control plane server side.")
+	cobraCmd.Flags().StringVar(&cmd.schedule, "schedule", "", "Orchestration schedule to use. Possible values: \"immediate\", \"maintenancewindow\". By default the schedule will be auto-selected on control plane server side.")
+	cobraCmd.Flags().StringVar(&cmd.scheduleAfter, "scheduleAfter", "", "If schedule is \"maintenancewindow\", a window after this date (2006-01-01) is picked.")
 	cobraCmd.Flags().BoolVar(&cmd.orchestrationParams.DryRun, "dry-run", false, "Perform the orchestration without executing the actual upgrade operations for the Runtimes. The details can be obtained using the \"kcp orchestrations\" command.")
 }
 
@@ -60,6 +63,13 @@ func (cmd *UpgradeCommand) ValidateTransformUpgradeOpts() error {
 		cmd.orchestrationParams.Strategy.Schedule = scheduleParam
 	} else {
 		return fmt.Errorf("invalid value for schedule: %s. Check kcp upgrade --help for more information", cmd.schedule)
+	}
+
+	// Validate schedule
+	if scheduleAfterParam, err := time.Parse("2006-12-31", string(cmd.scheduleAfter)); err != nil {
+		cmd.orchestrationParams.Strategy.ScheduleAfter = scheduleAfterParam
+	} else {
+		return fmt.Errorf("invalid value for scheduleAfter: %s. Check kcp upgrade --help for more information", cmd.scheduleAfter)
 	}
 
 	// Validate strategy type


### PR DESCRIPTION
Description
Schedule upgrades in future maintenance window

Changes proposed in this pull request:

Adds --scheduleAfter parameter to cli
KEB can schedule upgrades to maintenance windows later than the next one
Related issue(s)

[GHE/backlog#2480](https://github.tools.sap/kyma/backlog/issues/2480)