### PR TITLE
Option for KCP to display at least partial information for deprovisioned instances

### DIFF
--- a/components/kyma-environment-broker/common/runtime/client.go
+++ b/components/kyma-environment-broker/common/runtime/client.go
@@ -113,6 +113,9 @@ func setQuery(url *url.URL, params ListParameters) {
 	if params.Expired {
 		query.Add(ExpiredParam, "true")
 	}
+	if params.IncludeDeleted {
+		query.Add(IncludeDeletedParam, "true")
+	}
 	setParamList(query, GlobalAccountIDParam, params.GlobalAccountIDs)
 	setParamList(query, SubAccountIDParam, params.SubAccountIDs)
 	setParamList(query, InstanceIDParam, params.InstanceIDs)

--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -114,6 +114,7 @@ const (
 	KymaConfigParam      = "kyma_config"
 	ClusterConfigParam   = "cluster_config"
 	ExpiredParam         = "expired"
+	IncludeDeletedParam  = "include_deleted"
 )
 
 type OperationDetail string
@@ -154,6 +155,8 @@ type ListParameters struct {
 	Expired bool
 	// Events parameter fetches tracing events per instance
 	Events bool
+	// IncludeDeleted parameter instructs KEB to try best effort to include at least partial information regarding deprovisioned instances from residual operations
+	IncludeDeleted bool
 }
 
 func (rt RuntimeDTO) LastOperation() Operation {

--- a/components/kyma-environment-broker/internal/events/interface.go
+++ b/components/kyma-environment-broker/internal/events/interface.go
@@ -10,7 +10,7 @@ import (
 
 type Config struct {
 	Enabled       bool          `envconfig:"default=false"`
-	Retention     time.Duration `envconfig:"default=72h"`
+	Retention     time.Duration `envconfig:"default=336h"` // two weeks: 24*14 = 336
 	PollingPeriod time.Duration `envconfig:"default=1h"`
 }
 

--- a/components/kyma-environment-broker/internal/runtime/handler.go
+++ b/components/kyma-environment-broker/internal/runtime/handler.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
+	"github.com/pivotal-cf/brokerapi/v8/domain"
 
 	"github.com/gorilla/mux"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
@@ -43,6 +44,66 @@ func (h *Handler) AttachRoutes(router *mux.Router) {
 	router.HandleFunc("/runtimes", h.getRuntimes)
 }
 
+func findLastDeprovisioning(operations []internal.Operation) internal.Operation {
+	for i := len(operations) - 1; i > 0; i-- {
+		o := operations[i]
+		if o.Type != internal.OperationTypeDeprovision {
+			continue
+		}
+		if o.State != domain.Succeeded {
+			continue
+		}
+		return o
+	}
+	return operations[len(operations)-1]
+}
+
+func recreateInstances(operations []internal.Operation) []internal.Instance {
+	byInstance := make(map[string][]internal.Operation)
+	for _, o := range operations {
+		byInstance[o.InstanceID] = append(byInstance[o.InstanceID], o)
+	}
+	var instances []internal.Instance
+	for id, op := range byInstance {
+		o := op[0]
+		last := findLastDeprovisioning(op)
+		instances = append(instances, internal.Instance{
+			InstanceID:      id,
+			GlobalAccountID: o.GlobalAccountID,
+			SubAccountID:    o.SubAccountID,
+			RuntimeID:       o.RuntimeID,
+			CreatedAt:       o.CreatedAt,
+			ServicePlanID:   o.ProvisioningParameters.PlanID,
+			DeletedAt:       last.UpdatedAt,
+			InstanceDetails: last.InstanceDetails,
+			Parameters:      last.ProvisioningParameters,
+		})
+	}
+	return instances
+}
+
+func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]internal.Instance, int, int, error) {
+	instances, count, totalCount, err := h.instancesDb.List(filter)
+	if err != nil {
+		return instances, count, totalCount, err
+	}
+	if filter.IncludeDeleted != nil && *filter.IncludeDeleted {
+		opFilter := dbmodel.OperationFilter{}
+		opFilter.InstanceFilter = &filter
+		opFilter.Page = filter.Page
+		opFilter.PageSize = filter.PageSize
+		operations, _, _, err := h.operationsDb.ListOperations(opFilter)
+		if err != nil {
+			return instances, count, totalCount, err
+		}
+		instancesFromOperations := recreateInstances(operations)
+		instances = append(instances, instancesFromOperations...)
+		count += len(instancesFromOperations)
+		totalCount += len(instancesFromOperations)
+	}
+	return instances, count, totalCount, err
+}
+
 func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 	toReturn := make([]pkg.RuntimeDTO, 0)
 
@@ -58,7 +119,7 @@ func (h *Handler) getRuntimes(w http.ResponseWriter, req *http.Request) {
 	kymaConfig := getBoolParam(pkg.KymaConfigParam, req)
 	clusterConfig := getBoolParam(pkg.ClusterConfigParam, req)
 
-	instances, count, totalCount, err := h.instancesDb.List(filter)
+	instances, count, totalCount, err := h.listInstances(filter)
 	if err != nil {
 		httputil.WriteErrorResponse(w, http.StatusInternalServerError, errors.Wrap(err, "while fetching instances"))
 		return
@@ -330,6 +391,9 @@ func (h *Handler) getFilters(req *http.Request) dbmodel.InstanceFilter {
 	filter.Regions = query[pkg.RegionParam]
 	filter.Shoots = query[pkg.ShootParam]
 	filter.Plans = query[pkg.PlanParam]
+	if v, exists := query[pkg.IncludeDeletedParam]; exists && v[0] == "true" {
+		filter.IncludeDeleted = ptr.Bool(true)
+	}
 	if v, exists := query[pkg.ExpiredParam]; exists && v[0] == "true" {
 		filter.Expired = ptr.Bool(true)
 	}

--- a/components/kyma-environment-broker/internal/storage/dbmodel/instance.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/instance.go
@@ -34,6 +34,7 @@ type InstanceFilter struct {
 	Shoots                       []string
 	States                       []InstanceState
 	Expired                      *bool
+	IncludeDeleted               *bool
 }
 
 type InstanceDTO struct {

--- a/components/kyma-environment-broker/internal/storage/dbmodel/operation.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/operation.go
@@ -9,9 +9,10 @@ import (
 
 // OperationFilter holds the filters when listing multiple operations
 type OperationFilter struct {
-	Page     int
-	PageSize int
-	States   []string
+	InstanceFilter *InstanceFilter
+	Page           int
+	PageSize       int
+	States         []string
 }
 
 type OperationDTO struct {

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -834,6 +834,12 @@ func addOperationFilters(stmt *dbr.SelectStmt, filter dbmodel.OperationFilter) {
 	if len(filter.States) > 0 {
 		stmt.Where("state IN ?", filter.States)
 	}
+	if filter.InstanceFilter != nil {
+		fi := filter.InstanceFilter
+		if len(fi.InstanceIDs) != 0 {
+			stmt.Where("instance_id IN ?", fi.InstanceIDs)
+		}
+	}
 }
 
 func (r readSession) getOperationCount(filter dbmodel.OperationFilter) (int, error) {

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2277"
+      version: "PR-2283"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"

--- a/tools/cli/pkg/command/runtime.go
+++ b/tools/cli/pkg/command/runtime.go
@@ -98,8 +98,9 @@ https://github.com/kyma-project/control-plane/blob/main/docs/kyma-environment-br
 	cobraCmd.Flags().BoolVar(&cmd.opDetail, "ops", false, "Get all operations for the runtimes instead of just querying the last operation.")
 	cobraCmd.Flags().BoolVar(&cmd.params.KymaConfig, "kyma-config", false, "Get all Kyma configuration details for the selected runtimes.")
 	cobraCmd.Flags().BoolVar(&cmd.params.ClusterConfig, "cluster-config", false, "Get all cluster configuration details for the selected runtimes.")
-	cobraCmd.Flags().BoolVar(&cmd.params.Expired, "expired", false, "Lists only expired runtimes")
-	cobraCmd.Flags().BoolVar(&cmd.params.Events, "events", false, "Enhance output with tracing events")
+	cobraCmd.Flags().BoolVar(&cmd.params.Expired, "expired", false, "Lists only expired runtimes.")
+	cobraCmd.Flags().BoolVar(&cmd.params.Events, "events", false, "Enhance output with tracing events.")
+	cobraCmd.Flags().BoolVar(&cmd.params.IncludeDeleted, "include-deleted", false, "Try best effort to include at least partial information regarding deprovisioned instances.")
 
 	return cobraCmd
 }
@@ -155,6 +156,9 @@ func (cmd *RuntimeCommand) Validate() error {
 	cmd.params.OperationDetail = runtime.LastOperation
 	if cmd.opDetail {
 		cmd.params.OperationDetail = runtime.AllOperation
+	}
+	if cmd.params.IncludeDeleted == true && len(cmd.params.InstanceIDs) == 0 {
+		return fmt.Errorf("need to provide some Instance IDs when using --include-deleted")
 	}
 
 	return nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Whenever an instance is deprovisioned, the root reference in `Instances` table is deleted which results in failure to get any data through KCP. However, there is a possibility to reconstruct some data from residual `Operations` and events.

This PR enables getting some subset of information for troubleshooting purposes with following usage:
```
$ kcp runtime -i [instance_id] --include-deleted
```

<details>
  <summary>sample usage</summary>

Old way for calling kcp on deleted instance
```
$ kcp runtime -itest-jw252
GLOBALACCOUNT ID   SUBACCOUNT ID   SHOOT   REGION   PLAN   CREATED AT   STATE
```

Proposed `--include-deleted` parameter that will try best effort to reconstruct instance details from residual operations
```
$ kcp runtime -itest-jw25 --include-deleted
GLOBALACCOUNT ID   SUBACCOUNT ID                          SHOOT     REGION   PLAN   CREATED AT            STATE
                   19ea2000-865d-42fd-8d6f-3e3e2dcce3c8   fdc5963                   2022/11/16 12:38:45   suspended
```

The same in conjunction with `--events`
```
$ kcp runtime -itest-jw25 --include-deleted --events
GLOBALACCOUNT ID   SUBACCOUNT ID                          SHOOT     REGION   PLAN   CREATED AT            STATE
                   19ea2000-865d-42fd-8d6f-3e3e2dcce3c8   fdc5963                   2022/11/16 12:38:45   suspended
 ˫operation 5f4c19fe-8a7f-49d3-84e8-16889e26d1fd
  ˫info   2d2h                          processing step: Starting
  ˫info   2d2h                          processing step: Provision_Initialization
  ˫info   2d2h                          processing step: Init_Kyma_Template
  ˫info   2d2h                          processing step: Resolve_Target_Secret
  ˫info   2d2h                          processing step: AVS_Create_Internal_Eval_Step
  ˫info   2d2h                          processing step: EDP_Registration
  ˫info   2d2h                          step EDP_Registration sleeping for 1s
  ˫info   2d2h                          processing step: Overrides_From_Secrets_And_Config_Step
  ˫info   2d2h                          processing step: BTPOperatorOverrides
  ˫info   2d2h                          processing step: Create_Runtime_Without_Kyma
  ˫info   2d2h                          processing step: Check_Runtime
  ˫info   2d2h ago (4x in last 2d2h)    step Check_Runtime sleeping for 2m0s
  ˫info   2d2h                          processing step: Get_Kubeconfig
  ˫info   2d2h                          processing step: Inject_BTP_Operator_Credentials
  ˫info   2d2h                          processing step: Create_Cluster_Configuration
  ˫info   2d2h                          processing step: Check_Cluster_Configuration
  ˫info   2d2h ago (10x in last 2d2h)   step Check_Cluster_Configuration sleeping for 30s
  ˫info   2d2h                          processing step: AVS_Create_External_Eval_Step
  ˫info   2d2h                          processing step: AVS_Tags
 ˫operation 32ca2315-180c-4ca3-aa54-4ba3ffdb6bce
  ˫info   2d2h                          processing step: Initialisation
  ˫info   2d2h                          processing step: BTPOperator_Cleanup
  ˫info   2d2h                          processing step: De-provision_AVS_Evaluations
  ˫info   2d2h                          processing step: EDP_Deregistration
  ˫info   2d2h                          processing step: Deregister_Cluster
  ˫info   2d2h                          processing step: Check_Cluster_Deregistration
  ˫info   2d2h ago (8x in last 2d2h)    step Check_Cluster_Deregistration sleeping for 30s
  ˫info   2d2h                          processing step: Remove_Runtime
  ˫info   2d2h                          processing step: Check_Runtime_Removal
  ˫info   2d2h ago (17x in last 2d2h)   step Check_Runtime_Removal sleeping for 30s
  ˫info   2d2h                          processing step: Release_Subscription
  ˪info   2d2h                          processing step: Remove_Instance
```
</details>

closes: https://github.com/kyma-project/control-plane/issues/2256