### PR TITLE
Missing CloudSql Proxy Param for Provisioner and Migrator

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -1,4 +1,6 @@
 global:
+  images:
+    cloudsql_proxy_image: "eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.33.4-3cfeacc2"
   defaultTenant: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae
   images:
     containerRegistry:


### PR DESCRIPTION
Missing CloudSql Proxy for Provisioner and Migrator

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Missing CloudSql proxy for provisioner and migrator.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
