### PR TITLE
Migrate KEB, provisioner and KMC images to artifact registry

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -3,19 +3,19 @@ global:
     cloudsql_proxy_image: "eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.33.4-3cfeacc2"
     kyma_environment_broker:
       dir:
-      version: "PR-2661"
+      version: "v20230421-80711ae8"
     kyma_environments_cleanup_job:
       dir:
-      version: "PR-2618"
+      version: "v20230421-80711ae8"
     kyma_environments_subaccount_cleanup_job:
       dir:
-      version: "PR-2476"
+      version: "v20230421-80711ae8"
     kyma_environment_trial_cleanup_job:
       dir:
-      version: "PR-2476"
+      version: "v20230421-80711ae8"
     kyma_environment_deprovision_retrigger_job:
       dir:
-      version: "PR-2691"
+      version: "v20230421-80711ae8"
 
 deployment:
   replicaCount: 1

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -3,19 +3,19 @@ global:
     cloudsql_proxy_image: "eu.gcr.io/kyma-project/tpi/cloudsql-docker/gce-proxy:v1.33.4-3cfeacc2"
     kyma_environment_broker:
       dir:
-      version: "v20230421-80711ae8"
+      version: "v20230427-7b2c6ef5"
     kyma_environments_cleanup_job:
       dir:
-      version: "v20230421-80711ae8"
+      version: "v20230427-7b2c6ef5"
     kyma_environments_subaccount_cleanup_job:
       dir:
-      version: "v20230421-80711ae8"
+      version: "v20230427-7b2c6ef5"
     kyma_environment_trial_cleanup_job:
       dir:
-      version: "v20230421-80711ae8"
+      version: "v20230427-7b2c6ef5"
     kyma_environment_deprovision_retrigger_job:
       dir:
-      version: "v20230421-80711ae8"
+      version: "v20230427-7b2c6ef5"
 
 deployment:
   replicaCount: 1

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -4,9 +4,6 @@ global:
     kyma_environment_broker:
       dir:
       version: "v20230427-7b2c6ef5"
-    kyma_environments_cleanup_job:
-      dir:
-      version: "v20230427-7b2c6ef5"
     kyma_environments_subaccount_cleanup_job:
       dir:
       version: "v20230427-7b2c6ef5"

--- a/resources/kcp/charts/kyma-metrics-collector/values.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     kyma_metrics_collector:
       dir:
-      version: "PR-2238"
+      version: "v20230411-94ab3da5"
 
 nameOverride: ""
 fullnameOverride: ""

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -2,7 +2,7 @@ global:
   images:
     provisioner:
       dir:
-      version: "PR-2525"
+      version: "v20230412-91e5ada4"
 
 deployment:
   replicaCount: 1

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -10,7 +10,7 @@ global:
       version: "v20230120-865831c1"
     kyma_environments_subscription_cleanup_job:
       dir:
-      version: "v20230421-80711ae8"
+      version: "v20230427-7b2c6ef5"
     kyma_metrics_collector:
       dir:
       version: v20230411-94ab3da5

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -4,23 +4,23 @@ global:
   defaultTenant: 3e64ebae-38b5-46a0-b1ed-9ccee153a0ae
   images:
     containerRegistry:
-      path: eu.gcr.io/kyma-project/control-plane
+      path: europe-docker.pkg.dev/kyma-project/prod/control-plane
     schema_migrator:
       dir:
-      version: "PR-2380"
+      version: "v20230120-865831c1"
     kyma_environments_subscription_cleanup_job:
       dir:
-      version: "PR-2680"
+      version: "v20230421-80711ae8"
     kyma_metrics_collector:
       dir:
-      version: PR-2656
+      version: v20230411-94ab3da5
     tests:
       provisioner:
         dir:
-        version: "PR-2706"
+        version: "v20230426-ad965fac"
       e2e_provisioning:
         dir:
-        version: "PR-2678"
+        version: "v20230424-caf29954"
     busybox: eu.gcr.io/kyma-project/external/busybox:1.34.1
   isLocalEnv: false
   oauth2:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Since we are moving to the artifact registry, we need to switch from using PR images to images built after merging to the main branch. Since we don't yet have a solution to automate image bumping, we have to create a second PR from now on after merging a PR with changes to bump the image version to the image built after merging the previous PR. To summarise the workflow will look like this:
- A PR with some changes is created and merged to main
- The image is built using post build jobs
- A second PR with bumps is created using the image tag from post build jobs

Changes proposed in this pull request:

- Move KEB images to artifact registry
- Move Provisioner images to artifact registry
- Move KMC images to artifact registry
- Move test images to artifact registry

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
