### PR TITLE
Added vmprobes to rma reconciler clusterrole

### DIFF
--- a/resources/kcp/charts/component-reconcilers/charts/rma/templates/rbac.yaml
+++ b/resources/kcp/charts/component-reconcilers/charts/rma/templates/rbac.yaml
@@ -24,7 +24,7 @@ rules:
     resources: ["vmrules"]
     verbs: ["*"]
   - apiGroups: ["operator.victoriametrics.com"]
-    resources: ["vmusers"]
+    resources: ["vmusers", "vmprobes"]
     verbs: ["*"]
 ---
 kind: ClusterRoleBinding


### PR DESCRIPTION
There was a failure in provisioning due to rma reconciler rbac:     

```
"message": "Runner: failing reconciliation of 'rma' in version '2.11.2' with profile 'Production': helm install xxx-xxxx failed: rendered manifests contain a resource that already exists. Unable to continue with install: could not get information about the resource VMProbe \"xxx-xxxxxx\" in namespace \"monitoring-system\": vmprobes.operator.victoriametrics.com \"xxx-xxxxxxx\" is forbidden: User \"system:serviceaccount:xxxxxxxxx\" cannot get resource \"vmprobes\" in API group \"operator.victoriametrics.com\" in the namespace 
```

