### PR TITLE
restore tracing for reconciler tests

### DIFF
--- a/tools/reconciler/e2e-test/template-kyma-main.json
+++ b/tools/reconciler/e2e-test/template-kyma-main.json
@@ -74,6 +74,16 @@
         ]
       },
       {
+        "component": "tracing",
+        "namespace": "kyma-system",
+        "configuration": [
+          {
+              "key": "global.domainName",
+              "value": "example.com"
+          }
+        ]
+      },
+      {
         "component": "monitoring",
         "namespace": "kyma-system",
         "configuration": [


### PR DESCRIPTION
**Description**
Tracing component is deprecated and will be removed in the next Kyma releases.
However, the current `latest` Kyma version, `2.13.1` still contain tests for tracing in the sources.
Prow jobs for the reconciler component that execute tests on the `latest` Kyma fail without `tracing`.

[A PR](https://github.com/kyma-project/control-plane/pull/2708) has been merged that deletes the `tracing` component from reconciler's test configuration.
This PR restores that component to fix the pipelines.

Changes proposed in this pull request:

- restore tracing for reconciler tests

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/17379
https://github.com/kyma-project/control-plane/pull/2708