### PR TITLE
KCP CLI: fix setting maintenance window

### DIFF
--- a/tools/cli/pkg/command/orchestration.go
+++ b/tools/cli/pkg/command/orchestration.go
@@ -100,19 +100,20 @@ var operationColumns = []printer.Column{
 }
 
 var orchestrationDetailsTpl = `Orchestration ID: {{.OrchestrationID}}
-Type:             {{.Type}}
-Created At:       {{.CreatedAt}}
-Updated At:       {{.UpdatedAt}}
-Dry Run:          {{.Parameters.DryRun}}
-State:            {{.State}}
-Description:      {{.Description}}
-Strategy:         {{.Parameters.Strategy.Type}}
-Schedule:         {{.Parameters.Strategy.Schedule}}
-Workers:          {{.Parameters.Strategy.Parallel.Workers}}
+Type:               {{.Type}}
+Created At:         {{.CreatedAt}}
+Updated At:         {{.UpdatedAt}}
+Dry Run:            {{.Parameters.DryRun}}
+State:              {{.State}}
+Description:        {{.Description}}
+Strategy:           {{.Parameters.Strategy.Type}}
+Maintenance Window: {{.Parameters.Strategy.MaintenanceWindow}}
+Schedule After:     {{.Parameters.Strategy.ScheduleTime}}
+Workers:            {{.Parameters.Strategy.Parallel.Workers}}
 {{- if eq .Type "upgradeKyma" }}
-Kyma Version:     {{with .Parameters.Kyma}}{{.Version}}{{end}}
+Kyma Version:       {{with .Parameters.Kyma}}{{.Version}}{{end}}
 {{- else if eq .Type "upgradeCluster" }}
-K8s Version:      {{with .Parameters.Kubernetes}}{{.KubernetesVersion}}{{end}}
+K8s Version:        {{with .Parameters.Kubernetes}}{{.KubernetesVersion}}{{end}}
 {{- end }}
 Targets:
 {{- range $i, $t := .Parameters.Targets.Include }}
@@ -135,13 +136,14 @@ Operations:
 `
 
 var kymaUpgradePreviewTpl = `Kyma Upgrade Preview
-Strategy:         {{.Parameters.Strategy.Type}}
-Schedule:         {{.Parameters.Strategy.Schedule}}
-Workers:          {{.Parameters.Strategy.Parallel.Workers}}
+Strategy:           {{.Parameters.Strategy.Type}}
+Maintenance Window: {{.Parameters.Strategy.MaintenanceWindow}}
+Schedule After:     {{.Parameters.Strategy.Schedule}}
+Workers:            {{.Parameters.Strategy.Parallel.Workers}}
 {{- if eq .Parameters.Kyma.Version "" }}
-Kyma Version:     <determined after start>
+Kyma Version:       <determined after start>
 {{- else }}
-Kyma Version:     {{with .Parameters.Kyma}}{{.Version}}{{end}}
+Kyma Version:       {{with .Parameters.Kyma}}{{.Version}}{{end}}
 {{- end }}
 Targets:
 {{- range $i, $t := .Parameters.Targets.Include }}
@@ -156,10 +158,11 @@ Exclude Targets:
 `
 
 var kubernetesUpgradePreviewTpl = `Kubernetes Upgrade Preview
-Strategy:         {{.Parameters.Strategy.Type}}
-Schedule:         {{.Parameters.Strategy.Schedule}}
-Workers:          {{.Parameters.Strategy.Parallel.Workers}}
-K8s Version:      <determined after start>
+Strategy:           {{.Parameters.Strategy.Type}}
+Maintenance Window: {{.Parameters.Strategy.MaintenanceWindow}}
+Schedule After:     {{.Parameters.Strategy.Schedule}}
+Workers:            {{.Parameters.Strategy.Parallel.Workers}}
+K8s Version:        <determined after start>
 Targets:
 {{- range $i, $t := .Parameters.Targets.Include }}
   {{ orchestrationTarget $t }}
@@ -591,7 +594,7 @@ func orchestrationDetails(obj interface{}) string {
 func PromptUser(msg string) bool {
 	fmt.Printf("%s%s", "? ", msg)
 	for {
-		fmt.Print("Type (Y/N): ")
+		fmt.Print(" Type (Y/N): ")
 		var res string
 		if _, err := fmt.Scanf("%s", &res); err != nil {
 			return false

--- a/tools/cli/pkg/command/upgrade.go
+++ b/tools/cli/pkg/command/upgrade.go
@@ -48,7 +48,7 @@ func (cmd *UpgradeCommand) SetUpgradeOpts(cobraCmd *cobra.Command) {
 	cobraCmd.Flags().StringVar(&cmd.strategy, "strategy", string(orchestration.ParallelStrategy), "Orchestration strategy to use.")
 	cobraCmd.Flags().IntVar(&cmd.orchestrationParams.Strategy.Parallel.Workers, "parallel-workers", 1, "Number of parallel workers to use in parallel orchestration strategy. By default the amount of workers will be auto-selected on control plane server side.")
 	cobraCmd.Flags().BoolVarP(&cmd.maintenancewindow, "maintenancewindow", "", false, "Schedule the upgrade in the next possible maintenancewindow after 'schedule'. (default: false)")
-	cobraCmd.Flags().StringVar(&cmd.schedule, "schedule", "", "Orchestration schedule to use. Possible values: \"immediate\", \"now\" or a date (2006-01-01) . By default the schedule will be auto-selected on control plane server side.")
+	cobraCmd.Flags().StringVar(&cmd.schedule, "schedule", "now", "Orchestration schedule to use. Possible values: \"immediate\", \"now\" or a date (2006-01-01) . By default the schedule will be auto-selected on control plane server side.")
 	cobraCmd.Flags().BoolVar(&cmd.orchestrationParams.DryRun, "dry-run", false, "Perform the orchestration without executing the actual upgrade operations for the Runtimes. The details can be obtained using the \"kcp orchestrations\" command.")
 }
 
@@ -57,6 +57,10 @@ func (cmd *UpgradeCommand) ValidateTransformUpgradeOpts() error {
 	err := ValidateTransformRuntimeTargetOpts(cmd.targetInputs, cmd.targetExcludeInputs, &cmd.orchestrationParams.Targets)
 	if err != nil {
 		return err
+	}
+
+	if cmd.maintenancewindow {
+		cmd.orchestrationParams.Strategy.MaintenanceWindow = true
 	}
 
 	// Validate schedule


### PR DESCRIPTION
**Description**

KCP CLI doesn't currently propagate the `--maintenancewindow` option to KEB properly. This PR fixes it. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
