### PR TITLE
changing URL

### DIFF
--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -22,7 +22,7 @@ global:
 replicaCount: 1
 
 image:
-  repository: eu.gcr.io/kyma-project/control-plane/kubeconfig-service
+  repository: europe-docker.pkg.dev/kyma-project/dev/control-plane/kubeconfig-service
   tag: "PR-2666"
   pullPolicy: Always
 


### PR DESCRIPTION
kubeconfig-service cannot pull images from old artifact repository as it was removed in the name of cost reduction and moved to the new place.
```
  Warning  Failed     23m (x3 over 24m)     kubelet            Failed to pull image "eu.gcr.io/kyma-project/control-plane/kubeconfig-service:PR-2666": rpc error: code = NotFound desc = failed to pull and unpack image "eu.gcr.io/kyma-project/control-plane/kubeconfig-service:PR-2666": failed to resolve reference "eu.gcr.io/kyma-project/control-plane/kubeconfig-service:PR-2666": eu.gcr.io/kyma-project/control-plane/kubeconfig-service:PR-2666: not found
```