### PR TITLE
Explicit err check before err wrapping

### DIFF
--- a/components/kyma-environment-broker/cmd/environmentscleanup/main.go
+++ b/components/kyma-environment-broker/cmd/environmentscleanup/main.go
@@ -40,12 +40,18 @@ func main() {
 
 	cfg := config{}
 	err := envconfig.InitWithPrefix(&cfg, "APP")
-	fatalOnError(fmt.Errorf("while loading cleanup config: %w", err))
+	if err != nil {
+		fatalOnError(fmt.Errorf("while loading cleanup config: %w", err))
+	}
 
 	clusterCfg, err := gardener.NewGardenerClusterConfig(cfg.Gardener.KubeconfigPath)
-	fatalOnError(fmt.Errorf("while creating Gardener cluster config: %w", err))
+	if err != nil {
+		fatalOnError(fmt.Errorf("while creating Gardener cluster config: %w", err))
+	}
 	cli, err := dynamic.NewForConfig(clusterCfg)
-	fatalOnError(fmt.Errorf("while creating Gardener client: %w", err))
+	if err != nil {
+		fatalOnError(fmt.Errorf("while creating Gardener client: %w", err))
+	}
 	gardenerNamespace := fmt.Sprintf("garden-%s", cfg.Gardener.Project)
 	shootClient := cli.Resource(gardener.ShootResource).Namespace(gardenerNamespace)
 
@@ -56,7 +62,9 @@ func main() {
 	// create storage
 	cipher := storage.NewEncrypter(cfg.Database.SecretKey)
 	db, conn, err := storage.NewFromConfig(cfg.Database, events.Config{}, cipher, log.WithField("service", "storage"))
-	fatalOnError(err)
+	if err != nil {
+		fatalOnError(err)
+	}
 	dbStatsCollector := sqlstats.NewStatsCollector("broker", conn)
 	prometheus.MustRegister(dbStatsCollector)
 

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -5,7 +5,7 @@ global:
       version: "PR-2327"
     kyma_environments_cleanup_job:
       dir:
-      version: "PR-2337"
+      version: "PR-2363"
     kyma_environments_subaccount_cleanup_job:
       dir:
       version: "PR-2337"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

It was noticed that environment cleanup job started failing:
<img width="841" alt="env_err" src="https://user-images.githubusercontent.com/1529535/208671735-3f6cebba-7c41-4056-91bf-a9c5dda7330d.png">

The error message is
```
time="2022-12-16T00:00:57Z" level=fatal msg="while loading cleanup config: %!w(<nil>)" component="environmentscleanup/main.go:89:main.fatalOnError"
```

The error wrapping implemented in https://github.com/kyma-project/control-plane/pull/2234 had a side effect here that even `nil` error is still wrapped which results in marking job as failed. It surfaced during the last image bump https://github.com/kyma-project/control-plane/pull/2337.

This PR proposes remediation in form of explicit error checking.