### PR TITLE
keb: fix events client filter

### DIFF
--- a/components/kyma-environment-broker/common/events/client.go
+++ b/components/kyma-environment-broker/common/events/client.go
@@ -59,7 +59,9 @@ func (c *client) ListEvents(instanceIDs []string) ([]EventDTO, error) {
 	if err != nil {
 		return events, fmt.Errorf("while creating request: %v", err)
 	}
-	req.URL.Query().Add("instanceIds", strings.Join(instanceIDs, ","))
+	q := req.URL.Query()
+	q.Add("instance_ids", strings.Join(instanceIDs, ","))
+	req.URL.RawQuery = q.Encode()
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return events, fmt.Errorf("while calling %s: %v", req.URL.String(), err)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The instance ID filter on events API returns all events which is especially visible when using `-o json` with `kcp rt`. This is a fix for the filter to finally work appropriately.

Old output:
```
$ kcp runtime --events -ipreview016 -o json | jq -c '.[]' | wc -l
2153
```
Output post fix:
```
$ make build-linux-kcp && ./kcp-linux runtime --events -ipreview016 -o json | jq -c '.[]' | wc -l
CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o ./kcp-linux -ldflags '-s -w -X github.com/kyma-project/control-plane/tools/cli/pkg/command.Version=078665c7' cmd/kcp/main.go
23
```

**Related issue(s)**
closes: https://github.com/kyma-project/control-plane/issues/2301