### PR TITLE
KEB to set operation description on success

### DIFF
--- a/components/kyma-environment-broker/internal/process/staged_manager.go
+++ b/components/kyma-environment-broker/internal/process/staged_manager.go
@@ -164,6 +164,7 @@ func (m *StagedManager) Execute(operationID string) (time.Duration, error) {
 	logOperation.Infof("Operation succeeded")
 
 	processedOperation.State = domain.Succeeded
+	processedOperation.Description = "Processing finished"
 	m.publisher.Publish(context.TODO(), OperationSucceeded{
 		Operation: processedOperation,
 	})

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2471"
+      version: "PR-2474"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

When operation processing is finished, KEB `staged_manager` sets the operation state but keeps the description. Example for status after successful deprovisioning operation:

```
$ curl -XGET "${KEB}/oauth/v2/service_instances/${INSTANCE}/last_operation" -H "X-Broker-API-Version: 2.14"
{"state":"succeeded","description":"Operation created"}
```

This change sets the description for successfully processed operations.
```
$ curl -XGET "${KEB}/oauth/v2/service_instances/${INSTANCE}/last_operation" -H "X-Broker-API-Version: 2.14"
{"state":"succeeded","description":"Processing finished"}
```