### PR TITLE
Wrong kyma version on retry upgrade command

### DIFF
--- a/components/kyma-environment-broker/common/orchestration/dto.go
+++ b/components/kyma-environment-broker/common/orchestration/dto.go
@@ -35,7 +35,8 @@ type KubernetesParameters struct {
 
 // KymaParameters hold the attributes of kyma upgrade specific orchestration create requests.
 type KymaParameters struct {
-	Version string `json:"version,omitempty"`
+	Version        string `json:"version,omitempty"`
+	DisplayVersion string `json:"displayVersion,omitempty"`
 }
 
 const (

--- a/components/kyma-environment-broker/internal/orchestration/manager/manager.go
+++ b/components/kyma-environment-broker/internal/orchestration/manager/manager.go
@@ -208,8 +208,8 @@ func (m *orchestrationManager) NewOperationForPendingRetrying(o *internal.Orches
 
 	}
 
-	if o.Parameters.Kyma == nil || o.Parameters.Kyma.Version == "" {
-		o.Parameters.Kyma = &orchestration.KymaParameters{Version: m.kymaVersion}
+	if o.Parameters.Kyma == nil || o.Parameters.Kyma.DisplayVersion == "" {
+		o.Parameters.Kyma = &orchestration.KymaParameters{DisplayVersion: m.kymaVersion}
 	}
 	if o.Parameters.Kubernetes == nil || o.Parameters.Kubernetes.KubernetesVersion == "" {
 		o.Parameters.Kubernetes = &orchestration.KubernetesParameters{KubernetesVersion: m.kubernetesVersion}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR introduces the changes required to fix the bug that the kyma version is wrongly calculated when we use kcp cli's retry command. 

Note: Once these changes are merged, another PR is going to be introduced for kcp cli to use these changes. 

Changes proposed in this pull request:

- These changes introduce a new property in `orchestrations.KymaParameters` struct called `displayVersion`. 


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. --> 