### PR TITLE
Fix deprovision of avs evaluations for trial/freemium plan

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
@@ -43,7 +43,7 @@ func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger lo
 			return operation, 0, nil
 		}
 		if broker.IsTrialPlan(operation.ProvisioningParameters.PlanID) || broker.IsFreemiumPlan(operation.ProvisioningParameters.PlanID) {
-			logger.Infof("internal evaluation have been deleted, skipping external evaluation deletion for trial/freemium plan")
+			logger.Infof("Internal evaluation have been deleted, skipping external evaluation deletion for trial/freemium plan")
 			return operation, 0, nil
 		}
 	}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2513"
+      version: "PR-2519"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2363"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

If the `De-provision_AVS_Evaluations` step was run again for the trial/freemium plan, even if the internal evaluation was removed successfully in the previous run, the step was not skipped.

Changes proposed in this pull request:

- skip `De-provision_AVS_Evaluations` if internal evaluation have been deleted for trial/freemium plan

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
See also #2518 