### PR TITLE
KEB should pass provisioning parameters for suspension operations

### DIFF
--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -542,17 +542,18 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 func NewSuspensionOperationWithID(operationID string, instance *Instance) DeprovisioningOperation {
 	return DeprovisioningOperation{
 		Operation: Operation{
-			ID:              operationID,
-			Version:         0,
-			Description:     "Operation created",
-			InstanceID:      instance.InstanceID,
-			State:           orchestration.Pending,
-			CreatedAt:       time.Now(),
-			UpdatedAt:       time.Now(),
-			Type:            OperationTypeDeprovision,
-			InstanceDetails: instance.InstanceDetails,
-			FinishedStages:  make([]string, 0),
-			Temporary:       true,
+			ID:                     operationID,
+			Version:                0,
+			Description:            "Operation created",
+			InstanceID:             instance.InstanceID,
+			State:                  orchestration.Pending,
+			CreatedAt:              time.Now(),
+			UpdatedAt:              time.Now(),
+			Type:                   OperationTypeDeprovision,
+			InstanceDetails:        instance.InstanceDetails,
+			ProvisioningParameters: instance.Parameters,
+			FinishedStages:         make([]string, 0),
+			Temporary:              true,
 		},
 	}
 }

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2266"
+      version: "PR-2270"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Some time ago, we introduced a regression that suspension operations don't get provisioning parameters inherited from previous operations. This appears in DB as missing plan ID for example:
```
broker=> select id, instance_id, state, type, provisioning_parameters->'plan_id' as planid, created_at, updated_at from operations where instance_id = 'test-jw252';
                  id                  | instance_id |   state   |    type     |                 planid                 |          created_at           |          updated_at
--------------------------------------+-------------+-----------+-------------+----------------------------------------+-------------------------------+-------------------------------
 5f4c19fe-8a7f-49d3-84e8-16889e26d1fd | test-jw252  | succeeded | provision   | "7d55d31d-35ae-4438-bf13-6ffdfa107d9f" | 2022-11-16 12:38:45.160764+00 | 2022-11-16 12:51:58.396181+00
 32ca2315-180c-4ca3-aa54-4ba3ffdb6bce | test-jw252  | succeeded | deprovision | ""                                     | 2022-11-16 12:53:01.086263+00 | 2022-11-16 13:05:33.542474+00
```

This PR ensures even suspension operations inherit provisioning parameters from previous operations.
```
broker=> select id, instance_id, state, type, provisioning_parameters->'plan_id' as planid, created_at, updated_at from operations where instance_id = 'test-jw254';
                  id                  | instance_id |    state    |    type     |                 planid                 |          created_at           |          updated_at
--------------------------------------+-------------+-------------+-------------+----------------------------------------+-------------------------------+-------------------------------
 d213224d-e2ea-49fd-89e0-6dace0ba216a | test-jw254  | succeeded   | provision   | "7d55d31d-35ae-4438-bf13-6ffdfa107d9f" | 2022-11-16 13:56:31.816142+00 | 2022-11-16 14:09:12.344725+00
 3c1368dc-2ce3-4b21-bbde-0cae82904e42 | test-jw254  | in progress | deprovision | "7d55d31d-35ae-4438-bf13-6ffdfa107d9f" | 2022-11-16 14:09:48.994396+00 | 2022-11-16 14:09:51.11866+00
```

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
