### PR TITLE
kubeconfig-service: use SA TokenRequest API instead of secret bound token

### DIFF
--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 
 image:
   repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
-  tag: "PR-2335"
+  tag: "PR-2391"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
**Description**

In K8S 1.24, the default behavior of generating tokens for service accounts has changed:

> The LegacyServiceAccountTokenNoAutoGeneration feature gate is beta, and enabled by default. When enabled, Secret API objects containing service account tokens are no longer auto-generated for every ServiceAccount. Use the [TokenRequest](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) API to acquire service account tokens, or if a non-expiring token is required, create a Secret API object for the token controller to populate with a service account token by following this [guide](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets). (https://github.com/kubernetes/kubernetes/pull/108309, [@zshihang](https://github.com/zshihang))

To accommodate the breaking change in default behavior, kubeconfig-service shall now use TokenRequest API to request short-living token.
