### PR TITLE
Avs evaluations deprovision cleanup

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations.go
@@ -37,10 +37,6 @@ func (ars *AvsEvaluationRemovalStep) Name() string {
 
 func (ars *AvsEvaluationRemovalStep) Run(operation internal.Operation, logger logrus.FieldLogger) (internal.Operation, time.Duration, error) {
 	logger.Infof("Avs lifecycle %+v", operation.Avs)
-	if operation.Avs.AVSExternalEvaluationDeleted && operation.Avs.AVSInternalEvaluationDeleted {
-		logger.Infof("Both internal and external evaluations have been deleted")
-		return operation, 0, nil
-	}
 
 	operation, err := ars.delegator.DeleteAvsEvaluation(operation, logger, ars.internalEvalAssistant)
 	if err != nil {

--- a/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations_test.go
@@ -107,8 +107,6 @@ func TestAvsEvaluationsRemovalWhenAlreadyDeleted_Run(t *testing.T) {
 	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
 	step := NewAvsEvaluationsRemovalStep(avsDel, memoryStorage.Operations(), externalEvalAssistant, internalEvalAssistant)
 
-	assert.Equal(t, 0, len(evalIdsHolder))
-	assert.Equal(t, 0, len(parentEvalIdHolder))
 	// when
 	deProvisioningOperation, repeat, err := step.Run(deProvisioningOperation, logger)
 
@@ -148,8 +146,6 @@ func TestExternalAvsEvaluationsRemovalSkipForTrialPlan_Run(t *testing.T) {
 	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
 	step := NewAvsEvaluationsRemovalStep(avsDel, memoryStorage.Operations(), externalEvalAssistant, internalEvalAssistant)
 
-	assert.Equal(t, 0, len(evalIdsHolder))
-	assert.Equal(t, 0, len(parentEvalIdHolder))
 	// when
 	deProvisioningOperation, repeat, err := step.Run(deProvisioningOperation, logger)
 
@@ -187,8 +183,6 @@ func TestExternalAvsEvaluationsRemovalSkipForFreemiumPlan_Run(t *testing.T) {
 	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
 	step := NewAvsEvaluationsRemovalStep(avsDel, memoryStorage.Operations(), externalEvalAssistant, internalEvalAssistant)
 
-	assert.Equal(t, 0, len(evalIdsHolder))
-	assert.Equal(t, 0, len(parentEvalIdHolder))
 	// when
 	deProvisioningOperation, repeat, err := step.Run(deProvisioningOperation, logger)
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations_test.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/avs_evaluations_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/avs"
+	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/broker"
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal/storage"
 
 	"github.com/gorilla/mux"
@@ -76,6 +77,128 @@ func TestAvsEvaluationsRemovalStep_Run(t *testing.T) {
 	assert.True(t, inDB.Avs.AVSInternalEvaluationDeleted)
 	assert.True(t, inDB.Avs.AVSExternalEvaluationDeleted)
 	assert.Equal(t, internalEvalId, inDB.Avs.AvsEvaluationInternalId)
+	assert.Equal(t, externalEvalId, inDB.Avs.AVSEvaluationExternalId)
+}
+
+func TestAvsEvaluationsRemovalWhenAlreadyDeleted_Run(t *testing.T) {
+	// given
+	logger := logrus.New()
+	memoryStorage := storage.NewMemoryStorage()
+
+	deProvisioningOperation := fixDeprovisioningOperation().Operation
+	deProvisioningOperation.Avs.AvsEvaluationInternalId = internalEvalId
+	deProvisioningOperation.Avs.AVSEvaluationExternalId = externalEvalId
+	deProvisioningOperation.Avs.AVSExternalEvaluationDeleted = true
+	deProvisioningOperation.Avs.AVSInternalEvaluationDeleted = true
+	err := memoryStorage.Operations().InsertOperation(deProvisioningOperation)
+	assert.NoError(t, err)
+	assert.True(t, deProvisioningOperation.Avs.AVSInternalEvaluationDeleted)
+	assert.True(t, deProvisioningOperation.Avs.AVSExternalEvaluationDeleted)
+
+	mockOauthServer := newMockAvsOauthServer()
+	defer mockOauthServer.Close()
+	mockAvsServer := newMockAvsServer(t)
+	defer mockAvsServer.Close()
+	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig, logrus.New())
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
+	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
+	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
+	step := NewAvsEvaluationsRemovalStep(avsDel, memoryStorage.Operations(), externalEvalAssistant, internalEvalAssistant)
+
+	assert.Equal(t, 0, len(evalIdsHolder))
+	assert.Equal(t, 0, len(parentEvalIdHolder))
+	// when
+	deProvisioningOperation, repeat, err := step.Run(deProvisioningOperation, logger)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), repeat)
+
+	inDB, err := memoryStorage.Operations().GetDeprovisioningOperationByID(deProvisioningOperation.ID)
+	assert.NoError(t, err)
+	assert.True(t, inDB.Avs.AVSInternalEvaluationDeleted)
+	assert.True(t, inDB.Avs.AVSExternalEvaluationDeleted)
+	assert.Equal(t, internalEvalId, inDB.Avs.AvsEvaluationInternalId)
+	assert.Equal(t, externalEvalId, inDB.Avs.AVSEvaluationExternalId)
+}
+
+func TestExternalAvsEvaluationsRemovalSkipForTrialPlan_Run(t *testing.T) {
+	// given
+	logger := logrus.New()
+	memoryStorage := storage.NewMemoryStorage()
+
+	deProvisioningOperation := fixDeprovisioningOperationWithPlanID(broker.TrialPlanID)
+	deProvisioningOperation.Avs.AVSEvaluationExternalId = externalEvalId
+	err := memoryStorage.Operations().InsertOperation(deProvisioningOperation)
+	assert.NoError(t, err)
+	assert.False(t, deProvisioningOperation.Avs.AVSInternalEvaluationDeleted)
+	assert.False(t, deProvisioningOperation.Avs.AVSExternalEvaluationDeleted)
+
+	mockOauthServer := newMockAvsOauthServer()
+	defer mockOauthServer.Close()
+	mockAvsServer := newMockAvsServer(t)
+	defer mockAvsServer.Close()
+	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig, logrus.New())
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
+	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
+	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
+	step := NewAvsEvaluationsRemovalStep(avsDel, memoryStorage.Operations(), externalEvalAssistant, internalEvalAssistant)
+
+	assert.Equal(t, 0, len(evalIdsHolder))
+	assert.Equal(t, 0, len(parentEvalIdHolder))
+	// when
+	deProvisioningOperation, repeat, err := step.Run(deProvisioningOperation, logger)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), repeat)
+
+	inDB, err := memoryStorage.Operations().GetDeprovisioningOperationByID(deProvisioningOperation.ID)
+	assert.NoError(t, err)
+	assert.False(t, inDB.Avs.AVSExternalEvaluationDeleted)
+	assert.Equal(t, externalEvalId, inDB.Avs.AVSEvaluationExternalId)
+}
+
+func TestExternalAvsEvaluationsRemovalSkipForFreemiumPlan_Run(t *testing.T) {
+	// given
+	logger := logrus.New()
+	memoryStorage := storage.NewMemoryStorage()
+
+	deProvisioningOperation := fixDeprovisioningOperationWithPlanID(broker.FreemiumPlanID)
+	deProvisioningOperation.Avs.AVSEvaluationExternalId = externalEvalId
+	err := memoryStorage.Operations().InsertOperation(deProvisioningOperation)
+	assert.NoError(t, err)
+	assert.False(t, deProvisioningOperation.Avs.AVSInternalEvaluationDeleted)
+	assert.False(t, deProvisioningOperation.Avs.AVSExternalEvaluationDeleted)
+
+	mockOauthServer := newMockAvsOauthServer()
+	defer mockOauthServer.Close()
+	mockAvsServer := newMockAvsServer(t)
+	defer mockAvsServer.Close()
+	avsConfig := avsConfig(mockOauthServer, mockAvsServer)
+	avsClient, err := avs.NewClient(context.TODO(), avsConfig, logrus.New())
+	assert.NoError(t, err)
+	avsDel := avs.NewDelegator(avsClient, avsConfig, memoryStorage.Operations())
+	internalEvalAssistant := avs.NewInternalEvalAssistant(avsConfig)
+	externalEvalAssistant := avs.NewExternalEvalAssistant(avsConfig)
+	step := NewAvsEvaluationsRemovalStep(avsDel, memoryStorage.Operations(), externalEvalAssistant, internalEvalAssistant)
+
+	assert.Equal(t, 0, len(evalIdsHolder))
+	assert.Equal(t, 0, len(parentEvalIdHolder))
+	// when
+	deProvisioningOperation, repeat, err := step.Run(deProvisioningOperation, logger)
+
+	// then
+	assert.NoError(t, err)
+	assert.Equal(t, time.Duration(0), repeat)
+
+	inDB, err := memoryStorage.Operations().GetDeprovisioningOperationByID(deProvisioningOperation.ID)
+	assert.NoError(t, err)
+	assert.False(t, inDB.Avs.AVSExternalEvaluationDeleted)
 	assert.Equal(t, externalEvalId, inDB.Avs.AVSEvaluationExternalId)
 }
 

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -3,7 +3,7 @@ global:
     cloudsql_proxy_image: "eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.33.4-3cfeacc2"
     kyma_environment_broker:
       dir:
-      version: "PR-2616"
+      version: "PR-2622"
     kyma_environments_cleanup_job:
       dir:
       version: "PR-2618"


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Avs evaluations deprovision has redundant logic to check if evaluations have already been removed. This caused confusion during troubleshooting. The check is already present in the `deleteAvsEvaluation` method. This PR removes redundant logic and adds more unit tests.

Changes proposed in this pull request:

- Remove redundant check if avs evaluations already deleted
- Add unit test for removing avs evaluations if they have been removed previously
- Add unit tests for skipping the external avs evaluations removal for Trial and Freemium

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #2534 
