### PR TITLE
Update of reconciler image used on Kyma control plane 

### DIFF
--- a/resources/kcp/charts/component-reconcilers/values.yaml
+++ b/resources/kcp/charts/component-reconcilers/values.yaml
@@ -1,7 +1,7 @@
 global:
   images:
     cloudsql_proxy_image: "eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.33.4-3cfeacc2"
-    component_reconciler: "eu.gcr.io/kyma-project/incubator/reconciler/component:v20230330-7b2e2ae7"
+    component_reconciler: "eu.gcr.io/kyma-project/incubator/reconciler/component:v20230405-5bf21f04"
 
 # Default values for component-reconcilers.
 


### PR DESCRIPTION
Update of the reconciler image after merging pr-1317 to main branch with fix for problem of `connectivity-proxy-reconciler` not refreshing credentials.

https://github.com/kyma-incubator/reconciler/pull/1317 
