### PR TITLE
Generic Dockerfile for KEB jobs

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.job
+++ b/components/kyma-environment-broker/Dockerfile.job
@@ -1,0 +1,25 @@
+# Build image
+FROM golang:1.20.0-alpine3.16 AS build
+
+WORKDIR /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker
+
+COPY cmd cmd
+COPY common common
+COPY internal internal
+COPY go.mod go.mod
+COPY go.sum go.sum
+
+ARG BIN
+RUN CGO_ENABLED=0 go build -o /bin/${BIN} ./cmd/${BIN}/main.go
+
+# Get latest CA certs
+FROM alpine:latest as certs
+RUN apk --update add ca-certificates
+
+# Final image
+FROM scratch
+LABEL source = git@github.com:kyma-project/control-plane.git
+
+ARG BIN
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=build /bin/${BIN} /bin/${BIN}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Currently, there are 5 copy-paste Dockerfiles for various KEB `Jobs`. These all have similar content, only difference is the binary name and source path to respective `main.go` and container images are built by [test-infra kaniko build jobs](https://github.com/kyma-project/test-infra/blob/586a1f5/templates/data/control-plane-build.yaml).

* [`Dockerfile.cleanup`](https://github.com/kyma-project/control-plane/blob/6d611bf/components/kyma-environment-broker/Dockerfile.cleanup) - [test-infra](https://github.com/kyma-project/test-infra/blob/586a1f5a94de7e4bb96463aaf8d5abb75cc9b471/templates/data/control-plane-build.yaml#L164)
* [`Dockerfile.drj`](https://github.com/kyma-project/control-plane/blob/fd6fb1c/components/kyma-environment-broker/Dockerfile.drj) - [test-infra](https://github.com/kyma-project/test-infra/blob/586a1f5a94de7e4bb96463aaf8d5abb75cc9b471/templates/data/control-plane-build.yaml#L268)
* [`Dockerfile.sac`](https://github.com/kyma-project/control-plane/blob/6d611bf/components/kyma-environment-broker/Dockerfile.sac) - [test-infra](https://github.com/kyma-project/test-infra/blob/586a1f5a94de7e4bb96463aaf8d5abb75cc9b471/templates/data/control-plane-build.yaml#L190)
* [`Dockerfile.scj`](https://github.com/kyma-project/control-plane/blob/6d611bf/components/kyma-environment-broker/Dockerfile.cleanup) - [test-infra](https://github.com/kyma-project/test-infra/blob/586a1f5a94de7e4bb96463aaf8d5abb75cc9b471/templates/data/control-plane-build.yaml#L216)
* [`Dockerfile.tcj`](https://github.com/kyma-project/control-plane/blob/6d611bf/components/kyma-environment-broker/Dockerfile.cleanup) - [test-infra](https://github.com/kyma-project/test-infra/blob/586a1f5a94de7e4bb96463aaf8d5abb75cc9b471/templates/data/control-plane-build.yaml#L256)

This PR proposes introducing a new, generic Dockerfile, configurable via `ARG` build argument `BIN`. The test-infra build jobs can be then changed and copy-paste Dockerfiles later deleted.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
