### PR TITLE
KEB update machine type

### DIFF
--- a/components/kyma-environment-broker/internal/broker/instance_update.go
+++ b/components/kyma-environment-broker/internal/broker/instance_update.go
@@ -242,6 +242,9 @@ func (b *UpdateEndpoint) processUpdateParameters(instance *internal.Instance, de
 	if params.UpdateAutoScaler(&instance.Parameters.Parameters) {
 		updateStorage = append(updateStorage, "Auto Scaler parameters")
 	}
+	if params.MachineType != nil && *params.MachineType != "" {
+		instance.Parameters.Parameters.MachineType = params.MachineType
+	}
 	if len(updateStorage) > 0 {
 		if err := wait.Poll(500*time.Millisecond, 2*time.Second, func() (bool, error) {
 			instance, err = b.instanceStorage.Update(*instance)

--- a/components/kyma-environment-broker/internal/dto.go
+++ b/components/kyma-environment-broker/internal/dto.go
@@ -189,6 +189,7 @@ type UpdatingParametersDTO struct {
 
 	OIDC                  *OIDCConfigDTO `json:"oidc,omitempty"`
 	RuntimeAdministrators []string       `json:"administrators,omitempty"`
+	MachineType           *string        `json:"machineType,omitempty"`
 
 	// Expired - means that the trial SKR is marked as expired
 	Expired bool `json:"expired"`

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -544,6 +544,9 @@ func NewUpdateOperation(operationID string, instance *Instance, updatingParams U
 	}
 
 	updatingParams.UpdateAutoScaler(&op.ProvisioningParameters.Parameters)
+	if updatingParams.MachineType != nil && *updatingParams.MachineType != "" {
+		op.ProvisioningParameters.Parameters.MachineType = updatingParams.MachineType
+	}
 
 	return op
 }

--- a/components/kyma-environment-broker/internal/process/update/btp_operator_overrides.go
+++ b/components/kyma-environment-broker/internal/process/update/btp_operator_overrides.go
@@ -32,6 +32,10 @@ func (s *BTPOperatorOverridesStep) Name() string {
 }
 
 func (s *BTPOperatorOverridesStep) Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	if operation.LastRuntimeState.ClusterSetup == nil {
+		logger.Infof("no last runtime state found, skipping")
+		return operation, 0, nil
+	}
 	// get btp-operator component input and calculate overrides
 	ci, err := getComponentInput(s.components, BTPOperatorComponentName, operation.RuntimeVersion, operation.InputCreator.Configuration())
 	if err != nil {

--- a/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
+++ b/components/kyma-environment-broker/internal/process/update/upgrade_shoot_step.go
@@ -109,6 +109,7 @@ func (s *UpgradeShootStep) createUpgradeShootInput(operation internal.Operation)
 			AutoScalerMin:  operation.UpdatingParameters.AutoScalerMin,
 			MaxSurge:       operation.UpdatingParameters.MaxSurge,
 			MaxUnavailable: operation.UpdatingParameters.MaxUnavailable,
+			MachineType:    operation.UpdatingParameters.MachineType,
 		},
 		Administrators: fullInput.Administrators,
 	}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2429"
+      version: "PR-2447"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

- Allow MachineType update in KEB OSB API
- Sanitize BTP Operator overrides for KEB update operation

**Tested with following scenario:**
1) Provision instance in AWS larger than the default machine type - `m5.2xlarge` with put payload
```
$ kubectl get shoot f6f9e78 -o json | jq '.spec.provider.workers[].machine.type'
"m5.2xlarge"
```

2) Update machine type `m5.2xlarge` -> `m5.xlarge` with patch 1 payload

```
$ kubectl get shoot f6f9e78 -o json | jq '.spec.provider.workers[].machine.type'
"m5.xlarge"
```


3) Update machine type `m5.xlarge` -> `m5.large` with patch 2 payload

```
$ kubectl get shoot f6f9e78 -o json | jq '.spec.provider.workers[].machine.type'
"m5.large"
```

4) Update machine type `m5.large` -> `m5.2xlarge` with patch 3 payload

```
$ kubectl get shoot f6f9e78 -o json | jq '.spec.provider.workers[].machine.type'
"m5.2xlarge"
```

<details>
<summary>KEB put instance payload</summary>
     
```bash
instance=test-jw267

curl -XPUT "localhost:8080/oauth/v2/service_instances/$instance?accepts_incomplete=true" -i \
    -H "X-Broker-API-Version: 2.14" \
    -H "Content-Type: application/json" \
    --data-binary @- << EOF
{
   "service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281",
   "plan_id":"361c511f-f939-4621-b228-d0fb79a1fe15",
   "context":{
       "globalaccount_id":"e449f875-b5b2-4485-b7c0-98725c0571bf",
       "subaccount_id":"19ea2000-865d-42fd-8d6f-3e3e2dcce3c8",
       "user_id":"jan.wozniak@sap.com",
       "sm_operator_credentials": {
            "clientid": "$(jq --raw-output '.items[].credentials.clientid' ${creds})",
            "clientsecret": "$(jq --raw-output '.items[].credentials.clientsecret' ${creds})",
            "url": "$(jq --raw-output '.items[].credentials.url' ${creds})",
            "sm_url": "$(jq --raw-output '.items[].credentials.sm_url' ${creds})"
       },
       "url": "$url"
   },
   "parameters":{
       "name":"$instance",
       "machineType":"m5.2xlarge"
   }
}
EOF
```

</details>

<details>
<summary>KEB patch 1 instance payload</summary>
     
