### PR TITLE
Remove duplicate 'command' for trial cleanup job

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/trial-cleanup-job.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/trial-cleanup-job.yaml
@@ -23,8 +23,6 @@ spec:
           containers:
             - image: "{{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.kyma_environment_trial_cleanup_job.dir }}kyma-environment-trial-cleanup-job:{{ .Values.global.images.kyma_environment_trial_cleanup_job.version }}"
               name: trial-cleanup-job
-              command:
-                - /bin/trialcleanup
               env:
                 {{if eq .Values.global.database.embedded.enabled true}}
                 - name: DATABASE_EMBEDDED

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -11,7 +11,7 @@ global:
       version: "PR-2477"
     kyma_environment_trial_cleanup_job:
       dir:
-      version: "PR-2477"
+      version: "PR-2530"
     kyma_environment_deprovision_retrigger_job:
       dir:
       version: "PR-2477"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

https://github.com/kyma-project/control-plane/pull/2477 accidentally duplicated `command` for trial cleanup job.
```
...
147 2023-02-28T09:40:05.1854481Z /github/home/generated.yaml - CronJob trial-cleanup-job failed validation: error unmarshalling resource: error converting YAML to JSON: yaml: un     marshal errors:
148 2023-02-28T09:40:05.1854620Z   line 92: key "command" already set in map
...
```