### PR TITLE
KEB /runtime endpoint deprovision incomplete filter

### DIFF
--- a/components/kyma-environment-broker/common/runtime/client.go
+++ b/components/kyma-environment-broker/common/runtime/client.go
@@ -112,9 +112,6 @@ func setQuery(url *url.URL, params ListParameters) {
 	if params.Expired {
 		query.Add(ExpiredParam, "true")
 	}
-	if params.OnlyDeleted {
-		query.Add(OnlyDeletedParam, "true")
-	}
 	setParamList(query, GlobalAccountIDParam, params.GlobalAccountIDs)
 	setParamList(query, SubAccountIDParam, params.SubAccountIDs)
 	setParamList(query, InstanceIDParam, params.InstanceIDs)

--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -19,6 +19,9 @@ const (
 	StateProvisioning State = "provisioning"
 	// StateDeprovisioning means that the runtime deprovisioning (or suspension) is in progress (by the last runtime operation).
 	StateDeprovisioning State = "deprovisioning"
+	// StateDeprovisioned means that the runtime deprovisioning has finished removing the instance.
+	// In case the instance has already been deleted, KEB will try best effort to reconstruct at least partial information regarding deprovisioned instances from residual operations.
+	StateDeprovisioned State = "deprovisioned"
 	// StateUpgrading means that kyma upgrade or cluster upgrade operation is in progress.
 	StateUpgrading State = "upgrading"
 	// StateUpdating means the runtime configuration is being updated (i.e. OIDC is reconfigured).
@@ -116,7 +119,6 @@ const (
 	KymaConfigParam      = "kyma_config"
 	ClusterConfigParam   = "cluster_config"
 	ExpiredParam         = "expired"
-	OnlyDeletedParam     = "only_deleted"
 )
 
 type OperationDetail string
@@ -157,8 +159,6 @@ type ListParameters struct {
 	Expired bool
 	// Events parameter fetches tracing events per instance
 	Events string
-	// OnlyDeleted parameter instructs KEB to try best effort to reconstruct at least partial information regarding deprovisioned instances from residual operations
-	OnlyDeleted bool
 }
 
 func (rt RuntimeDTO) LastOperation() Operation {

--- a/components/kyma-environment-broker/common/runtime/model.go
+++ b/components/kyma-environment-broker/common/runtime/model.go
@@ -22,6 +22,8 @@ const (
 	// StateDeprovisioned means that the runtime deprovisioning has finished removing the instance.
 	// In case the instance has already been deleted, KEB will try best effort to reconstruct at least partial information regarding deprovisioned instances from residual operations.
 	StateDeprovisioned State = "deprovisioned"
+	// StateDeprovisionIncomplete means that the runtime deprovisioning has finished removing the instance but certain steps have not finished and the instance should be requeued for repeated deprovisioning.
+	StateDeprovisionIncomplete State = "deprovisionincomplete"
 	// StateUpgrading means that kyma upgrade or cluster upgrade operation is in progress.
 	StateUpgrading State = "upgrading"
 	// StateUpdating means the runtime configuration is being updated (i.e. OIDC is reconfigured).

--- a/components/kyma-environment-broker/internal/runtime/handler.go
+++ b/components/kyma-environment-broker/internal/runtime/handler.go
@@ -441,6 +441,9 @@ func (h *Handler) getFilters(req *http.Request) dbmodel.InstanceFilter {
 				filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
 			case pkg.StateDeprovisioned:
 				filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
+			case pkg.StateDeprovisionIncomplete:
+				deletionAttempted := true
+				filter.DeletionAttempted = &deletionAttempted
 			case pkg.AllState:
 				allState = true
 			}

--- a/components/kyma-environment-broker/internal/runtime/handler.go
+++ b/components/kyma-environment-broker/internal/runtime/handler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/ptr"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
+	"golang.org/x/exp/slices"
 
 	"github.com/gorilla/mux"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
@@ -98,11 +99,11 @@ func unionInstances(sets ...[]internal.Instance) (union []internal.Instance) {
 }
 
 func (h *Handler) listInstances(filter dbmodel.InstanceFilter) ([]internal.Instance, int, int, error) {
-	if filter.OnlyDeleted != nil && *filter.OnlyDeleted {
+	if slices.Contains(filter.States, dbmodel.InstanceDeprovisioned) {
 		// try to list instances where deletion didn't finish successfully
 		// entry in the Instances table still exists but has deletion timestamp and contains list of incomplete steps
-		filter.DeletionAttempted = filter.OnlyDeleted
-		filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
+		deletionAttempted := true
+		filter.DeletionAttempted = &deletionAttempted
 		instances, instancesCount, instancesTotalCount, _ := h.instancesDb.List(filter)
 
 		// try to recreate instances from the operations table where entry in the instances table is gone
@@ -411,9 +412,6 @@ func (h *Handler) getFilters(req *http.Request) dbmodel.InstanceFilter {
 	filter.Regions = query[pkg.RegionParam]
 	filter.Shoots = query[pkg.ShootParam]
 	filter.Plans = query[pkg.PlanParam]
-	if v, exists := query[pkg.OnlyDeletedParam]; exists && v[0] == "true" {
-		filter.OnlyDeleted = ptr.Bool(true)
-	}
 	if v, exists := query[pkg.ExpiredParam]; exists && v[0] == "true" {
 		filter.Expired = ptr.Bool(true)
 	}
@@ -440,6 +438,8 @@ func (h *Handler) getFilters(req *http.Request) dbmodel.InstanceFilter {
 			case pkg.StateUpdating:
 				filter.States = append(filter.States, dbmodel.InstanceUpdating)
 			case pkg.StateSuspended:
+				filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
+			case pkg.StateDeprovisioned:
 				filter.States = append(filter.States, dbmodel.InstanceDeprovisioned)
 			case pkg.AllState:
 				allState = true

--- a/components/kyma-environment-broker/internal/storage/dbmodel/instance.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/instance.go
@@ -34,7 +34,6 @@ type InstanceFilter struct {
 	Shoots                       []string
 	States                       []InstanceState
 	Expired                      *bool
-	OnlyDeleted                  *bool
 	DeletionAttempted            *bool
 }
 

--- a/components/kyma-environment-broker/internal/storage/postsql/read.go
+++ b/components/kyma-environment-broker/internal/storage/postsql/read.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dberr"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/dbmodel"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage/predicate"
+	"golang.org/x/exp/slices"
 
 	"github.com/gocraft/dbr"
 	"github.com/pivotal-cf/brokerapi/v8/domain"
@@ -843,7 +844,7 @@ func addOperationFilters(stmt *dbr.SelectStmt, filter dbmodel.OperationFilter) {
 	}
 	if filter.InstanceFilter != nil {
 		fi := filter.InstanceFilter
-		if fi.OnlyDeleted != nil && *fi.OnlyDeleted {
+		if slices.Contains(filter.States, string(dbmodel.InstanceDeprovisioned)) {
 			stmt.LeftJoin(dbr.I(InstancesTableName).As("i"), "i.instance_id = o.instance_id").
 				Where("i.instance_id IS NULL")
 		}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_environment_broker:
       dir:
-      version: "PR-2570"
+      version: "PR-2563"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2540"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

The `/runtime` endpoint is used to enable better visibility for KCP where OSB API is not sufficient. This PR introduces two changes
1) https://github.com/kyma-project/control-plane/pull/2563/commits/783c01b17c9ac2c7770f308b1c9af5d89d59ae7c - a filter for listing instances that require re-execution for deprovisioning due to some steps not completing.
2) https://github.com/kyma-project/control-plane/pull/2563/commits/a7457b66d1269d1eed24d8d5e78dd319612550b0 - refactor of `only-deleted` introduced in https://github.com/kyma-project/control-plane/pull/2286. After exploring the flags and parameters on both KCP and KEB, I think it will provide better consistency to use `state=deprovisioned` filter instead of the completely independent and own `only-deleted` parameter.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
see also: https://github.com/kyma-project/control-plane/issues/2533