### PR TITLE
For testing purposes always fail instance creation (EU Access story)

### DIFF
--- a/components/kyma-environment-broker/internal/broker/instance_create.go
+++ b/components/kyma-environment-broker/internal/broker/instance_create.go
@@ -230,6 +230,13 @@ func (b *ProvisionEndpoint) validateAndExtract(details domain.ProvisionDetails, 
 		return ersContext, parameters, fmt.Errorf("while extracting ers context: %w", err)
 	}
 
+	// temporarily reject all request for this subaccount ID to test one scenario in EU Access story
+	if ersContext.SubAccountID == "7363aece-1cc5-4797-b35b-4ef9d8e86a42" {
+		logger.Infof("request rejected - temporary behaviour for test purposes")
+		err = fmt.Errorf("request rejected - temporary behaviour for test purposes, see:https://github.tools.sap/kyma/backlog/issues/3420")
+		return ersContext, parameters, apiresponses.NewFailureResponse(err, http.StatusBadRequest, "provisioning")
+	}
+
 	parameters, err = b.extractInputParameters(details)
 	if err != nil {
 		return ersContext, parameters, fmt.Errorf("while extracting input parameters: %w", err)

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2410"
+      version: "PR-2402"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

We need to test how BTP presents the result of instance creation failure.

Changes proposed in this pull request:

- Every instance creation request with predefined subaccont ID fails with a distinctive message.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
