### PR TITLE
Undo the changes done to service monitor.

### DIFF
--- a/resources/kcp/charts/component-reconcilers/values.yaml
+++ b/resources/kcp/charts/component-reconcilers/values.yaml
@@ -25,4 +25,9 @@ service:
   port: 8080
   istioPort: 15020
 
-# needs to be enabled in https://github.tools.sap/kyma/management-plane-config
+# needs to be enabled in https://github.tools.sap/kyma/management-plane-config/blob/master/resources/control-plane/config/base/kcp.yaml
+# disable here to bypass deploy AuthorizationPolicy and ServiceMonitor in Pipeline Cluster
+serviceMonitor:
+  enabled: false
+  scrapeTimeout: 30s
+  interval: 60s


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

recent changes to `resources/kcp/charts/component-reconcilers/values.yaml`

deleting

```yaml
# needs to be enabled in https://github.tools.sap/kyma/management-plane-config/blob/master/resources/control-plane/config/base/kcp.yaml
# disable here to bypass deploy AuthorizationPolicy and ServiceMonitor in Pipeline Cluster
serviceMonitor:
  enabled: false
  scrapeTimeout: 30s
  interval: 60s
```

were unintentional and must be reverted.

Changes proposed in this pull request:

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
