### PR TITLE
Revert "kcp-migration-broker and provisioner - change on helm hook annotations (#2330)"

### DIFF
--- a/resources/kcp/templates/migrator-job.yaml
+++ b/resources/kcp/templates/migrator-job.yaml
@@ -7,7 +7,7 @@ metadata:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": post-install,pre-upgrade
+        "helm.sh/hook": post-install,post-upgrade
         "helm.sh/hook-weight": "1"
         "helm.sh/hook-delete-policy": before-hook-creation
 spec:
@@ -120,7 +120,7 @@ metadata:
         app: {{ .Chart.Name }}
         release: {{ .Release.Name }}
     annotations:
-        "helm.sh/hook": post-install,pre-upgrade
+        "helm.sh/hook": post-install,post-upgrade
         "helm.sh/hook-weight": "2"
         "helm.sh/hook-delete-policy": before-hook-creation
 spec:


### PR DESCRIPTION

This reverts commit 2cce31ffd9e794f646514d92d941752c6770840a.

The change causes problems during update after pruning resources deployed after the pre-upgrade hook.


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
