### PR TITLE
Introduced Bool Type for Incorrect DB Values

### DIFF
--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -1,6 +1,8 @@
 package orchestration
 
 import (
+	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/provisioner/pkg/gqlschema"
@@ -18,9 +20,10 @@ type Parameters struct {
 	NotificationState notificationStateType    `json:"notificationstate,omitempty"`
 	RetryOperation    RetryOperationParameters `json:"retryoperation,omitempty"`
 }
+
 type RetryOperationParameters struct {
-	RetryOperations []string `json:"retryoperations,omitempty"`
-	Immediate       bool     `json:"immediate,omitempty"`
+	RetryOperations []string      `json:"retryoperations,omitempty"`
+	Immediate       stringBoolean `json:"immediate,omitempty"`
 }
 
 type KubernetesParameters struct {
@@ -209,3 +212,22 @@ const (
 	NotificationCreated   notificationStateType = "created"
 	NotificationCancelled notificationStateType = "cancelled"
 )
+
+type stringBoolean bool
+
+func (p *stringBoolean) UnmarshalJSON(data []byte) error {
+	str := string(data)
+	if str == `"true"` {
+		*p = stringBoolean(true)
+	} else if str == `"false"` {
+		*p = stringBoolean(false)
+	} else {
+		v, err := strconv.ParseBool(string(data))
+		if err != nil {
+			return fmt.Errorf("custom error: %w", err)
+		}
+		*p = stringBoolean(v)
+		return nil
+	}
+	return nil
+}

--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -215,19 +215,18 @@ const (
 
 type stringBoolean bool
 
-func (p *stringBoolean) UnmarshalJSON(data []byte) error {
+func (sb *stringBoolean) UnmarshalJSON(data []byte) error {
 	str := string(data)
 	if str == `"true"` {
-		*p = stringBoolean(true)
+		*sb = stringBoolean(true)
 	} else if str == `"false"` {
-		*p = stringBoolean(false)
+		*sb = stringBoolean(false)
 	} else {
 		v, err := strconv.ParseBool(string(data))
 		if err != nil {
-			return fmt.Errorf("custom error: %w", err)
+			return fmt.Errorf("while unmarshaling stringBoolean: %w", err)
 		}
-		*p = stringBoolean(v)
-		return nil
+		*sb = stringBoolean(v)
 	}
 	return nil
 }

--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -1,6 +1,7 @@
 package orchestration
 
 import (
+	"bytes"
 	"fmt"
 	"strconv"
 	"time"
@@ -216,17 +217,11 @@ const (
 type stringBoolean bool
 
 func (sb *stringBoolean) UnmarshalJSON(data []byte) error {
-	str := string(data)
-	if str == `"true"` {
-		*sb = stringBoolean(true)
-	} else if str == `"false"` {
-		*sb = stringBoolean(false)
-	} else {
-		v, err := strconv.ParseBool(string(data))
-		if err != nil {
-			return fmt.Errorf("while unmarshaling stringBoolean: %w", err)
-		}
-		*sb = stringBoolean(v)
+	unqotedBool := bytes.Trim(data, `"`)
+	v, err := strconv.ParseBool(string(unqotedBool))
+	if err != nil {
+		return fmt.Errorf("while unmarshaling stringBoolean: %w", err)
 	}
+	*sb = stringBoolean(v)
 	return nil
 }

--- a/components/kyma-environment-broker/internal/orchestration/manager/manager.go
+++ b/components/kyma-environment-broker/internal/orchestration/manager/manager.go
@@ -179,7 +179,7 @@ func (m *orchestrationManager) NewOperationForPendingRetrying(o *internal.Orches
 			if o.State == orchestration.Pending && o.Parameters.Strategy.MaintenanceWindow {
 				windowBegin, windowEnd, days = resolveMaintenanceWindowTime(r, policy, o.Parameters.Strategy.ScheduleTime)
 			}
-			if o.State == orchestration.Retrying && o.Parameters.RetryOperation.Immediate && o.Parameters.Strategy.MaintenanceWindow {
+			if o.State == orchestration.Retrying && bool(o.Parameters.RetryOperation.Immediate) && o.Parameters.Strategy.MaintenanceWindow {
 				windowBegin, windowEnd, days = resolveMaintenanceWindowTime(r, policy, o.Parameters.Strategy.ScheduleTime)
 			}
 

--- a/components/kyma-environment-broker/internal/storage/dbmodel/orchestration_test.go
+++ b/components/kyma-environment-broker/internal/storage/dbmodel/orchestration_test.go
@@ -1,0 +1,28 @@
+package dbmodel
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/orchestration"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrchestration(t *testing.T) {
+
+	t.Run("success json", func(t *testing.T) {
+		var params orchestration.Parameters
+		err := json.Unmarshal([]byte(`{"targets":{"include":[]}}`), &params)
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(`{"retryoperation": {}, "targets":{"include":[]}}`), &params)
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(`{"retryoperation": {"immediate": true}, "targets":{"include":[]}}`), &params)
+		require.NoError(t, err)
+
+		err = json.Unmarshal([]byte(`{"retryoperation": {"immediate": "true"}, "targets":{"include":[]}}`), &params)
+		require.NoError(t, err)
+	})
+
+}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -3,7 +3,7 @@ global:
     cloudsql_proxy_image: "eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.33.4-3cfeacc2"
     kyma_environment_broker:
       dir:
-      version: "PR-2599"
+      version: "PR-2616"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2609"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

If orchestration field `immediate` is persisted as a string value `"true"` in database the request send to "orchestration" endpoint fails on unmarshaling this value to bool of https://github.dev/kyma-project/control-plane/blob/c825f45f79d9d4b1b1fe9f5f9ac54c779e494a1a/components/kyma-environment-broker/internal/storage/dbmodel/orchestration.go#L50. Error example: 
```
while getting orchestrations: json: cannot unmarshal string into Go struct field RetryOperationParameters.retryoperation.immediate of type bool"}
``` 

Changes proposed in this pull request:

- Tests that mitigate the orginal problem (see case with `"immediate": "true"`)
- New `stringBoolean` with custom unmarshal that handles bool represented as strings.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
