### PR TITLE
Bump golang images to 1.20.4 ver. in KEB and E2E Provisioning test

### DIFF
--- a/components/kyma-environment-broker/Dockerfile.job
+++ b/components/kyma-environment-broker/Dockerfile.job
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.20.3-alpine3.16 AS build
+FROM golang:1.20.4-alpine3.17 AS build
 
 WORKDIR /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker
 

--- a/components/kyma-environment-broker/Dockerfile.keb
+++ b/components/kyma-environment-broker/Dockerfile.keb
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.20.3-alpine3.17 AS build
+FROM golang:1.20.4-alpine3.17 AS build
 
 WORKDIR /go/src/github.com/kyma-project/control-plane/components/kyma-environment-broker
 

--- a/tests/e2e/provisioning/Dockerfile
+++ b/tests/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.3-alpine3.17 as builder
+FROM golang:1.20.4-alpine3.17 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/e2e/provisioning
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- bump golang builder images to 1.20.4 ver. in dockerfiles.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
