### PR TITLE
Change KCP runtime flag `--include-deleted` to `--only-deleted`

### DIFF
--- a/components/kyma-environment-broker/common/runtime/client.go
+++ b/components/kyma-environment-broker/common/runtime/client.go
@@ -113,8 +113,8 @@ func setQuery(url *url.URL, params ListParameters) {
 	if params.Expired {
 		query.Add(ExpiredParam, "true")
 	}
-	if params.IncludeDeleted {
-		query.Add(IncludeDeletedParam, "true")
+	if params.OnlyDeleted {
+		query.Add(OnlyDeletedParam, "true")
 	}
 	setParamList(query, GlobalAccountIDParam, params.GlobalAccountIDs)
 	setParamList(query, SubAccountIDParam, params.SubAccountIDs)

--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -114,7 +114,7 @@ const (
 	KymaConfigParam      = "kyma_config"
 	ClusterConfigParam   = "cluster_config"
 	ExpiredParam         = "expired"
-	IncludeDeletedParam  = "include_deleted"
+	OnlyDeletedParam     = "only_deleted"
 )
 
 type OperationDetail string
@@ -155,8 +155,8 @@ type ListParameters struct {
 	Expired bool
 	// Events parameter fetches tracing events per instance
 	Events bool
-	// IncludeDeleted parameter instructs KEB to try best effort to include at least partial information regarding deprovisioned instances from residual operations
-	IncludeDeleted bool
+	// OnlyDeleted parameter instructs KEB to try best effort to reconstruct at least partial information regarding deprovisioned instances from residual operations
+	OnlyDeleted bool
 }
 
 func (rt RuntimeDTO) LastOperation() Operation {

--- a/components/kyma-environment-broker/internal/storage/dbmodel/instance.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/instance.go
@@ -34,7 +34,7 @@ type InstanceFilter struct {
 	Shoots                       []string
 	States                       []InstanceState
 	Expired                      *bool
-	IncludeDeleted               *bool
+	OnlyDeleted                  *bool
 }
 
 type InstanceDTO struct {

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -151,9 +151,9 @@ func (r readSession) GetOperationByID(opID string) (dbmodel.OperationDTO, dberr.
 func (r readSession) ListOperations(filter dbmodel.OperationFilter) ([]dbmodel.OperationDTO, int, int, error) {
 	var operations []dbmodel.OperationDTO
 
-	stmt := r.session.Select("*").
-		From(OperationTableName).
-		OrderBy(CreatedAtField)
+	stmt := r.session.Select("o.*").
+		From(dbr.I(OperationTableName).As("o")).
+		OrderBy("o.created_at")
 
 	// Add pagination if provided
 	if filter.Page > 0 && filter.PageSize > 0 {
@@ -350,10 +350,10 @@ func (r readSession) ListOperationsByOrchestrationID(orchestrationID string, fil
 	condition := dbr.Eq("orchestration_id", orchestrationID)
 
 	stmt := r.session.
-		Select("*").
-		From(OperationTableName).
+		Select("o.*").
+		From(dbr.I(OperationTableName).As("o")).
 		Where(condition).
-		OrderBy(CreatedAtField)
+		OrderBy("o.created_at")
 
 	// Add pagination if provided
 	if filter.Page > 0 && filter.PageSize > 0 {
@@ -832,12 +832,16 @@ func addOrchestrationFilters(stmt *dbr.SelectStmt, filter dbmodel.OrchestrationF
 
 func addOperationFilters(stmt *dbr.SelectStmt, filter dbmodel.OperationFilter) {
 	if len(filter.States) > 0 {
-		stmt.Where("state IN ?", filter.States)
+		stmt.Where("o.state IN ?", filter.States)
 	}
 	if filter.InstanceFilter != nil {
 		fi := filter.InstanceFilter
+		if fi.OnlyDeleted != nil && *fi.OnlyDeleted {
+			stmt.LeftJoin(dbr.I(InstancesTableName).As("i"), "i.instance_id = o.instance_id").
+				Where("i.instance_id IS NULL")
+		}
 		if len(fi.InstanceIDs) != 0 {
-			stmt.Where("instance_id IN ?", fi.InstanceIDs)
+			stmt.Where("o.instance_id IN ?", fi.InstanceIDs)
 		}
 	}
 }
@@ -846,8 +850,8 @@ func (r readSession) getOperationCount(filter dbmodel.OperationFilter) (int, err
 	var res struct {
 		Total int
 	}
-	stmt := r.session.Select("count(*) as total").
-		From(OperationTableName)
+	stmt := r.session.Select("count(1) as total").
+		From(dbr.I(OperationTableName).As("o"))
 	addOperationFilters(stmt, filter)
 	err := stmt.LoadOne(&res)
 
@@ -858,9 +862,9 @@ func (r readSession) getUpgradeOperationCount(orchestrationID string, filter dbm
 	var res struct {
 		Total int
 	}
-	stmt := r.session.Select("count(*) as total").
-		From(OperationTableName).
-		Where(dbr.Eq("orchestration_id", orchestrationID))
+	stmt := r.session.Select("count(1) as total").
+		From(dbr.I(OperationTableName).As("o")).
+		Where(dbr.Eq("o.orchestration_id", orchestrationID))
 	addOperationFilters(stmt, filter)
 	err := stmt.LoadOne(&res)
 

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2285"
+      version: "PR-2286"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2175"

--- a/tools/cli/pkg/command/runtime.go
+++ b/tools/cli/pkg/command/runtime.go
@@ -100,7 +100,7 @@ https://github.com/kyma-project/control-plane/blob/main/docs/kyma-environment-br
 	cobraCmd.Flags().BoolVar(&cmd.params.ClusterConfig, "cluster-config", false, "Get all cluster configuration details for the selected runtimes.")
 	cobraCmd.Flags().BoolVar(&cmd.params.Expired, "expired", false, "Lists only expired runtimes.")
 	cobraCmd.Flags().BoolVar(&cmd.params.Events, "events", false, "Enhance output with tracing events.")
-	cobraCmd.Flags().BoolVar(&cmd.params.IncludeDeleted, "include-deleted", false, "Try best effort to include at least partial information regarding deprovisioned instances.")
+	cobraCmd.Flags().BoolVar(&cmd.params.OnlyDeleted, "only-deleted", false, "Try best effort to reconstruct at least partial information regarding deprovisioned instances.")
 
 	return cobraCmd
 }
@@ -157,8 +157,8 @@ func (cmd *RuntimeCommand) Validate() error {
 	if cmd.opDetail {
 		cmd.params.OperationDetail = runtime.AllOperation
 	}
-	if cmd.params.IncludeDeleted == true && len(cmd.params.InstanceIDs) == 0 {
-		return fmt.Errorf("need to provide some Instance IDs when using --include-deleted")
+	if cmd.params.OnlyDeleted == true && len(cmd.params.InstanceIDs) == 0 {
+		return fmt.Errorf("need to provide some Instance IDs when using --only-deleted")
 	}
 
 	return nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

In https://github.com/kyma-project/control-plane/pull/2283, new flag for `kcp runtimes` called `--include-deleted` was introduced. After followup discussion in https://github.com/kyma-project/control-plane/issues/2256, it was expressed as desirable to rename the flag to `--only-deleted` with all semantic changes relevant for the rename.

closes: https://github.com/kyma-project/control-plane/issues/2256