### PR TITLE
Store failed steps during deprovisioning

### DIFF
--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -216,6 +216,7 @@ type Operation struct {
 	ClusterConfigurationDeleted bool      `json:"clusterConfigurationDeleted"`
 	Retries                     int       `json:"-"`
 	ReconcilerDeregistrationAt  time.Time `json:"reconcilerDeregistrationAt"`
+	FailedToFinishSteps         []string  `json:"failedToFinishSteps"`
 
 	// UPDATING
 	UpdatingParameters    UpdatingParametersDTO `json:"updating_parameters"`

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -216,7 +216,7 @@ type Operation struct {
 	ClusterConfigurationDeleted bool      `json:"clusterConfigurationDeleted"`
 	Retries                     int       `json:"-"`
 	ReconcilerDeregistrationAt  time.Time `json:"reconcilerDeregistrationAt"`
-	FailedToFinishSteps         []string  `json:"failedToFinishSteps"`
+	ExcutedButNotCompleted      []string  `json:"excutedButNotCompleted"`
 
 	// UPDATING
 	UpdatingParameters    UpdatingParametersDTO `json:"updating_parameters"`

--- a/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
@@ -45,7 +45,7 @@ func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger lo
 	operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
 	if err != nil {
 		logger.Warnf("unable to delete internal evaluation: %s", err.Error())
-		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, "error while deleting avs internal evaluation", 10*time.Second, 1*time.Minute, logger)
+		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs internal evaluation", 10*time.Second, 1*time.Minute, logger)
 	}
 
 	if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
@@ -55,7 +55,7 @@ func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger lo
 	operation, err = ars.delegator.DeleteAvsEvaluation(operation, logger, ars.externalEvalAssistant)
 	if err != nil {
 		logger.Warnf("unable to delete external evaluation: %s", err.Error())
-		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, "error while deleting avs external evaluation", 10*time.Second, 1*time.Minute, logger)
+		return ars.deProvisioningManager.RetryOperationWithoutFail(operation, ars.Name(), "error while deleting avs external evaluation", 10*time.Second, 1*time.Minute, logger)
 	}
 
 	newOperation, err := ars.operationsStorage.UpdateOperation(operation)

--- a/components/kyma-environment-broker/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/check_kyma_resource_deleted_step.go
@@ -48,12 +48,12 @@ func (step *CheckKymaResourceDeletedStep) Run(operation internal.Operation, logg
 
 	if err == nil {
 		logger.Infof("Kyma resource still exists: %s", err)
-		return step.operationManager.RetryOperationWithoutFail(operation, "Kyma resource still exists", 15*time.Second, 30*time.Minute, logger)
+		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "Kyma resource still exists", 15*time.Second, 30*time.Minute, logger)
 	}
 
 	if !errors.IsNotFound(err) {
 		logger.Errorf("unable to check Kyma resource existence: %s", err)
-		return step.operationManager.RetryOperationWithoutFail(operation, "unable to check Kyma resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger)
+		return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to check Kyma resource existence", backoffForK8SOperation, timeoutForK8sOperation, logger)
 	}
 
 	return operation, 0, nil

--- a/components/kyma-environment-broker/internal/process/deprovisioning/delete_kyma_resource_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/delete_kyma_resource_step.go
@@ -55,7 +55,7 @@ func (step *DeleteKymaResourceStep) Run(operation internal.Operation, logger log
 			logger.Info("no Kyma resource to delete - ignoring")
 		} else {
 			logger.Errorf("unable to delete the Kyma resource: %s", err)
-			return step.operationManager.RetryOperationWithoutFail(operation, "unable to delete the Kyma resource", backoffForK8SOperation, timeoutForK8sOperation, logger)
+			return step.operationManager.RetryOperationWithoutFail(operation, step.Name(), "unable to delete the Kyma resource", backoffForK8SOperation, timeoutForK8sOperation, logger)
 		}
 	}
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/ias_deregistration.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/ias_deregistration.go
@@ -41,7 +41,7 @@ func (s *IASDeregistrationStep) Run(operation internal.Operation, log logrus.Fie
 		if err != nil {
 			msg := fmt.Sprintf("cannot delete ServiceProvider %s", spb.ServiceProviderName())
 			log.Errorf("%s: %s", msg, err)
-			return s.operationManager.RetryOperationWithoutFail(operation, msg, 5*time.Second, 5*time.Minute, log)
+			return s.operationManager.RetryOperationWithoutFail(operation, s.Name(), msg, 5*time.Second, 5*time.Minute, log)
 		}
 	}
 

