### PR TITLE
KEB RBAC to manage secrets for lifecycle manager

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/rbac.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
 rules:
   - apiGroups: ["*"]
     resources: ["secrets"]
-    verbs: ["list", "get"]
+    verbs: ["*"]
   - apiGroups: ["*"]
     resources: ["configmaps"]
     verbs: ["list", "get"]


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In https://github.com/kyma-project/control-plane/pull/2216, I forgot to update RBAC for KEB to manage secrets for lifecycle manager.
```
{"instanceID":"799efc2c-a78f-4388-8046-e21f06d856a0","level":"error","msg":"failed to create kubeconfig secret kyma-system/kubeconfig-28704cd3-09c3-40c1-993d-ca7199c6c02a for lifecycle manager: secrets is forbidden: User \"system:serviceaccount:kcp-system:kcp-kyma-environment-broker\" cannot create resource \"secrets\" in API group \"\" in the namespace \"kyma-system\"","operation":"7e21985b-745f-4464-9bf8-8ed6597f5eac","planID":"7d55d31d-35ae-4438-bf13-6ffdfa107d9f","provisioning":"manager","stage":"create_runtime","step":"Sync_Kubeconfig","time":"2022-11-11T10:22:15Z"}
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
