### PR TITLE
EU Access in KEB - handling default regions

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/provisioning_test.go
+++ b/components/kyma-environment-broker/cmd/broker/provisioning_test.go
@@ -166,6 +166,37 @@ func TestProvisioning_AzureWithEURestrictedAccessHappyFlow(t *testing.T) {
 	suite.AssertAzureRegion("switzerlandnorth")
 }
 
+func TestProvisioning_AzureWithEURestrictedAccessDefaultRegion(t *testing.T) {
+	// given
+	suite := NewBrokerSuiteTest(t)
+	defer suite.TearDown()
+	iid := uuid.New().String()
+
+	// when
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-ch20/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+					"plan_id": "4deee563-e5ec-4731-b9b1-53b42d855f0c",
+					"context": {
+						"sm_platform_credentials": {
+							  "url": "https://sm.url",
+							  "credentials": {}
+					    },
+						"globalaccount_id": "g-account-id",
+						"subaccount_id": "sub-id",
+						"user_id": "john.smith@email.com"
+					},
+					"parameters": {
+						"name": "testing-cluster"
+					}
+		}`)
+	opID := suite.DecodeOperationID(resp)
+	suite.processProvisioningAndReconcilingByOperationID(opID)
+
+	// then
+	suite.AssertAzureRegion("switzerlandnorth")
+}
+
 func TestProvisioning_AWSWithEURestrictedAccessHappyFlow(t *testing.T) {
 	// given
 	suite := NewBrokerSuiteTest(t)
@@ -189,6 +220,37 @@ func TestProvisioning_AWSWithEURestrictedAccessHappyFlow(t *testing.T) {
 					"parameters": {
 						"name": "testing-cluster",
 						"region":"eu-central-1"
+					}
+		}`)
+	opID := suite.DecodeOperationID(resp)
+	suite.processProvisioningAndReconcilingByOperationID(opID)
+
+	// then
+	suite.AssertAWSRegionAndZone("eu-central-1")
+}
+
+func TestProvisioning_AWSWithEURestrictedAccessDefaultRegion(t *testing.T) {
+	// given
+	suite := NewBrokerSuiteTest(t)
+	defer suite.TearDown()
+	iid := uuid.New().String()
+
+	// when
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu11/v2/service_instances/%s?accepts_incomplete=true", iid),
+		`{
+					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
+					"plan_id": "361c511f-f939-4621-b228-d0fb79a1fe15",
+					"context": {
+						"sm_platform_credentials": {
+							  "url": "https://sm.url",
+							  "credentials": {}
+					    },
+						"globalaccount_id": "g-account-id",
+						"subaccount_id": "sub-id",
+						"user_id": "john.smith@email.com"
+					},
+					"parameters": {
+						"name": "testing-cluster"
 					}
 		}`)
 	opID := suite.DecodeOperationID(resp)
