### PR TITLE
Update Dockerfile for kubeconfig-service to use scratch image

### DIFF
--- a/components/kubeconfig-service/Dockerfile
+++ b/components/kubeconfig-service/Dockerfile
@@ -17,8 +17,8 @@ COPY . .
 RUN go build -v -o main ./cmd/generator/main.go
 RUN mkdir /app && mv ./main /app/main
 
-FROM eu.gcr.io/kyma-project/external/alpine:3.16.2
-LABEL source = git@github.com:kyma-project/control-plane.git
+
+FROM eu.gcr.io/kyma-project/external/alpine:3.16.2 as alpine
 
 WORKDIR /app
 
@@ -26,17 +26,16 @@ WORKDIR /app
 # Install certificates
 #
 RUN apk --no-cache add --update openssl zlib busybox --repository=https://dl-cdn.alpinelinux.org/alpine/edge/main
-
 RUN apk add --no-cache ca-certificates
 
-#
+FROM scratch
+LABEL source = git@github.com:kyma-project/control-plane.git
+WORKDIR /
 # Copy binary
-#
-
 COPY --from=builder /app /app
-
-#
+COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=alpine /usr/bin/openssl /usr/bin/
+COPY --from=alpine /bin/busybox /bin/
+COPY --from=alpine /usr/lib/* /usr/lib/
 # Run app
-#
-
 CMD ["/app/main"]

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
-  tag: "PR-2068"
+  tag: "PR-2257"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
Update Dockerfile for kubeconfig-service to use scratch image.
