### PR TITLE
KEB cleanup btp-operator resources on instance force delete

### DIFF
--- a/components/kyma-environment-broker/cmd/deprovisionretrigger/main.go
+++ b/components/kyma-environment-broker/cmd/deprovisionretrigger/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 type BrokerClient interface {
-	Deprovision(instance internal.Instance) (string, error)
+	Deprovision(instance internal.Instance, force bool) (string, error)
 }
 
 type Config struct {
@@ -113,7 +113,7 @@ func (s *DeprovisionRetriggerService) retriggerDeprovisioningForInstances(instan
 
 func (s *DeprovisionRetriggerService) deprovisionInstance(instance internal.Instance) (err error) {
 	log.Infof("About to deprovision instance for instanceId: %+v", instance.InstanceID)
-	operationId, err := s.brokerClient.Deprovision(instance)
+	operationId, err := s.brokerClient.Deprovision(instance, false)
 	if err != nil {
 		log.Error(fmt.Sprintf("while sending deprovision request for instance ID %s: %s", instance.InstanceID, err))
 		return err

--- a/components/kyma-environment-broker/internal/broker/client.go
+++ b/components/kyma-environment-broker/internal/broker/client.go
@@ -93,8 +93,8 @@ func NewClientWithPoller(ctx context.Context, config ClientConfig, poller Poller
 }
 
 // Deprovision requests Runtime deprovisioning in KEB with given details
-func (c *Client) Deprovision(instance internal.Instance) (string, error) {
-	deprovisionURL, err := c.formatDeprovisionUrl(instance)
+func (c *Client) Deprovision(instance internal.Instance, force bool) (string, error) {
+	deprovisionURL, err := c.formatDeprovisionUrl(instance, force)
 	if err != nil {
 		return "", err
 	}
@@ -221,12 +221,16 @@ func preparePayload(instance internal.Instance) ([]byte, error) {
 	return jsonPayload, err
 }
 
-func (c *Client) formatDeprovisionUrl(instance internal.Instance) (string, error) {
+func (c *Client) formatDeprovisionUrl(instance internal.Instance, force bool) (string, error) {
 	if len(instance.ServicePlanID) == 0 {
 		return "", fmt.Errorf("empty ServicePlanID")
 	}
 
-	return fmt.Sprintf(deprovisionTmpl, c.brokerConfig.URL, instancesURL, instance.InstanceID, kymaClassID, instance.ServicePlanID), nil
+	url := fmt.Sprintf(deprovisionTmpl, c.brokerConfig.URL, instancesURL, instance.InstanceID, kymaClassID, instance.ServicePlanID)
+	if force {
+		url = url + "&force=true"
+	}
+	return url, nil
 }
 
 func (c *Client) executeRequestWithPoll(method, url string, expectedStatus int, body io.Reader, responseBody interface{}) error {

--- a/components/kyma-environment-broker/internal/broker/client_test.go
+++ b/components/kyma-environment-broker/internal/broker/client_test.go
@@ -39,7 +39,7 @@ func TestClient_Deprovision(t *testing.T) {
 		}
 
 		// when
-		opID, err := client.Deprovision(instance)
+		opID, err := client.Deprovision(instance, false)
 
 		// then
 		assert.NoError(t, err)
@@ -64,7 +64,7 @@ func TestClient_Deprovision(t *testing.T) {
 		}
 
 		// when
-		opID, err := client.Deprovision(instance)
+		opID, err := client.Deprovision(instance, false)
 
 		// then
 		assert.Error(t, err)

--- a/components/kyma-environment-broker/internal/broker/instance_deprovision.go
+++ b/components/kyma-environment-broker/internal/broker/instance_deprovision.go
@@ -92,6 +92,9 @@ func (b *DeprovisionEndpoint) Deprovision(ctx context.Context, instanceID string
 		logger.Errorf("cannot create new operation: %s", err)
 		return domain.DeprovisionServiceSpec{}, fmt.Errorf("cannot create new operation")
 	}
+	if details.Force {
+		operation.ForceDelete = true
+	}
 	err = b.operationsStorage.InsertDeprovisioningOperation(operation)
 	if err != nil {
 		logger.Errorf("cannot save operation: %s", err)

--- a/components/kyma-environment-broker/internal/cis/account_cleanup.go
+++ b/components/kyma-environment-broker/internal/cis/account_cleanup.go
@@ -16,7 +16,7 @@ type CisClient interface {
 
 //go:generate mockery --name=BrokerClient --output=automock
 type BrokerClient interface {
-	Deprovision(instance internal.Instance) (string, error)
+	Deprovision(instance internal.Instance, force bool) (string, error)
 }
 
 type SubAccountCleanupService struct {
@@ -77,7 +77,7 @@ func (ac *SubAccountCleanupService) executeDeprovisioning(subaccounts []string, 
 	}
 
 	for _, instance := range instances {
-		operation, err := ac.brokerClient.Deprovision(instance)
+		operation, err := ac.brokerClient.Deprovision(instance, true)
 		if err != nil {
 			errCh <- fmt.Errorf("error occurred during deprovisioning instance with ID %s: %w", instance.InstanceID, err)
 			continue

--- a/components/kyma-environment-broker/internal/cis/automock/BrokerClient.go
+++ b/components/kyma-environment-broker/internal/cis/automock/BrokerClient.go
@@ -13,7 +13,7 @@ type BrokerClient struct {
 }
 
 // Deprovision provides a mock function with given fields: instance
-func (_m *BrokerClient) Deprovision(instance internal.Instance) (string, error) {
+func (_m *BrokerClient) Deprovision(instance internal.Instance, force bool) (string, error) {
 	ret := _m.Called(instance)
 
 	var r0 string

--- a/components/kyma-environment-broker/internal/environmentscleanup/automock/BrokerClient.go
+++ b/components/kyma-environment-broker/internal/environmentscleanup/automock/BrokerClient.go
@@ -13,7 +13,7 @@ type BrokerClient struct {
 }
 
 // Deprovision provides a mock function with given fields: instance
-func (_m *BrokerClient) Deprovision(instance internal.Instance) (string, error) {
+func (_m *BrokerClient) Deprovision(instance internal.Instance, force bool) (string, error) {
 	ret := _m.Called(instance)
 
 	var r0 string

--- a/components/kyma-environment-broker/internal/environmentscleanup/service.go
+++ b/components/kyma-environment-broker/internal/environmentscleanup/service.go
@@ -29,7 +29,7 @@ type GardenerClient interface {
 
 //go:generate mockery --name=BrokerClient --output=automock
 type BrokerClient interface {
-	Deprovision(instance internal.Instance) (string, error)
+	Deprovision(instance internal.Instance, force bool) (string, error)
 }
 
 //go:generate mockery --name=ProvisionerClient --output=automock
@@ -232,7 +232,7 @@ func (s *Service) triggerRuntimeDeprovisioning(runtime runtime) error {
 }
 
 func (s *Service) triggerEnvironmentDeprovisioning(instance internal.Instance) error {
-	opID, err := s.brokerService.Deprovision(instance)
+	opID, err := s.brokerService.Deprovision(instance, false)
 	if err != nil {
 		err = fmt.Errorf("while triggering deprovisioning for instance ID %q: %w", instance.InstanceID, err)
 		s.logger.Error(err)

--- a/components/kyma-environment-broker/internal/model.go
+++ b/components/kyma-environment-broker/internal/model.go
@@ -219,6 +219,7 @@ type Operation struct {
 	Retries                     int       `json:"-"`
 	ReconcilerDeregistrationAt  time.Time `json:"reconcilerDeregistrationAt"`
 	ExcutedButNotCompleted      []string  `json:"excutedButNotCompleted"`
+	ForceDelete                 bool      `json:"forceDelete,omitempty"`
 
 	// UPDATING
 	UpdatingParameters    UpdatingParametersDTO `json:"updating_parameters"`

--- a/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/btp_operator_cleanup.go
@@ -46,7 +46,51 @@ func (s *BTPOperatorCleanupStep) Name() string {
 	return "BTPOperator_Cleanup"
 }
 
+func (s *BTPOperatorCleanupStep) force(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	k8sClient, err := s.getKubeClient(operation, log)
+	if err != nil || k8sClient == nil {
+		return s.retryOnError(operation, err, log, "failed to get kube client")
+	}
+	namespaces := corev1.NamespaceList{}
+	if err := k8sClient.List(context.Background(), &namespaces); err != nil {
+		return s.retryOnError(operation, err, log, "failed to list namespaces")
+	}
+	gvk := schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorBinding}
+	var errors []string
+	for _, ns := range namespaces.Items {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		if err := k8sClient.DeleteAllOf(context.Background(), obj, client.InNamespace(ns.Name)); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if err := s.removeFinalizers(k8sClient, namespaces, gvk); err != nil {
+		errors = append(errors, err.Error())
+	}
+
+	gvk.Kind = btpOperatorServiceInstance
+	for _, ns := range namespaces.Items {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(gvk)
+		if err := k8sClient.DeleteAllOf(context.Background(), obj, client.InNamespace(ns.Name)); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if err := s.removeFinalizers(k8sClient, namespaces, gvk); err != nil {
+		errors = append(errors, err.Error())
+	}
+
+	if len(errors) != 0 {
+		return s.retryOnError(operation, fmt.Errorf(strings.Join(errors, ";")), log, "failed to cleanup")
+	}
+	return operation, 0, nil
+}
+
 func (s *BTPOperatorCleanupStep) Run(operation internal.Operation, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	if operation.ForceDelete {
+		log.Info("executing force delete cleanup")
+		return s.force(operation, log)
+	}
 	if !operation.Temporary {
 		log.Info("cleanup executed only for suspensions")
 		return operation, 0, nil
@@ -88,22 +132,27 @@ func (s *BTPOperatorCleanupStep) deleteServiceBindingsAndInstances(k8sClient cli
 	return nil
 }
 
-func (s *BTPOperatorCleanupStep) removeFinalizers(k8sClient client.Client, namespaces corev1.NamespaceList, gvk schema.GroupVersionKind, log logrus.FieldLogger) {
+func (s *BTPOperatorCleanupStep) removeFinalizers(k8sClient client.Client, namespaces corev1.NamespaceList, gvk schema.GroupVersionKind) error {
 	listGvk := gvk
 	listGvk.Kind = gvk.Kind + "List"
+	var errors []string
 	for _, ns := range namespaces.Items {
 		list := &unstructured.UnstructuredList{}
 		list.SetGroupVersionKind(listGvk)
 		if err := k8sClient.List(context.Background(), list, client.InNamespace(ns.Name)); err != nil {
-			log.Errorf("failed listing resource %v in namespace %v", gvk, ns.Name)
+			errors = append(errors, fmt.Sprintf("failed listing resource %v in namespace %v: %v", gvk, ns.Name, err))
 		}
 		for _, r := range list.Items {
 			r.SetFinalizers([]string{})
 			if err := k8sClient.Update(context.Background(), &r); err != nil {
-				log.Errorf("failed remove finalizer for resource %v: %v/%v", gvk, r.GetNamespace(), r.GetName())
+				errors = append(errors, fmt.Sprintf("failed remove finalizer for resource %v %v/%v: %v", gvk, r.GetNamespace(), r.GetName(), err))
 			}
 		}
 	}
+	if len(errors) != 0 {
+		return fmt.Errorf("failed to remove finalizers: %v", strings.Join(errors, ";"))
+	}
+	return nil
 }
 
 func (s *BTPOperatorCleanupStep) deleteResource(k8sClient client.Client, namespaces corev1.NamespaceList, gvk schema.GroupVersionKind, log logrus.FieldLogger) (requeue bool) {
@@ -172,8 +221,12 @@ func (s *BTPOperatorCleanupStep) attemptToRemoveFinalizers(op internal.Operation
 		log.Errorf("failed to list namespaces to remove finalizers", err)
 		return
 	}
-	s.removeFinalizers(k8sClient, namespaces, schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorBinding}, log)
-	s.removeFinalizers(k8sClient, namespaces, schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorServiceInstance}, log)
+	if err := s.removeFinalizers(k8sClient, namespaces, schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorBinding}); err != nil {
+		log.Errorf("failed to remove finalizers for bindings: %v", err)
+	}
+	if err := s.removeFinalizers(k8sClient, namespaces, schema.GroupVersionKind{Group: btpOperatorGroup, Version: btpOperatorApiVer, Kind: btpOperatorServiceInstance}); err != nil {
+		log.Errorf("failed to remove finalizers for instances: %v", err)
+	}
 }
 
 func (s *BTPOperatorCleanupStep) getKubeClient(operation internal.Operation, log logrus.FieldLogger) (client.Client, error) {

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2513"
+      version: "PR-2514"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Instances and bindings from btp-operator can be problematic for subaccount cleanup causing extended delays and many false errors during the deprovisioning. This PR introduces usage of OSB API `force` parameter for instance `DELETE` endpoint call which is propagated to the deprovisioning operation and picked up by BTP Operator cleanup step ensuring resources are deleted and finalizers from them removed. The external resources are going to be removed by other SAP service providers because this is triggered only when the whole subaccount is triggered for deletion.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
see: https://github.com/kyma-project/control-plane/issues/2512