### PR TITLE
Dropping tobiscr from` values.yaml` ownership

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,7 +8,7 @@
 * @PK85 @akgalwas @franpog859 @ralikio @mvshao @VOID404 @koala7659 @piotrmiskiewicz @szwedm @wozniakjan @tillknuesting
 
 # All developers working on this repository are able to edit main values.yaml file.
-/resources/kcp/values.yaml @PK85 @akgalwas @franpog859 @ralikio @mvshao @VOID404 @piotrmiskiewicz @szwedm @koala7659 @k15r @marcobebway @nachtmaar @wozniakjan @tillknuesting @ebensom @tobiscr @m00g3n @pPrecel @moelsayed @cortey @clebs @jeremyharisch @khlifi411 @Tomasz-Smelcerz-SAP @ruanxin @jakobmoellersap @adityabhatia @mfaizanse @friedrichwilken @vladislavpaskar @raypinto @jaroslaw-pieszka
+/resources/kcp/values.yaml @PK85 @akgalwas @franpog859 @ralikio @mvshao @VOID404 @piotrmiskiewicz @szwedm @koala7659 @k15r @marcobebway @nachtmaar @wozniakjan @tillknuesting @ebensom @m00g3n @pPrecel @moelsayed @cortey @clebs @jeremyharisch @khlifi411 @Tomasz-Smelcerz-SAP @ruanxin @jakobmoellersap @adityabhatia @mfaizanse @friedrichwilken @vladislavpaskar @raypinto @jaroslaw-pieszka
 
 # All developers working on this repository are able to edit scripts directory.
 /scripts @PK85 @akgalwas @franpog859 @ralikio @mvshao @VOID404 @piotrmiskiewicz @szwedm @koala7659 @wozniakjan @tillknuesting @ebensom


### PR DESCRIPTION
**Description**

Dropping tobiscr from CODEOWNER file. Ownership no longer needed caused by team/role restructuring.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
