### PR TITLE
reverts to DEV PR in order to see if it will help with url duplication

### DIFF
--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,8 +3,8 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "v20230508-19cfa22a"
-      dir: "prod"
+      version: "PR-2718"
+      dir: "dev"
 
 deployment:
   replicaCount: 1


### PR DESCRIPTION
**Description**
- The KCP contains reference `europe-docker.pkg.dev/kyma-project/prod/control-plane/prod/control-plane%2Fprovisioner:v20230508-19cfa22a` where `prod/control-plane` is duplicated. This PR should help in debugging the isue.  

Changes proposed in this pull request:

- Switches image to `PR-` version and `dev` directory
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/control-plane/pull/2733