### PR TITLE
Tracing events helper on operation struct in KEB

### DIFF
--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/gardener"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
 	kebError "github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/error"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/events"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
@@ -236,6 +237,14 @@ type Operation struct {
 
 func (o *Operation) IsFinished() bool {
 	return o.State != orchestration.InProgress && o.State != orchestration.Pending && o.State != orchestration.Canceling && o.State != orchestration.Retrying
+}
+
+func (o *Operation) EventInfof(fmt string, args ...any) {
+	events.Infof(o.InstanceID, o.ID, fmt, args...)
+}
+
+func (o *Operation) EventErrorf(err error, fmt string, args ...any) {
+	events.Errorf(o.InstanceID, o.ID, err, fmt, args...)
 }
 
 // Orchestration holds all information about an orchestration.

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2247"
+      version: "PR-2239"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

During review of https://github.com/kyma-project/control-plane/pull/2094, @piotrmiskiewicz expressed desire to have event throwing helper on operations struct directly. Before https://github.com/kyma-project/control-plane/pull/2203 this was difficult because of import cycle but now it should be simple to implement such helper there.
