### PR TITLE
Assert the removal of service binding and instances during trial deprovisioning

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/update_test.go
+++ b/components/kyma-environment-broker/cmd/broker/update_test.go
@@ -532,6 +532,8 @@ func TestUnsuspensionTrialKyma20(t *testing.T) {
 	opID := suite.DecodeOperationID(resp)
 	suite.processProvisioningAndReconcilingByOperationID(opID)
 
+	suite.fixServiceBindingAndInstances(t)
+
 	suite.Log("*** Suspension ***")
 
 	// Process Suspension
@@ -553,6 +555,8 @@ func TestUnsuspensionTrialKyma20(t *testing.T) {
 	suite.FinishDeprovisioningOperationByProvisioner(suspensionOpID)
 	suite.WaitForOperationState(suspensionOpID, domain.Succeeded)
 	suite.RemoveFromReconcilerByInstanceID(iid)
+
+	suite.assertServiceBindingAndInstancesAreRemoved(t)
 
 	// OSB update
 	suite.Log("*** Unsuspension ***")

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2282"
+      version: "PR-2277"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Logic to cover the case when during `trial` deprovisioning (suspension) we are not able to remove service bindings and service instances. During BTPOperator_Cleanup step we should remove all service bindings and all service instances.

Changes proposed in this pull request:

- While testing trial plan after SKR creation we add one service instance and one service binding
- After deprovisioning we check if the resources no longer exist

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
