### PR TITLE
Enhance staged manager tracing events in KEB

### DIFF
--- a/components/kyma-environment-broker/internal/process/staged_manager.go
+++ b/components/kyma-environment-broker/internal/process/staged_manager.go
@@ -140,12 +140,13 @@ func (m *StagedManager) Execute(operationID string) (time.Duration, error) {
 
 			processedOperation, when, err = m.runStep(step, processedOperation, logStep)
 			if err != nil {
-				events.Errorf(operation.InstanceID, operation.ID, err, "step failed: %v", step.Name())
+				events.Errorf(operation.InstanceID, operation.ID, err, "step %v processing returned error", step.Name())
 				logStep.Errorf("Process operation failed: %s", err)
 				return 0, err
 			}
 			if processedOperation.State == domain.Failed || processedOperation.State == domain.Succeeded {
 				logStep.Infof("Operation %q got status %s. Process finished.", operation.ID, processedOperation.State)
+				events.Infof(operation.InstanceID, operation.ID, "operation processing finished %v", processedOperation.State)
 				return 0, nil
 			}
 
@@ -223,6 +224,7 @@ func (m *StagedManager) runStep(step Step, operation internal.Operation, logger 
 		if when == 0 || err != nil || time.Since(begin) > 10*time.Minute {
 			return processedOperation, when, err
 		}
+		events.Infof(operation.ID, operation.InstanceID, "processing step %v sleeping for %v", step.Name(), when)
 		time.Sleep(when / time.Duration(m.speedFactor))
 	}
 }

--- a/components/kyma-environment-broker/internal/storage/driver/postsql/events/events.go
+++ b/components/kyma-environment-broker/internal/storage/driver/postsql/events/events.go
@@ -43,12 +43,12 @@ func New(cfg Config, sess postsql.Factory, log logrus.FieldLogger) *events {
 	return ev
 }
 
-func Infof(instanceID, operationID, format string, args ...string) {
-	ev.InsertEvent(dbmodel.InfoEventLevel, fmt.Sprintf(format, args), instanceID, operationID)
+func Infof(instanceID, operationID, format string, args ...any) {
+	ev.InsertEvent(dbmodel.InfoEventLevel, fmt.Sprintf(format, args...), instanceID, operationID)
 }
 
-func Errorf(instanceID, operationID string, err error, format string, args ...string) {
-	ev.InsertEvent(dbmodel.ErrorEventLevel, fmt.Sprintf("%v: %v", fmt.Sprintf(format, args), err), instanceID, operationID)
+func Errorf(instanceID, operationID string, err error, format string, args ...any) {
+	ev.InsertEvent(dbmodel.ErrorEventLevel, fmt.Sprintf("%v: %v", fmt.Sprintf(format, args...), err), instanceID, operationID)
 }
 
 func (e *events) ListEvents(filter dbmodel.EventFilter) ([]dbmodel.EventDTO, error) {

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2114"
+      version: "PR-2200"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Currently, steps in operation processing are not forwarding errors to the staged manager which makes visibility with tracing events limited. This PR will at least help to observe a step when the process is put to sleep and also clearly state when the operation changed to one of the terminal states.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
