### PR TITLE
kcp-migration-broker and provisioner - change on helm hook annotations

### DIFF
--- a/resources/kcp/templates/migrator-job.yaml
+++ b/resources/kcp/templates/migrator-job.yaml
@@ -7,7 +7,7 @@ metadata:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook": pre-install,pre-upgrade
         "helm.sh/hook-weight": "1"
         "helm.sh/hook-delete-policy": before-hook-creation
 spec:
@@ -115,7 +115,7 @@ metadata:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": post-install,post-upgrade
+        "helm.sh/hook": pre-install,pre-upgrade
         "helm.sh/hook-weight": "2"
         "helm.sh/hook-delete-policy": before-hook-creation
 spec:

--- a/resources/kcp/templates/migrator-job.yaml
+++ b/resources/kcp/templates/migrator-job.yaml
@@ -7,7 +7,7 @@ metadata:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": pre-install,pre-upgrade
+        "helm.sh/hook": post-install,pre-upgrade
         "helm.sh/hook-weight": "1"
         "helm.sh/hook-delete-policy": before-hook-creation
 spec:
@@ -115,7 +115,7 @@ metadata:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": pre-install,pre-upgrade
+        "helm.sh/hook": post-install,pre-upgrade
         "helm.sh/hook-weight": "2"
         "helm.sh/hook-delete-policy": before-hook-creation
 spec:


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Moving kcp-migration-broker and kcp-migration-provisioner jobs to pre-install/pre-upgrade hook, as we observed issues that argocd did not execute this job during post-sync having conflict with long-running post-sync e2e test. 

**Related issue(s)**
[KCP Dev Provision failed: \"eu_access\" of relation \"gardener_config\" does not exist #3295](https://github.tools.sap/kyma/backlog/issues/3295)
