### PR TITLE
KEB ClusterRole to manage Secrets in all namespaces for Lifecycle Manager

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/rbac.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/rbac.yaml
@@ -8,9 +8,6 @@ metadata:
     release: {{ .Release.Name }}
 rules:
   - apiGroups: ["*"]
-    resources: ["secrets"]
-    verbs: ["*"]
-  - apiGroups: ["*"]
     resources: ["configmaps"]
     verbs: ["list", "get"]
   - apiGroups: ["core.gardener.cloud"]
@@ -19,7 +16,18 @@ rules:
   - apiGroups: ["core.gardener.cloud"]
     resources: ["secretbindings"]
     verbs: ["list", "get", "update"]
-
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "kyma-env-broker.fullname" . }}
+  labels:
+    app: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+rules:
+  - apiGroups: ["*"]
+    resources: ["secrets"]
+    verbs: ["*"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -37,7 +45,22 @@ roleRef:
   kind: Role
   name: {{ include "kyma-env-broker.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
-
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "kyma-env-broker.fullname" . }}
+  labels:
+    app: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.global.kyma_environment_broker.serviceAccountName }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "kyma-env-broker.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: v1
 kind: ServiceAccount


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

https://github.com/kyma-project/control-plane/pull/2261 allowed KEB to manage `Secrets` in `kcp-system` only, but they primarily reside in `kyma-system` at the moment with a plan to potentially put them in any other namespace.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