@@ -356,7 +418,7 @@ func TestProvisioning_TrialAtEU(t *testing.T) {
 	iid := uuid.New().String()
 
 	// when
-	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu10/v2/service_instances/%s?accepts_incomplete=true", iid),
+	resp := suite.CallAPI("PUT", fmt.Sprintf("oauth/cf-eu11/v2/service_instances/%s?accepts_incomplete=true", iid),
 		`{
 					"service_id": "47c9dcbf-ff30-448e-ab36-d3bad66ba281",
 					"plan_id": "7d55d31d-35ae-4438-bf13-6ffdfa107d9f",
@@ -377,7 +439,7 @@ func TestProvisioning_TrialAtEU(t *testing.T) {
 	suite.processProvisioningAndReconcilingByOperationID(opID)
 
 	// then
-	suite.AssertAWSRegionAndZone("eu-west-1")
+	suite.AssertAWSRegionAndZone("eu-central-1")
 }
 
 func TestProvisioning_HandleExistingOperation(t *testing.T) {

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	DefaultAzureRegion         = "eastus"
+	DefaultEuAccessAzureRegion = "switzerlandnorth"
 	DefaultAzureMultiZoneCount = 3
 )
 
@@ -74,6 +75,11 @@ func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
 }
 
 func (p *AzureInput) ApplyParameters(input *gqlschema.ClusterConfigInput, pp internal.ProvisioningParameters) {
+	if internal.IsEuAccess(pp.PlatformRegion) {
+		updateString(&input.GardenerConfig.Region, ptr.String(DefaultEuAccessAzureRegion))
+		return
+	}
+
 	// explicit zones list is provided
 	if len(pp.Parameters.Zones) > 0 {
 		zones := []int{}
@@ -126,6 +132,9 @@ func (p *AzureLiteInput) Defaults() *gqlschema.ClusterConfigInput {
 }
 
 func (p *AzureLiteInput) ApplyParameters(input *gqlschema.ClusterConfigInput, pp internal.ProvisioningParameters) {
+	if internal.IsEuAccess(pp.PlatformRegion) {
+		updateString(&input.GardenerConfig.Region, ptr.String(DefaultEuAccessAzureRegion))
+	}
 }
 
 func (p *AzureLiteInput) Profile() gqlschema.KymaProfile {
@@ -172,6 +181,11 @@ func azureTrialDefaults() *gqlschema.ClusterConfigInput {
 
 func (p *AzureTrialInput) ApplyParameters(input *gqlschema.ClusterConfigInput, pp internal.ProvisioningParameters) {
 	params := pp.Parameters
+
+	if internal.IsEuAccess(pp.PlatformRegion) {
+		updateString(&input.GardenerConfig.Region, ptr.String(DefaultEuAccessAzureRegion))
+		return
+	}
 
 	// read platform region if exists
 	if pp.PlatformRegion != "" {

--- a/components/kyma-environment-broker/internal/provider/azure_provider_test.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAzureTrialInput_ApplyParametersWithRegion(t *testing.T) {
+func TestAzureTrialInput_ApplyParametersWithRegion(t *testing.T) { //TODO apply EU Access for trials
 	// given
 	svc := AzureTrialInput{
 		PlatformRegionMapping: map[string]string{
@@ -63,7 +63,25 @@ func TestAzureTrialInput_ApplyParametersWithRegion(t *testing.T) {
 		})
 
 		//then
-		assert.Equal(t, "eastus", input.GardenerConfig.Region)
+		assert.Equal(t, DefaultAzureRegion, input.GardenerConfig.Region)
+	})
+
+	// when
+	t.Run("forget customer empty region for EU Access", func(t *testing.T) {
+		// given
+		input := svc.Defaults()
+		r := ""
+
+		// when
+		svc.ApplyParameters(input, internal.ProvisioningParameters{
+			PlatformRegion: "cf-ch20",
+			Parameters: internal.ProvisioningParametersDTO{
+				Region: &r,
+			},
+		})
+
+		//then
+		assert.Equal(t, DefaultEuAccessAzureRegion, input.GardenerConfig.Region)
 	})
 
 	// when
@@ -76,6 +94,20 @@ func TestAzureTrialInput_ApplyParametersWithRegion(t *testing.T) {
 
 		//then
 		assert.Equal(t, DefaultAzureRegion, input.GardenerConfig.Region)
+	})
+
+	// when
+	t.Run("use default region for EU Access", func(t *testing.T) {
+		// given
+		input := svc.Defaults()
+
+		// when
+		svc.ApplyParameters(input, internal.ProvisioningParameters{
+			PlatformRegion: "cf-ch20"},
+		)
+
+		//then
+		assert.Equal(t, DefaultEuAccessAzureRegion, input.GardenerConfig.Region)
 	})
 
 	// when

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2341"
+      version: "PR-2370"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

For access from PlatformRegions `cf-eu11` and `cf-ch20` we restrict set of available regions accordingly. When region is not provided default is assumed - this is not aligned with EU Access restrictions. 

Changes proposed in this pull request:

- Default regions for AWS and Azure plans are EU Access compliant in case EU Access restrictions apply

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
