### PR TITLE
Add the port forward option in the instruction on how to provision an SKR

### DIFF
--- a/docs/kyma-control-plane/01-01-overview.md
+++ b/docs/kyma-control-plane/01-01-overview.md
@@ -1,3 +1,3 @@
 # Kyma Control Plane (KCP)
 
-Kyma Control Plane (KCP) is a central system that allows you to provision and deprovision Kyma Runtimes from one central place. It consists of Kyma Enrivonment Broker and Runtime Provisioner.
+Kyma Control Plane (KCP) is a central system that allows you to provision and deprovision Kyma Runtimes from one central place. It consists of Kyma Environment Broker and Runtime Provisioner.

--- a/docs/kyma-environment-broker/03-01-service-description.md
+++ b/docs/kyma-environment-broker/03-01-service-description.md
@@ -159,12 +159,12 @@ These are the provisioning parameters for Openstack that you can configure:
 ## Trial plan
 
 Trial plan allows you to install Kyma on Azure, AWS, or GCP. The trial plan assumptions are as follows:
-- Kyma is uninstalled after 30 days and the Kyma cluster is deprovisioned after this time.
+- Kyma is uninstalled after 14 days and the Kyma cluster is deprovisioned after this time.
 - It's possible to provision only one Kyma Runtime per global account.
 
