### PR TITLE
bump golang-runtime from 1.20.2 to 1.20.3 in keb

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.job
+++ b/components/kyma-environment-broker/Dockerfile.job
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.20.2-alpine3.16 AS build
+FROM golang:1.20.3-alpine3.16 AS build
 
 WORKDIR /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker
 

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -10,7 +10,7 @@ global:
       version: "PR-2380"
     kyma_environments_subscription_cleanup_job:
       dir:
-      version: "PR-2476"
+      version: "PR-2680"
     kyma_metrics_collector:
       dir:
       version: PR-2656


### PR DESCRIPTION
Aims to fix:
- CVE-2022-41723
- CVE-2022-41722
- CVE-2022-41724
- CVE-2022-41725
- CVE-2023-24537
- CVE-2023-24532
in kyma-environment-subscription-cleanup-job

**Description**

Changes proposed in this pull request:

- bump golang-runtime from 1.20.2 to 1.20.3

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