```bash
instance=test-jw267

curl -XPATCH "localhost:8080/oauth/v2/service_instances/$instance?accepts_incomplete=true" -i \
    -H "X-Broker-API-Version: 2.14" \
    -H "Content-Type: application/json" \
    --data-binary @- << EOF
{
   "service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281",
   "context":{
       "globalaccount_id":"e449f875-b5b2-4485-b7c0-98725c0571bf"
   },
   "parameters":{
       "machineType":"m5.xlarge"
   }
}
EOF
```

</details>

<details>
<summary>KEB patch 2 instance payload</summary>
     
```bash
instance=test-jw267

curl -XPATCH "localhost:8080/oauth/v2/service_instances/$instance?accepts_incomplete=true" -i \
    -H "X-Broker-API-Version: 2.14" \
    -H "Content-Type: application/json" \
    --data-binary @- << EOF
{
   "service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281",
   "context":{
       "globalaccount_id":"e449f875-b5b2-4485-b7c0-98725c0571bf"
   },
   "parameters":{
       "machineType":"m5.large"
   }
}
EOF
```

</details>

<details>
<summary>KEB patch 3 instance payload</summary>
     
```bash
instance=test-jw267

curl -XPATCH "localhost:8080/oauth/v2/service_instances/$instance?accepts_incomplete=true" -i \
    -H "X-Broker-API-Version: 2.14" \
    -H "Content-Type: application/json" \
    --data-binary @- << EOF
{
   "service_id":"47c9dcbf-ff30-448e-ab36-d3bad66ba281",
   "context":{
       "globalaccount_id":"e449f875-b5b2-4485-b7c0-98725c0571bf"
   },
   "parameters":{
       "machineType":"m5.2xlarge"
   }
}
EOF
```

</details>


</details>

<details>
<summary>kcp operations and events</summary>

```
$ kcp rt -i test-jw267 --events
GLOBALACCOUNT ID                       SUBACCOUNT ID                          SHOOT     REGION         PLAN   CREATED AT            STATE       EU ACCESS   KYMA VERSION
e449f875-b5b2-4485-b7c0-98725c0571bf   19ea2000-865d-42fd-8d6f-3e3e2dcce3c8   f6f9e78   eu-central-1   aws    2023/02/01 08:22:54   succeeded   No          2.10.1
 ˫provision operation de44e24c-e917-4f81-ba96-360916cb52de: succeeded
  ˫info   76m                         processing step: Starting
  ˫info   76m                         processing step: Provision_Initialization
  ˫info   76m                         processing step: Init_Kyma_Template
  ˫info   76m                         processing step: Resolve_Target_Secret
  ˫info   76m                         processing step: AVS_Create_Internal_Eval_Step
  ˫info   76m                         processing step: EDP_Registration
  ˫info   76m                         processing step: Overrides_From_Secrets_And_Config_Step
  ˫info   76m                         processing step: BTPOperatorOverrides
  ˫info   76m                         processing step: Create_Runtime_Without_Kyma
  ˫info   76m                         processing step: Check_Runtime
  ˫info   70m ago (4x in last 76m)    step Check_Runtime sleeping for 2m0s
  ˫info   68m                         processing step: Get_Kubeconfig
  ˫info   68m                         processing step: Inject_BTP_Operator_Credentials
  ˫info   68m                         processing step: Sync_Kubeconfig
  ˫info   68m                         processing step: Create_Cluster_Configuration
  ˫info   68m                         processing step: Check_Cluster_Configuration
  ˫info   64m ago (10x in last 68m)   step Check_Cluster_Configuration sleeping for 30s
  ˫info   63m                         processing step: Apply_Kyma
  ˫info   63m                         processing step: AVS_Create_External_Eval_Step
  ˫info   63m                         processing step: AVS_Tags
 ˫unknown operation 46605d1d-e9ee-40d8-b165-d7a7957d185c
  ˫info   62m                         processing step: Update_Kyma_Initialisation
  ˫info   62m                         processing step: Upgrade_Shoot
  ˫info   62m                         processing step: Update_Init_Kyma_Version
  ˫info   62m                         processing step: Get_Kubeconfig
  ˫info   62m                         processing step: BTPOperatorOverrides
  ˫info   62m                         processing step: Check_Runtime
  ˫info   58m ago (5x in last 62m)    step Check_Runtime sleeping for 1m0s
 ˫update operation b922c8ad-ff5f-40f7-87c1-e1985824fa11: succeeded
  ˫info   48m                         processing step: Update_Kyma_Initialisation
  ˫info   48m                         processing step: Upgrade_Shoot
  ˫info   48m                         processing step: Update_Init_Kyma_Version
  ˫info   48m                         processing step: Get_Kubeconfig
  ˫info   48m                         processing step: BTPOperatorOverrides
  ˫info   48m                         processing step: Check_Runtime
  ˫info   40m ago (9x in last 48m)    step Check_Runtime sleeping for 1m0s
 ˫update operation 8a3ff5ea-8cc3-4a31-ba22-cd59f97f73f9: succeeded
  ˫info   30m                         processing step: Update_Kyma_Initialisation
  ˫info   30m                         processing step: Upgrade_Shoot
  ˫info   30m                         processing step: Update_Init_Kyma_Version
  ˫info   30m                         processing step: Get_Kubeconfig
  ˫info   30m                         processing step: BTPOperatorOverrides
  ˫info   30m                         processing step: Check_Runtime
  ˪info   23m ago (8x in last 30m)    step Check_Runtime sleeping for 1m0s
```

</details>

**Related issue(s)**
see also: https://github.com/kyma-project/control-plane/issues/2446
changes to OSB catalog will follow up in separate PR