### PR TITLE
Hook legacy deprovisioning duration metric to staged manager

### DIFF
--- a/components/kyma-environment-broker/internal/metrics/metrics.go
+++ b/components/kyma-environment-broker/internal/metrics/metrics.go
@@ -27,4 +27,5 @@ func RegisterAll(sub event.Subscriber, operationStatsGetter OperationsStatsGette
 	sub.Subscribe(process.OperationStepProcessed{}, opResultCollector.OnOperationStepProcessed)
 	sub.Subscribe(process.OperationSucceeded{}, opResultCollector.OnOperationSucceeded)
 	sub.Subscribe(process.OperationSucceeded{}, opDurationCollector.OnOperationSucceeded)
+	sub.Subscribe(process.OperationStepProcessed{}, opDurationCollector.OnOperationStepProcessed)
 }

--- a/components/kyma-environment-broker/internal/process/events.go
+++ b/components/kyma-environment-broker/internal/process/events.go
@@ -48,7 +48,8 @@ type ProvisioningSucceeded struct {
 
 type OperationStepProcessed struct {
 	StepProcessed
-	Operation internal.Operation
+	OldOperation internal.Operation
+	Operation    internal.Operation
 }
 
 type OperationSucceeded struct {

--- a/components/kyma-environment-broker/internal/process/staged_manager.go
+++ b/components/kyma-environment-broker/internal/process/staged_manager.go
@@ -213,7 +213,8 @@ func (m *StagedManager) runStep(step Step, operation internal.Operation, logger 
 				When:     when,
 				Error:    err,
 			},
-			Operation: processedOperation,
+			Operation:    processedOperation,
+			OldOperation: operation,
 		})
 
 		// break the loop if:
@@ -223,7 +224,7 @@ func (m *StagedManager) runStep(step Step, operation internal.Operation, logger 
 		if when == 0 || err != nil || time.Since(begin) > 10*time.Minute {
 			return processedOperation, when, err
 		}
-		operation.EventInfof("processing step %v sleeping for %v", step.Name(), when)
+		operation.EventInfof("step %v sleeping for %v", step.Name(), when)
 		time.Sleep(when / time.Duration(m.speedFactor))
 	}
 }
@@ -237,6 +238,7 @@ func (m *StagedManager) callPubSubOutsideSteps(operation *internal.Operation, er
 			Duration: time.Since(operation.CreatedAt),
 			Error:    err,
 		},
-		Operation: *operation,
+		OldOperation: *operation,
+		Operation:    *operation,
 	})
 }

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2250"
+      version: "PR-2254"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"


### PR DESCRIPTION
**Description**
Reported by @JackCheng01:
> We are collecting metrics like `compass_keb_deprovisioning_duration_minutes_sum` in grafana [dashboard](https://github.com/kyma-project/control-plane/blob/a7e4debe949f4185914cc8cd1f0c3c808a7bed8b/resources/kcp/charts/kyma-environment-broker/files/dashboard.json) for KEB.
We observed metrics for [deprovisioning_duration_minutes](https://github.com/kyma-project/control-plane/blob/main/components/kyma-environment-broker/internal/metrics/operation_duration.go#L31-L37) are missing.
> <img width="1734" alt="image" src="https://media.github.tools.sap/user/906/files/74fe196a-2874-4ce0-a5ae-48a003c3cf2d">
> Issue persists on current version deployed on dev:
`eu.gcr.io/kyma-project/control-plane/kyma-environment-broker:PR-2203`

The `DeprovisioningStepProcessed` event got disconnected from `OperationDurationCollector` during refactoring done in https://github.com/kyma-project/control-plane/pull/2049. This PR provides connection of the `OperationStepProcessed` event through `DeprovisioningStepProcessed` back to the `OperationDurationCollector` for the legacy metrics.

```
$ curl -s localhost:8080/metrics | grep compass_keb_deprovisioning_duration_minutes_sum
compass_keb_deprovisioning_duration_minutes_sum{global_account_id="e449f875-b5b2-4485-b7c0-98725c0571bf",instance_id="test-jw244",operation_id="58259c13-c232-41c1-bbfd-f4e6686e7f00",plan_id="7d55d31d-35ae-4438-bf13-6ffdfa107d9f"} 12.032624726266667
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
