### PR TITLE
Stoping using of deprecated field EnableBasicAuthentication from shoot

### DIFF
--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -119,7 +119,6 @@ func NewCertConfig() *ExtensionProviderConfig {
 }
 
 func (c GardenerConfig) ToShootTemplate(namespace string, accountId string, subAccountId string, oidcConfig *OIDCConfig, dnsInputConfig *DNSConfig) (*gardener_types.Shoot, apperrors.AppError) {
-	enableBasicAuthentication := false
 
 	var seed *string = nil
 	if c.Seed != "" {
@@ -185,8 +184,7 @@ func (c GardenerConfig) ToShootTemplate(namespace string, accountId string, subA
 			Kubernetes: gardener_types.Kubernetes{
 				Version: c.KubernetesVersion,
 				KubeAPIServer: &gardener_types.KubeAPIServerConfig{
-					EnableBasicAuthentication: &enableBasicAuthentication,
-					OIDCConfig:                gardenerOidcConfig(oidcConfig),
+					OIDCConfig: gardenerOidcConfig(oidcConfig),
 				},
 			},
 			Networking: gardener_types.Networking{

--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -237,8 +237,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					Kubernetes: gardener_types.Kubernetes{
 						Version: "1.15",
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
-							EnableBasicAuthentication: util.BoolPtr(false),
-							OIDCConfig:                gardenerOidcConfig(oidcConfig()),
+							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
 					},
 					Maintenance: &gardener_types.Maintenance{
@@ -317,8 +316,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					Kubernetes: gardener_types.Kubernetes{
 						Version: "1.15",
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
-							EnableBasicAuthentication: util.BoolPtr(false),
-							OIDCConfig:                gardenerOidcConfig(oidcConfig()),
+							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
 					},
 					Maintenance: &gardener_types.Maintenance{
@@ -397,8 +395,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					Kubernetes: gardener_types.Kubernetes{
 						Version: "1.15",
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
-							EnableBasicAuthentication: util.BoolPtr(false),
-							OIDCConfig:                gardenerOidcConfig(oidcConfig()),
+							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
 					},
 					Maintenance: &gardener_types.Maintenance{
@@ -477,8 +474,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					Kubernetes: gardener_types.Kubernetes{
 						Version: "1.15",
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
-							EnableBasicAuthentication: util.BoolPtr(false),
-							OIDCConfig:                gardenerOidcConfig(oidcConfig()),
+							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
 					},
 					Maintenance: &gardener_types.Maintenance{
@@ -557,8 +553,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 					Kubernetes: gardener_types.Kubernetes{
 						Version: "1.15",
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
-							EnableBasicAuthentication: util.BoolPtr(false),
-							OIDCConfig:                gardenerOidcConfig(oidcConfig()),
+							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
 					},
 					Maintenance: &gardener_types.Maintenance{

--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.global.images.containerRegistry.path }}/{{ .Values.global.images.provisioner.dir }}/control-plane%2Fprovisioner:{{ .Values.global.images.provisioner.version }}
+          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.images.provisioner.dir }}/control-plane%2Fprovisioner:{{ .Values.global.images.provisioner.version }}
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           ports:
             - name: http

--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ .Values.global.containerRegistry.path }}/{{ .Values.global.images.provisioner.dir }}/control-plane%2Fprovisioner:{{ .Values.global.images.provisioner.version }}
+          image: "{{ .Values.global.containerRegistry.path }}/{{ .Values.global.images.provisioner.dir }}/control-plane%2Fprovisioner:{{ .Values.global.images.provisioner.version }}"
           imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           ports:
             - name: http

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,8 +3,8 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "v20230508-19cfa22a"
-      dir: "prod"
+      version: "PR-2738"
+      dir: "dev"
 
 deployment:
   replicaCount: 1


### PR DESCRIPTION
Change requested by Gardener team:

Updating all related code in open-source Kyma to not use Shoot with basic auth any more, as it's a deprecated field which is getting removed very very soon.