### PR TITLE
Fix 'kcp rt status -c shoot' returning random runtime status

### DIFF
--- a/tools/cli/pkg/command/reconciliations_state.go
+++ b/tools/cli/pkg/command/reconciliations_state.go
@@ -96,7 +96,8 @@ func (cmd *RuntimeStateCommand) Run() error {
 	if cmd.opts.shootName != "" {
 		kebURL := GlobalOpts.KEBAPIURL()
 		kebClient := cmd.provideKebClient(kebURL, httpClient)
-		runtimeID, err := getRuntimeID(kebClient, cmd.opts.shootName)
+		var err error
+		runtimeID, err = getRuntimeID(kebClient, cmd.opts.shootName)
 		if err != nil {
 			return errors.Wrap(err, "while listing runtimes")
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->
reported internally by @zralt 
> Using `kcp rc state` command seems to be heavily flawed, when I use it with `-c shoot_id`  it returns a random entry (not every time, but it's pretty frequent).
It also seems to be working fine with the "-r runtime" flag.

> Now I wonder that this is related to using the shoot flag, and in that case maybe some clusters got their reconciliation disabled while I was trying to disable the cluster `f34cd39`. Seemingly it never picked this cluster.

> To reproduce:
For ex. on the prod environment, issue this a few times:
```
kcp rc state -c f34cd39 -ojson
```

This fixes the `runtimeID` variable shadowed in code resulting in it always being an empty string `""`.


Before fix:
```
$ kcp rt -c c-247e667 -o json | jq '.data[].runtimeID'
"3ee099f0-6105-4dc4-a6a7-f7a657063644"

$ kcp rc state -c c-247e667
RUNTIME ID                             KYMA VERSION   KYMA PROFILE   STATUS   DELETED   CREATED AT
0bb83f1b-cf4c-4048-8d9c-4ee6def3e8aa   2.10.1         Production     ready    false     2023/03/02 08:23:46
```

After fix:
```
$ ./kcp-linux rc state -c c-247e667
RUNTIME ID                             KYMA VERSION   KYMA PROFILE   STATUS   DELETED   CREATED AT
3ee099f0-6105-4dc4-a6a7-f7a657063644   2.10.1         Production     ready    false     2023/03/02 08:38:01
```