-To reduce the costs, the Trial plan skips some of the [provisioning steps](./03-03-runtime-operations.md#provisioning).
-- `Provision_Azure_Event_Hubs`
-- `AVS External Evaluation` (part of the post actions during the `Initialisation` step)
+To reduce the costs, the Trial plan skips one of the [provisioning steps](./03-03-runtime-operations.md#provisioning).
+
+- `AVS External Evaluation` 
 
 ### Provisioning parameters
 

--- a/docs/kyma-environment-broker/03-03-runtime-operations.md
+++ b/docs/kyma-environment-broker/03-03-runtime-operations.md
@@ -96,7 +96,7 @@ The upgrade process contains the following steps:
 
 ## Provide additional steps
 
-You can configure Runtime operations by providing additional steps. To add a new step, follow the tutorials:
+You can configure Runtime operations by providing additional steps. To add a new step, follow these tutorials:
 
 <div tabs name="runtime-provisioning-deprovisioning" group="runtime-provisioning-deprovisioning">
   <details>

--- a/docs/kyma-environment-broker/03-03-runtime-operations.md
+++ b/docs/kyma-environment-broker/03-03-runtime-operations.md
@@ -9,7 +9,7 @@ Kyma Environment Broker allows you to configure operations that you can run on a
 
 ## Provisioning
 
-Each provisioning step is responsible for a separate part of preparing Runtime parameters. For example, in a step you can provide tokens, credentials, or URLs to integrate Kyma Runtime with external systems. All data collected in provisioning steps are used in the step called [`create_runtime`](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/provisioning/create_runtime.go) which transforms the data into a request input. The request is sent to the Runtime Provisioner component which provisions a Runtime.
+Each provisioning step is responsible for a separate part of preparing Runtime parameters. For example, in a step you can provide tokens, credentials, or URLs to integrate Kyma Runtime with external systems. All data collected in provisioning steps are used in the step called [`create_cluster_configuration`](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/provisioning/create_cluster_configuration.go) which transforms the data into a request input. The request is sent to the Runtime Provisioner component which provisions a Runtime.
 The provisioning process contains the following steps:
 
 | Stage          | Step                                   | Domain                   | Description                                                                                                                                 | Owner           |
@@ -57,7 +57,7 @@ The deprovisioning process contains the following steps:
 
 ## Upgrade Kyma
 
-Each upgrade step is responsible for a separate part of upgrading Runtime dependencies. To properly upgrade the Runtime, you need the data used during the Runtime provisioning. You can fetch this data from the **ProvisioningOperation** struct in the [initialization](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/kyma_upgrade/initialisation.go) step.
+Each upgrade step is responsible for a separate part of upgrading Runtime dependencies. To properly upgrade the Runtime, you need the data used during the Runtime provisioning. You can fetch this data from the **ProvisioningOperation** struct in the [initialization](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/upgrade_kyma/initialisation.go) step.
 
 The upgrade process contains the following steps:
 
@@ -84,7 +84,7 @@ The upgrade process contains the following steps:
 
 | Stage               | Step                           | Description                                                                                   |
 |---------------------|--------------------------------|-----------------------------------------------------------------------------------------------|
-| cluster             | Update_Kyma_Initialisation     | Changes the state from `pending` to `in progress` if there is no other operation in progress. |                                                                                                                     
+| cluster             | Update_Kyma_Initialization     | Changes the state from `pending` to `in progress` if there is no other operation in progress. |                                                                                                                     
 | cluster             | Upgrade_Shoot                  | Sends the updated cluster parameters to the Provisioner.                                      |                                                                                                                     
 | btp-operator        | Update_Init_Kyma_Version       | Specifies the Kyma version to install.                                                        |                                                                                                                      
 | btp-operator        | Get_Kubeconfig                 | Gets the kubeconfig file.                                                                     |                                                                                                                      
@@ -96,7 +96,7 @@ The upgrade process contains the following steps:
 
 ## Provide additional steps
 
-You can configure Runtime operations by providing additional steps. To add a new step, follow these tutorials:
+You can configure Runtime operations by providing additional steps. To add a new step, follow the following tutorials:
 
 <div tabs name="runtime-provisioning-deprovisioning" group="runtime-provisioning-deprovisioning">
   <details>
@@ -134,7 +134,7 @@ You can configure Runtime operations by providing additional steps. To add a new
     ```
 
     If your functionality contains long-term processes, you can store data in the storage.
-    To do this, add this field to the provisioning operation in which you want to save data:
+    To do this, add the following field to the provisioning operation in which you want to save data:
 
     ```go
     type Operation struct {
@@ -147,7 +147,7 @@ You can configure Runtime operations by providing additional steps. To add a new
     }
     ```
 
-    By saving data in the storage, you can check if you already have the necessary data and avoid time-consuming processes. You should always return the modified operation from the method.
+    By saving data in the storage, you can check if you already have the necessary data and avoid time-consuming processes. You must always return the modified operation from the method.
 
     See the example of the step implementation:
 
@@ -250,7 +250,7 @@ You can configure Runtime operations by providing additional steps. To add a new
     }
     ```
 
-    Once all steps in the stage have finished succeeded, the stage won't be retried even if the application is restarted.
+    Once all the steps in the stage have run successfully, the stage is  not retried even if the application is restarted.
 
   </details>
   
@@ -259,9 +259,9 @@ You can configure Runtime operations by providing additional steps. To add a new
   Upgrade
   </summary>
 
-  1. Create a new file in [this](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/kyma_upgrade) directory.
+  1. Create a new file in [this directory](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/process/kyma_upgrade).
 
-2. Implement this interface in your upgrade step:
+2. Implement the following interface in your upgrade step:
 
     ```go
     type Step interface {

--- a/docs/kyma-environment-broker/03-03-runtime-operations.md
+++ b/docs/kyma-environment-broker/03-03-runtime-operations.md
@@ -96,7 +96,7 @@ The upgrade process contains the following steps:
 
 ## Provide additional steps
 
-You can configure Runtime operations by providing additional steps. To add a new step, follow the following tutorials:
+You can configure Runtime operations by providing additional steps. To add a new step, follow the tutorials:
 
 <div tabs name="runtime-provisioning-deprovisioning" group="runtime-provisioning-deprovisioning">
   <details>

--- a/docs/kyma-environment-broker/03-11-swagger.md
+++ b/docs/kyma-environment-broker/03-11-swagger.md
@@ -12,7 +12,6 @@ You can either use Virtual Service or port-forward the Pod to expose and use the
 
 Open one of the following websites:
 
-   ```
    https://kyma-env-broker.cp.dev.kyma.cloud.sap/
    ```
    ```

--- a/docs/kyma-environment-broker/03-11-swagger.md
+++ b/docs/kyma-environment-broker/03-11-swagger.md
@@ -12,7 +12,7 @@ You can either use Virtual Service or port-forward the Pod to expose and use the
 
 Open Kyma Environment Broker APIs on [development env](https://kyma-env-broker.cp.dev.kyma.cloud.sap/) or on [stage env](https://kyma-env-broker.cp.stage.kyma.cloud.sap/).
 
-   ```
+ 
 
 To use the `Try it out` feature on Virtual Service, you need this [Chrome browser extension](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf).
 

--- a/docs/kyma-environment-broker/03-11-swagger.md
+++ b/docs/kyma-environment-broker/03-11-swagger.md
@@ -10,10 +10,8 @@ You can either use Virtual Service or port-forward the Pod to expose and use the
 
 ## Use Virtual Service
 
-Open one of the following websites:
+Open Kyma Environment Broker APIs on [development env](https://kyma-env-broker.cp.dev.kyma.cloud.sap/) or on [stage env](https://kyma-env-broker.cp.stage.kyma.cloud.sap/).
 
-   https://kyma-env-broker.cp.dev.kyma.cloud.sap/
-   ```
    ```
    https://kyma-env-broker.cp.stage.kyma.cloud.sap/
    ```

--- a/docs/kyma-environment-broker/03-11-swagger.md
+++ b/docs/kyma-environment-broker/03-11-swagger.md
@@ -10,10 +10,13 @@ You can either use Virtual Service or port-forward the Pod to expose and use the
 
 ## Use Virtual Service
 
-Open the following website:
+Open one of the following websites:
 
    ```
-   https://$BROKER_URL/
+   https://kyma-env-broker.cp.dev.kyma.cloud.sap/
+   ```
+   ```
+   https://kyma-env-broker.cp.stage.kyma.cloud.sap/
    ```
 
 To use the `Try it out` feature on Virtual Service, you need this [Chrome browser extension](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf).

--- a/docs/kyma-environment-broker/03-11-swagger.md
+++ b/docs/kyma-environment-broker/03-11-swagger.md
@@ -10,7 +10,9 @@ You can either use Virtual Service or port-forward the Pod to expose and use the
 
 ## Use Virtual Service
 
-Open Kyma Environment Broker APIs on [development env](https://kyma-env-broker.cp.dev.kyma.cloud.sap/) or on [stage env](https://kyma-env-broker.cp.stage.kyma.cloud.sap/).
+Open the KEB APIs in the desired environment:
+- [DEV environment](https://kyma-env-broker.cp.dev.kyma.cloud.sap/) 
+- [STAGE environment](https://kyma-env-broker.cp.stage.kyma.cloud.sap/)
 
  
 

--- a/docs/kyma-environment-broker/03-11-swagger.md
+++ b/docs/kyma-environment-broker/03-11-swagger.md
@@ -13,8 +13,6 @@ You can either use Virtual Service or port-forward the Pod to expose and use the
 Open Kyma Environment Broker APIs on [development env](https://kyma-env-broker.cp.dev.kyma.cloud.sap/) or on [stage env](https://kyma-env-broker.cp.stage.kyma.cloud.sap/).
 
    ```
-   https://kyma-env-broker.cp.stage.kyma.cloud.sap/
-   ```
 
 To use the `Try it out` feature on Virtual Service, you need this [Chrome browser extension](https://chrome.google.com/webstore/detail/allow-cors-access-control/lhobafahddgcelffkeicbaginigeejlf).
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add the port forward option to step 2 in the instruction on how to provision an SKR.
- Fix a typo.

**Related issue(s)**
Update Control Plane docs after removing them from the website #676
