### PR TITLE
bumps provisioner golang to 1.20.3 and alpine to 3.17.3

### DIFF
--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.19.4-alpine3.17 as builder
+FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 RUN go build -v -o main ./cmd/
 RUN mkdir /app && mv ./main /app/main
 
-FROM eu.gcr.io/kyma-project/external/alpine:3.16.2
+FROM eu.gcr.io/kyma-project/external/alpine:3.17.3
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/control-plane/components/provisioner
 
-go 1.19
+go 1.20
 
 require (
 	github.com/99designs/gqlgen v0.11.3

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     provisioner:
       dir:
-      version: "PR-2625"
+      version: "PR-2657"
 
 deployment:
   replicaCount: 1


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps provisioner golang-runtime to 1.20.3
- switches go version from 1.19 to 1.20 
- updates alpine to 3.17.3

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