--- a/components/kyma-environment-broker/internal/process/operation_manager.go
+++ b/components/kyma-environment-broker/internal/process/operation_manager.go
@@ -78,7 +78,7 @@ func (om *OperationManager) RetryOperationWithoutFail(operation internal.Operati
 	op, repeat, err := om.UpdateOperation(operation, func(operation *internal.Operation) {
 		operation.State = domain.InProgress
 		operation.Description = description
-		operation.FailedToFinishSteps = append(operation.FailedToFinishSteps, stepName)
+		operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, stepName)
 	}, log)
 	if repeat != 0 {
 		return op, repeat, err

--- a/components/kyma-environment-broker/internal/process/operation_manager.go
+++ b/components/kyma-environment-broker/internal/process/operation_manager.go
@@ -68,14 +68,18 @@ func (om *OperationManager) RetryOperation(operation internal.Operation, errorMe
 }
 
 // RetryOperationWithoutFail checks if operation should be retried or updates the status to InProgress, but omits setting the operation to failed if maxTime is reached
-func (om *OperationManager) RetryOperationWithoutFail(operation internal.Operation, description string, retryInterval, maxTime time.Duration, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+func (om *OperationManager) RetryOperationWithoutFail(operation internal.Operation, stepName string, description string, retryInterval, maxTime time.Duration, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
 	log.Infof("Retry Operation was triggered with message: %s", description)
 	log.Infof("Retrying for %s in %s steps", maxTime.String(), retryInterval.String())
 	if time.Since(operation.UpdatedAt) < maxTime {
 		return operation, retryInterval, nil
 	}
 	// update description to track failed steps
-	op, repeat, err := om.update(operation, domain.InProgress, description, log)
+	op, repeat, err := om.UpdateOperation(operation, func(operation *internal.Operation) {
+		operation.State = domain.InProgress
+		operation.Description = description
+		operation.FailedToFinishSteps = append(operation.FailedToFinishSteps, stepName)
+	}, log)
 	if repeat != 0 {
 		return op, repeat, err
 	}

--- a/components/kyma-environment-broker/internal/process/steps/lifecycle_manager_kubeconfig.go
+++ b/components/kyma-environment-broker/internal/process/steps/lifecycle_manager_kubeconfig.go
@@ -64,7 +64,7 @@ func (s deleteKubeconfig) Run(o internal.Operation, log logrus.FieldLogger) (int
 	if err := s.k8sClient.Delete(context.Background(), secret); err != nil && !errors.IsNotFound(err) {
 		msg := fmt.Sprintf("failed to delete kubeconfig secret %v/%v for lifecycle manager: %v", secret.Namespace, secret.Name, err)
 		log.Error(msg)
-		return s.operationManager.RetryOperationWithoutFail(o, msg, time.Minute, time.Minute*5, log)
+		return s.operationManager.RetryOperationWithoutFail(o, s.Name(), msg, time.Minute, time.Minute*5, log)
 	}
 	return o, 0, nil
 }

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2402"
+      version: "PR-2412"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

If a step cannot finish his job and goes to the next one, the step needs to be marked. The idea is to store those steps

Changes proposed in this pull request:

- Store the step that was retried via `RetryOperationWithoutFail` without success in the DB

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
