### PR TITLE
bumps golang to 1.20.4 in provisioner and subscription cleanup job

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.job
+++ b/components/kyma-environment-broker/Dockerfile.job
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.20.3-alpine3.16 AS build
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.4-alpine3.17 as builder
 
 WORKDIR /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker
 

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.4-alpine3.17 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,7 +3,7 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "PR-2718"
+      version: "PR-2726"
       dir: "dev"
 
 deployment:

--- a/tests/provisioner-tests/Dockerfile
+++ b/tests/provisioner-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.3-alpine3.17 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.4-alpine3.17 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/provisioner-tests
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps golang to 1.20.4 in provisioner and subscription cleanup job
- because of the different .yaml structure of `resources/kcp/values.yaml` I would propose to bump the image for `provisioner tests` and `subscription cleanup job` in a separate PR.
- ...