### PR TITLE
Add nataliasiitko to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,4 +53,4 @@
 /components/reconciler @kwiatekus @cortey @clebs @jeremyharisch @khlifi411 @Tomasz-Smelcerz-SAP @ruanxin @jakobmoellersap @adityabhatia
 
 # All .md files
-*.md @mmitoraj @NHingerl @grego952 @IwonaLanger  
+*.md @mmitoraj @NHingerl @grego952 @IwonaLanger @nataliasitko

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,10 +3,12 @@ aliases:
     - mmitoraj
     - NHingerl
     - grego952
+    - nataliasitko
   documentation-approvers:
     - mmitoraj
     - NHingerl
     - grego952
+    - nataliasitko
   kmc-reviewers:
     - k15r
     - nachtmaar


### PR DESCRIPTION
Changes proposed in this pull request:

- Add nataliasitko to CODEOWNERS and OWNERS_ALIASES

**Related issue**
- https://github.com/kyma-project/kyma/issues/16378