### PR TITLE
Fix scheme concurrent map write panic

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/main.go
+++ b/components/kyma-environment-broker/cmd/broker/main.go
@@ -199,6 +199,7 @@ func periodicProfile(logger lager.Logger, profiler ProfilerConfig) {
 }
 
 func main() {
+	apiextensionsv1.AddToScheme(scheme.Scheme)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -422,11 +423,8 @@ func k8sClientProvider(kcfg string) (client.Client, error) {
 		return nil, err
 	}
 
-	sch := scheme.Scheme
-	apiextensionsv1.AddToScheme(sch)
-
 	k8sCli, err := client.New(restCfg, client.Options{
-		Scheme: sch,
+		Scheme: scheme.Scheme,
 	})
 	return k8sCli, err
 }

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2399"
+      version: "PR-2410"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
KEB occasionally crashes with concurrent ma writes
```
fatal error: concurrent map writes
/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/cmd/broker/main.go:426 +0x65
/go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go:196 +0x194
```
The stacktrace points to `k8sClientProvider` function used in operations to get kube client. It is called during the processing of each operation, however, it uses global `Scheme` from the client-go package and tries to register `apiextensions` group each time. Processing two operations at the same time then risks concurrent map write because `Scheme` is implemented as a map of `GroupVersionKind` to `runtime.Object`.

This change registers `apiextension` in the global `Scheme` at the KEB startup just once and should prevent the crash from happening.

<details>
<summary>full log</summary>

```
...
{"deprovisioning":"manager","instanceID":"3D5CE9C3-74E9-4E37-BA9A-40CFB1E494D0","level":"info","msg":"kubeconfig length: 1952","operation":"6fefb8de-94a2-4300-bb96-0348a709356b","planID":"7d55d31d-35ae-4438-bf13-6ffdfa107d9f","stage":"BTPOperator_Cleanup","step":"BTPOperator_Cleanup","time":"2023-01-18T01:15:21Z"}
fatal error: concurrent map writes
fatal error: concurrent map writes

goroutine 430 [running]:
k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypeWithName(0xc000338000, {{0x1a05201, 0x14}, {0x19eabd4, 0x2}, {0x1680312, 0x18}}, {0x1ccda80?, 0xc0004a4780})
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/runtime/scheme.go:174 +0x2f7
k8s.io/apimachinery/pkg/runtime.(*Scheme).AddKnownTypes(0xc000338000, {{0x1a05201?, 0x0?}, {0x19eabd4?, 0x0?}}, {0xc001d85878?, 0x3, 0x0?})
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/runtime/scheme.go:148 +0x237
k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1.addKnownTypes(0x0?)
        /go/pkg/mod/k8s.io/apiextensions-apiserver@v0.24.1/pkg/apis/apiextensions/v1/register.go:48 +0xdf
k8s.io/apimachinery/pkg/runtime.(*SchemeBuilder).AddToScheme(0x7a0?, 0xc0010d1000?)
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/runtime/scheme_builder.go:29 +0x5b
main.k8sClientProvider({0xc0010d0800?, 0x1a0727b?})
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/cmd/broker/main.go:426 +0x65
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/deprovisioning.(*BTPOperatorCleanupStep).getKubeClient(_, {{{0xfbd39b6, 0x0, {{...}, {...}}, {{...}, {...}}, 0x0, 0x0}, {0x0}, ...}, ...}, ...)
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go:196 +0x194
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/deprovisioning.(*BTPOperatorCleanupStep).Run(_, {{{0xfbd39b6, 0x0, {{...}, {...}}, {{...}, {...}}, 0x0, 0x0}, {0x0}, ...}, ...}, ...)
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go:63 +0xfa
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*StagedManager).runStep(_, {_, _}, {{{0xfbd39b6, 0x0, {{...}, {...}}, {{...}, {...}}, 0x0, ...}, ...}, ...}, ...)
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/staged_manager.go:196 +0x168
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*StagedManager).Execute(0xc00084dc00, {0xc000abd9b0, 0x24})
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/staged_manager.go:140 +0x1125
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).worker.func1.1({0x1ce3470, 0xc00032f580}, 0xc000330220, 0xc00030cfc0, 0xc00031e2d0)
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:87 +0x1a5
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).worker.func1()
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:100 +0x4a
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0x30?)
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/util/wait/wait.go:155 +0x3e
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0x1?, {0x1cc7060, 0xc0008748a0}, 0x1, 0xc000976900)
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/util/wait/wait.go:156 +0xb6
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc00031e2d0?, 0x3b9aca00, 0x0, 0xc0?, 0x1cec620?)
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/util/wait/wait.go:133 +0x89
k8s.io/apimachinery/pkg/util/wait.Until(...)
        /go/pkg/mod/k8s.io/apimachinery@v0.24.1/pkg/util/wait/wait.go:90
github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).createWorker.func1()
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:64 +0x5c
created by github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process.(*Queue).createWorker
        /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/process/queue.go:63 +0x12a

goroutine 1 [IO wait, 6 minutes]:
internal/poll.runtime_pollWait(0x7fb308ffc2c8, 0x72)
        /usr/local/go/src/runtime/netpoll.go:305 +0x89
internal/poll.(*pollDesc).wait(0xc00043b800?, 0x6?, 0x0)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:84 +0x32
internal/poll.(*pollDesc).waitRead(...)
        /usr/local/go/src/internal/poll/fd_poll_runtime.go:89
internal/poll.(*FD).Accept(0xc00043b800)
        /usr/local/go/src/internal/poll/fd_unix.go:614 +0x234
net.(*netFD).accept(0xc00043b800)
        /usr/local/go/src/net/fd_unix.go:172 +0x35
net.(*TCPListener).accept(0xc0001abad0)
        /usr/local/go/src/net/tcpsock_posix.go:142 +0x28
net.(*TCPListener).Accept(0xc0001abad0)
        /usr/local/go/src/net/tcpsock.go:288 +0x3d
net/http.(*Server).Serve(0xc00026c3c0, {0x1cda7c0, 0xc0001abad0})
        /usr/local/go/src/net/http/server.go:3070 +0x385
net/http.(*Server).ListenAndServe(0xc00026c3c0)
        /usr/local/go/src/net/http/server.go:2999 +0x7d
...
```
</details>