### PR TITLE
Sanity check for deprovisioning retrigger

### DIFF
--- a/components/kyma-environment-broker/cmd/deprovisionretrigger/main.go
+++ b/components/kyma-environment-broker/cmd/deprovisionretrigger/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -18,6 +19,7 @@ import (
 
 type BrokerClient interface {
 	Deprovision(instance internal.Instance) (string, error)
+	GetInstanceRequest(instanceID string) (*http.Response, error)
 }
 
 type Config struct {
@@ -92,8 +94,10 @@ func (s *DeprovisionRetriggerService) PerformCleanup() error {
 		s.logInstances(instancesToDeprovisionAgain)
 		log.Infof("Instances to retrigger deprovisioning: %d", len(instancesToDeprovisionAgain))
 	} else {
-		deprovisioningAccepted, failuresCount := s.retriggerDeprovisioningForInstances(instancesToDeprovisionAgain)
-		log.Infof("Instances to retrigger deprovisioning: %d, accepted requests: %d, failed requests: %d", len(instancesToDeprovisionAgain), deprovisioningAccepted, failuresCount)
+		failuresCount, sanityFailedCount := s.retriggerDeprovisioningForInstances(instancesToDeprovisionAgain)
+		deprovisioningAccepted := len(instancesToDeprovisionAgain) - failuresCount - sanityFailedCount
+		log.Infof("Instances to retrigger deprovisioning: %d, accepted requests: %d, skipped due to sanity failed: %d, failed requests: %d",
+			len(instancesToDeprovisionAgain), deprovisioningAccepted, sanityFailedCount, failuresCount)
 	}
 
 	return nil
@@ -101,14 +105,21 @@ func (s *DeprovisionRetriggerService) PerformCleanup() error {
 
 func (s *DeprovisionRetriggerService) retriggerDeprovisioningForInstances(instances []internal.Instance) (int, int) {
 	var failuresCount int
+	var sanityFailedCount int
 	for _, instance := range instances {
-		err := s.deprovisionInstance(instance)
-		if err != nil {
-			// just counting, logging and ignoring errors
-			failuresCount += 1
+		// sanity check - if the instance is visible we shall not trigger deprovisioning
+		notFound := s.getInstanceReturned404(instance.InstanceID)
+		if notFound {
+			err := s.deprovisionInstance(instance)
+			if err != nil {
+				// just counting, logging and ignoring errors
+				failuresCount += 1
+			}
+		} else {
+			sanityFailedCount += 1
 		}
 	}
-	return len(instances) - failuresCount, failuresCount
+	return failuresCount, sanityFailedCount
 }
 
 func (s *DeprovisionRetriggerService) deprovisionInstance(instance internal.Instance) (err error) {
@@ -122,9 +133,28 @@ func (s *DeprovisionRetriggerService) deprovisionInstance(instance internal.Inst
 	return nil
 }
 
+// Sanity check - instance is supposed to be not visible via API. Call should return 404 - NotFound
+func (s *DeprovisionRetriggerService) getInstanceReturned404(instanceID string) bool {
+	response, err := s.brokerClient.GetInstanceRequest(instanceID)
+	if err != nil {
+		log.Warn(fmt.Sprintf("while trying to GET instance resource for %s: %s", instanceID, err))
+		return false
+	}
+	if response != nil && response.StatusCode != http.StatusNotFound {
+		log.Error(fmt.Sprintf("unexpextedly GET instance resource for  %s: returned %s", instanceID, http.StatusText(response.StatusCode)))
+		return false
+	}
+	return true
+}
+
 func (s *DeprovisionRetriggerService) logInstances(instances []internal.Instance) {
 	for _, instance := range instances {
-		log.Infof("instanceId: %s, createdAt: %+v, deletedAt %+v", instance.InstanceID, instance.CreatedAt, instance.DeletedAt)
+		notFound := s.getInstanceReturned404(instance.InstanceID)
+		if notFound {
+			log.Infof("instanceId: %s, createdAt: %+v, deletedAt %+v, GET retured: NotFound", instance.InstanceID, instance.CreatedAt, instance.DeletedAt)
+		} else {
+			log.Infof("instanceId: %s, createdAt: %+v, deletedAt %+v, GET retured: unexpected result", instance.InstanceID, instance.CreatedAt, instance.DeletedAt)
+		}
 	}
 }
 

--- a/components/kyma-environment-broker/internal/broker/client.go
+++ b/components/kyma-environment-broker/internal/broker/client.go
@@ -22,6 +22,7 @@ const (
 	instancesURL       = "/oauth/v2/service_instances"
 	deprovisionTmpl    = "%s%s/%s?service_id=%s&plan_id=%s"
 	updateInstanceTmpl = "%s%s/%s"
+	getInstanceTmpl    = "%s%s/%s"
 )
 
 type (
@@ -136,6 +137,22 @@ func (c *Client) SendExpirationRequest(instance internal.Instance) (suspensionUn
 	return processResponse(instance.InstanceID, resp.StatusCode, resp)
 }
 
+func (c *Client) GetInstanceRequest(instanceID string) (response *http.Response, err error) {
+	request, err := prepareGetRequest(instanceID, c.brokerConfig.URL)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(request)
+	if err != nil {
+		return resp, fmt.Errorf("while executing request URL: %s for instanceID: %s: %w", request.URL,
+			instanceID, err)
+	}
+	defer c.warnOnError(resp.Body.Close)
+
+	return resp, nil
+}
+
 func processResponse(instanceID string, statusCode int, resp *http.Response) (suspensionUnderWay bool, err error) {
 	switch statusCode {
 	case http.StatusAccepted, http.StatusOK:
@@ -203,6 +220,17 @@ func preparePatchRequest(instance internal.Instance, brokerConfigURL string) (*h
 	request, err := http.NewRequest(http.MethodPatch, updateInstanceUrl, bytes.NewBuffer(jsonPayload))
 	if err != nil {
 		return nil, fmt.Errorf("while creating request for instanceID: %s: %w", instance.InstanceID, err)
+	}
+	request.Header.Set("X-Broker-API-Version", "2.14")
+	return request, nil
+}
+
+func prepareGetRequest(instanceID string, brokerConfigURL string) (*http.Request, error) {
+	getInstanceUrl := fmt.Sprintf(getInstanceTmpl, brokerConfigURL, instancesURL, instanceID)
+
+	request, err := http.NewRequest(http.MethodGet, getInstanceUrl, nil)
+	if err != nil {
+		return nil, fmt.Errorf("while creating GET request for instanceID: %s: %w", instanceID, err)
 	}
 	request.Header.Set("X-Broker-API-Version", "2.14")
 	return request, nil


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

To reduce the risk of deprovisioning the instances not intended to be deprovisioned now it is checked if OSB API call GET returns 404 for the given instance.
These instances that requires retrigger should be not visible/reachable. 

Changes proposed in this pull request:

- Checking if GET returns 404 as a prerequisite to deprovision

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
