### PR TITLE
KEB set and read instance deleted_at field

### DIFF
--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -55,6 +55,7 @@ type RuntimeStatus struct {
 	CreatedAt        time.Time       `json:"createdAt"`
 	ModifiedAt       time.Time       `json:"modifiedAt"`
 	ExpiredAt        *time.Time      `json:"expiredAt,omitempty"`
+	DeletedAt        *time.Time      `json:"deletedAt,omitempty"`
 	State            State           `json:"state"`
 	Provisioning     *Operation      `json:"provisioning,omitempty"`
 	Deprovisioning   *Operation      `json:"deprovisioning,omitempty"`

--- a/components/kyma-environment-broker/internal/runtime/converter.go
+++ b/components/kyma-environment-broker/internal/runtime/converter.go
@@ -86,6 +86,9 @@ func (c *converter) NewDTO(instance internal.Instance) (pkg.RuntimeDTO, error) {
 			ExpiredAt:  instance.ExpiredAt,
 		},
 	}
+	if !instance.DeletedAt.IsZero() {
+		toReturn.Status.DeletedAt = &instance.DeletedAt
+	}
 
 	c.setRegionOrDefault(instance, &toReturn)
 

--- a/components/kyma-environment-broker/internal/storage/postsql/write.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/write.go
@@ -79,6 +79,7 @@ func (ws writeSession) UpdateInstance(instance dbmodel.InstanceDTO) dberr.Error 
 		Set("provider_region", instance.ProviderRegion).
 		Set("provider", instance.Provider).
 		Set("updated_at", time.Now()).
+		Set("deleted_at", instance.DeletedAt).
 		Set("version", instance.Version+1).
 		Set("expired_at", instance.ExpiredAt).
 		Exec()

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2493"
+      version: "PR-2499"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Followup to https://github.com/kyma-project/control-plane/pull/2429, the `deleted_at` never got to the database because it was not set.

see also: https://github.com/kyma-project/control-plane/issues/2406#issuecomment-1437230078