### PR TITLE
Implementation of in memory tracing events sink for tests

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2216"
+      version: "PR-2243"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

During the review of https://github.com/kyma-project/control-plane/pull/2094#discussion_r987810866, it was decided that in case DB sink is not configured, the default for tracing events for tests should be `/dev/null`. The https://github.com/kyma-project/control-plane/pull/2203 enabled to implement different sink backends for tracing events.

This PR implements in memory / stdout sink for tracing events, configured for unit tests.