### PR TITLE
Configurable integration of KEB with LM and Reconciler

### DIFF
--- a/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_kyma_step.go
+++ b/components/kyma-environment-broker/internal/process/upgrade_kyma/apply_kyma_step.go
@@ -1,0 +1,26 @@
+package upgrade_kyma
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/provisioning"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
+)
+
+// NOTE: adapter for upgrade_kyma which is currently not using shared staged_manager
+type ApplyKymaStep struct {
+	*provisioning.ApplyKymaStep
+}
+
+func NewApplyKymaStep(os storage.Operations, cli client.Client) *ApplyKymaStep {
+	return &ApplyKymaStep{provisioning.NewApplyKymaStep(os, cli)}
+}
+
+func (s *ApplyKymaStep) Run(o internal.UpgradeKymaOperation, logger logrus.FieldLogger) (internal.UpgradeKymaOperation, time.Duration, error) {
+	o2, w, err := s.ApplyKymaStep.Run(o.Operation, logger)
+	return internal.UpgradeKymaOperation{o2}, w, err
+}

--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -85,6 +85,8 @@ spec:
               value: "{{ .Values.reconciler.URL }}"
             - name: APP_LIFECYCLE_MANAGER_INTEGRATION_DISABLED
               value: "{{ .Values.lifecycleManager.disabled}}"
+            - name: APP_RECONCILER_INTEGRATION_DISABLED
+              value: "{{ .Values.reconciler.disabled }}"
             - name: APP_RECONCILER_PROVISIONING_TIMEOUT
               value: "{{ .Values.reconciler.provisioningTimeout }}"
             - name: APP_PROVISIONER_URL

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -64,6 +64,7 @@ reconciler:
   URL: "http://kcp-mothership-reconciler.kcp-system.svc.cluster.local"
   # Defines how long KEB checks the status of the provisioning reconciliation.
   provisioningTimeout: "2h"
+  disabled: "false"
 
 lifecycleManager:
   disabled: "true"

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2369"
+      version: "PR-2372"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

KEB should be configurable to dynamically enable and disable its integration with Lifecycle Manager as well as Reconciler.

related to: https://github.com/kyma-project/kyma/issues/15445

<details>
<summary>kcp events</summary>

the lifecycle manager steps are highlighted

```diff
$ kcp rt --events -i test-jw256
GLOBALACCOUNT ID                       SUBACCOUNT ID                          SHOOT       REGION         PLAN   CREATED AT            STATE            KYMA VERSION
e449f875-b5b2-4485-b7c0-98725c0571bf   19ea2000-865d-42fd-8d6f-3e3e2dcce3c8   c-98ca31a   eu-central-1   aws    2023/01/04 09:59:12   deprovisioning   2.9.3
 ˫provision operation 4b7134a3-2dac-4e81-8ba2-596def96149a: succeeded
  ˫info   89m                         processing step: Starting
  ˫info   89m                         processing step: Provision_Initialization
  ˫info   89m                         processing step: Init_Kyma_Template
  ˫info   89m                         processing step: Resolve_Target_Secret
  ˫info   89m                         processing step: AVS_Create_Internal_Eval_Step
  ˫info   89m                         processing step: EDP_Registration
  ˫info   89m                         processing step: Overrides_From_Secrets_And_Config_Step
  ˫info   89m                         processing step: BTPOperatorOverrides
  ˫info   89m                         processing step: Create_Runtime_Without_Kyma
  ˫info   89m                         processing step: Check_Runtime
  ˫info   83m ago (4x in last 89m)    step Check_Runtime sleeping for 2m0s
  ˫info   81m                         processing step: Get_Kubeconfig
  ˫info   81m                         processing step: Inject_BTP_Operator_Credentials
+ ˫info   81m                         processing step: Sync_Kubeconfig
  ˫info   81m                         processing step: Create_Cluster_Configuration
  ˫info   81m                         processing step: Check_Cluster_Configuration
  ˫info   77m ago (10x in last 81m)   step Check_Cluster_Configuration sleeping for 30s
+ ˫info   76m                         processing step: Apply_Kyma
  ˫info   76m                         processing step: AVS_Create_External_Eval_Step
  ˫info   76m                         processing step: AVS_Tags
 ˫deprovision operation e5ebe9ef-6f2f-4806-9e1e-256ff8d7840a: in progress
  ˫info   2m17s                       processing step: Initialisation
  ˫info   2m17s                       processing step: BTPOperator_Cleanup
  ˫info   2m17s                       processing step: De-provision_AVS_Evaluations
  ˫info   2m12s                       processing step: EDP_Deregistration
+ ˫info   2m12s                       processing step: Delete_Kyma_Resource
+ ˫info   2m12s                       processing step: Check_Kyma_Resource_Deleted
  ˫info   2m12s                       step Check_Kyma_Resource_Deleted sleeping for 15s
  ˫info   117s                        processing step: Deregister_Cluster
  ˫info   117s                        processing step: Check_Cluster_Deregistration
  ˪info   26s ago (4x in last 117s)   step Check_Cluster_Deregistration sleeping for 30s
```

</details>