### PR TITLE
Increase Buffer max size to 5MB for long lines

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/templates/mr-fluentbit-cm.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/mr-fluentbit-cm.yaml
@@ -40,6 +40,8 @@ data:
         Mem_Buf_Limit     5MB
         exit_on_eof       false
         Key               log
+        Buffer_Max_Size   1MB
+        Skip_Long_Lines   off
 
     [FILTER]
         Name         parser


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Default buffer size is 32k Increase it to 1Mb to accomodate long log lines
- skip_log_lines is off by default but make it explicit.
**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
