### PR TITLE
Fix Kyma deprovisioning test

### DIFF
--- a/components/kyma-environment-broker/cmd/broker/deprovisioning_suite_test.go
+++ b/components/kyma-environment-broker/cmd/broker/deprovisioning_suite_test.go
@@ -116,6 +116,7 @@ func (s *DeprovisioningSuite) CreateProvisionedRuntime(options RuntimeOptions) s
 	instance.ProviderRegion = *options.ProvideRegion()
 
 	provisioningOperation := fixture.FixProvisioningOperation(operationID, randomInstanceId)
+	provisioningOperation.SubAccountID = options.ProvideSubAccountID()
 
 	require.NoError(s.t, s.storage.Instances().Insert(instance))
 	require.NoError(s.t, s.storage.Operations().InsertOperation(provisioningOperation))
@@ -229,6 +230,7 @@ func fixEDPClient() *edp.FakeClient {
 		edp.MaasConsumerEnvironmentKey,
 		edp.MaasConsumerRegionKey,
 		edp.MaasConsumerSubAccountKey,
+		edp.MaasConsumerServicePlan,
 	}
 
 	for _, key := range metadataTenantKeys {

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2546"
+      version: "PR-2555"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2540"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

`TestKymaDeprovision` logged an error in the `EDP_Deregistration` step during deprovisioning, and it shouldn't have. This was due to different SubAccountID in the instance and the provisioning operation. In addition, the mocked EDPClient was also missing the `MaasConsumerServicePlan`.

Changes proposed in this pull request:

- Fix the SubAccountID mismatch
- Add `MaasConsumerServicePlan` to the mocked EDPClient

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
