### PR TITLE
Do not Log kubeconfig hash

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -2,8 +2,6 @@ package deprovisioning
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -191,8 +189,7 @@ func (s *BTPOperatorCleanupStep) getKubeClient(operation internal.Operation, log
 		return nil, kebError.NewTemporaryError("empty kubeconfig")
 	}
 	k := *status.RuntimeConfiguration.Kubeconfig
-	hash := sha256.Sum256([]byte(k))
-	log.Infof("kubeconfig details length: %v, sha256: %v", len(k), base64.StdEncoding.EncodeToString(hash[:]))
+	log.Infof("kubeconfig length: %v", len(k))
 	if len(k) < 10 {
 		return nil, kebError.NewTemporaryError("kubeconfig suspiciously small, requeuing")
 	}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -3,6 +3,7 @@ package deprovisioning
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"time"
@@ -191,7 +192,7 @@ func (s *BTPOperatorCleanupStep) getKubeClient(operation internal.Operation, log
 	}
 	k := *status.RuntimeConfiguration.Kubeconfig
 	hash := sha256.Sum256([]byte(k))
-	log.Infof("kubeconfig details length: %v, sha256: %v", len(k), string(hash[:]))
+	log.Infof("kubeconfig details length: %v, sha256: %v", len(k), base64.StdEncoding.EncodeToString(hash[:]))
 	if len(k) < 10 {
 		return nil, kebError.NewTemporaryError("kubeconfig suspiciously small, requeuing")
 	}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2315"
+      version: "PR-2341"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently hash is logged as binary converted to string.

Changes proposed in this pull request:

- `kubeconfig` hash is not logged any more


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
