### PR TITLE
Add missing error state event for deprovisioning steps

### DIFF
--- a/components/kyma-environment-broker/internal/process/deprovisioning/deregister_cluster.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/deregister_cluster.go
@@ -1,6 +1,7 @@
 package deprovisioning
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/internal"
@@ -60,10 +61,8 @@ func (s *DeregisterClusterStep) handleError(operation internal.Operation, err er
 			return operation, 15 * time.Second, nil
 		}
 	}
-	log.Errorf("Reconciler cluster configuration have not been deleted in step %s.", s.Name())
-	operation, repeat, err := s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-		operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, s.Name())
-	}, log)
+	errMsg := fmt.Sprintf("Reconciler cluster configuration have not been deleted in step %s.", s.Name())
+	operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), errMsg, log)
 	if repeat != 0 {
 		return operation, repeat, err
 	}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/edp_deregistration.go
@@ -74,10 +74,8 @@ func (s *EDPDeregistrationStep) handleError(operation internal.Operation, err er
 		}
 	}
 
-	log.Errorf("Step %s failed. EDP data have not been deleted.", s.Name())
-	operation, repeat, err := s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-		operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, s.Name())
-	}, log)
+	errMsg := fmt.Sprintf("Step %s failed. EDP data have not been deleted.", s.Name())
+	operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), errMsg, log)
 	if repeat != 0 {
 		return operation, repeat, err
 	}

--- a/components/kyma-environment-broker/internal/process/deprovisioning/release_subscription_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/release_subscription_step.go
@@ -1,6 +1,7 @@
 package deprovisioning
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kyma-project/control-plane/components/kyma-environment-broker/common/hyperscaler"
@@ -39,25 +40,29 @@ func (s ReleaseSubscriptionStep) Run(operation internal.Operation, log logrus.Fi
 	if !broker.IsTrialPlan(planID) && !broker.IsOwnClusterPlan(planID) {
 		instance, err := s.instanceStorage.GetByID(operation.InstanceID)
 		if err != nil {
-			log.Errorf("after successful deprovisioning failing to release hyperscaler subscription - get the instance data for instanceID: %s", operation.InstanceID, err.Error())
+			msg := fmt.Sprintf("after successful deprovisioning failing to release hyperscaler subscription - get the instance data for instanceID [%s]: %s", operation.InstanceID, err.Error())
+			log.Errorf(msg)
 			operation, repeat, err := s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
 				operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, s.Name())
 			}, log)
 			if repeat != 0 {
 				return operation, repeat, err
 			}
+			operation.EventErrorf(fmt.Errorf(msg), "step %s failed: operation continues", s.Name())
 			return operation, 0, nil
 		}
 
 		hypType, err := hyperscaler.FromCloudProvider(instance.Provider)
 		if err != nil {
-			log.Errorf("after successful deprovisioning failing to release hyperscaler subscription - determine the type of hyperscaler to use for planID [%s]: %s", planID, err.Error())
+			msg := fmt.Sprintf("after successful deprovisioning failing to release hyperscaler subscription - determine the type of hyperscaler to use for planID [%s]: %s", planID, err.Error())
+			log.Errorf(msg)
 			operation, repeat, err := s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
 				operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, s.Name())
 			}, log)
 			if repeat != 0 {
 				return operation, repeat, err
 			}
+			operation.EventErrorf(fmt.Errorf(msg), "step %s failed: operation continues", s.Name())
 			return operation, 0, nil
 		}
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/release_subscription_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/release_subscription_step.go
@@ -41,14 +41,10 @@ func (s ReleaseSubscriptionStep) Run(operation internal.Operation, log logrus.Fi
 		instance, err := s.instanceStorage.GetByID(operation.InstanceID)
 		if err != nil {
 			msg := fmt.Sprintf("after successful deprovisioning failing to release hyperscaler subscription - get the instance data for instanceID [%s]: %s", operation.InstanceID, err.Error())
-			log.Errorf(msg)
-			operation, repeat, err := s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-				operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, s.Name())
-			}, log)
+			operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), msg, log)
 			if repeat != 0 {
 				return operation, repeat, err
 			}
-			operation.EventErrorf(fmt.Errorf(msg), "step %s failed: operation continues", s.Name())
 			return operation, 0, nil
 		}
 

--- a/components/kyma-environment-broker/internal/process/deprovisioning/release_subscription_step.go
+++ b/components/kyma-environment-broker/internal/process/deprovisioning/release_subscription_step.go
@@ -51,14 +51,10 @@ func (s ReleaseSubscriptionStep) Run(operation internal.Operation, log logrus.Fi
 		hypType, err := hyperscaler.FromCloudProvider(instance.Provider)
 		if err != nil {
 			msg := fmt.Sprintf("after successful deprovisioning failing to release hyperscaler subscription - determine the type of hyperscaler to use for planID [%s]: %s", planID, err.Error())
-			log.Errorf(msg)
-			operation, repeat, err := s.operationManager.UpdateOperation(operation, func(operation *internal.Operation) {
-				operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, s.Name())
-			}, log)
+			operation, repeat, err := s.operationManager.MarkStepAsExcutedButNotCompleted(operation, s.Name(), msg, log)
 			if repeat != 0 {
 				return operation, repeat, err
 			}
-			operation.EventErrorf(fmt.Errorf(msg), "step %s failed: operation continues", s.Name())
 			return operation, 0, nil
 		}
 

--- a/components/kyma-environment-broker/internal/process/operation_manager.go
+++ b/components/kyma-environment-broker/internal/process/operation_manager.go
@@ -121,6 +121,19 @@ func (om *OperationManager) UpdateOperation(operation internal.Operation, update
 	return *op, 0, nil
 }
 
+func (om *OperationManager) MarkStepAsExcutedButNotCompleted(operation internal.Operation, stepName string, msg string, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
+	op, repeat, err := om.UpdateOperation(operation, func(operation *internal.Operation) {
+		operation.ExcutedButNotCompleted = append(operation.ExcutedButNotCompleted, stepName)
+	}, log)
+	if repeat != 0 {
+		return op, repeat, err
+	}
+
+	op.EventErrorf(fmt.Errorf(msg), "step %s failed: operation continues", stepName)
+	log.Errorf(msg)
+	return op, 0, nil
+}
+
 func (om *OperationManager) update(operation internal.Operation, state domain.LastOperationState, description string, log logrus.FieldLogger) (internal.Operation, time.Duration, error) {
 	return om.UpdateOperation(operation, func(operation *internal.Operation) {
 		operation.State = state


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Some steps don't have the error state event in the kcp cli view when errors occur.

Changes proposed in this pull request:

- Add error state event for deregister cluster step
- Add error state event for edp deregistration step
- Add error state event for release subscription step

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #2569 