### PR TITLE
add more labels to Kyma resource

### DIFF
--- a/components/kyma-environment-broker/internal/process/steps/lifecycle_manager.go
+++ b/components/kyma-environment-broker/internal/process/steps/lifecycle_manager.go
@@ -23,6 +23,9 @@ func ApplyLabelsAndAnnotationsForLM(object client.Object, operation internal.Ope
 	l["kyma-project.io/broker-plan-id"] = operation.ProvisioningParameters.PlanID
 	l["kyma-project.io/broker-plan-name"] = broker.PlanNamesMapping[operation.ProvisioningParameters.PlanID]
 	l["kyma-project.io/global-account-id"] = operation.GlobalAccountID
+	l["kyma-project.io/subaccount-id"] = operation.SubAccountID
+	l["kyma-project.io/shoot-name"] = operation.ShootName
+	l["kyma-project.io/region"] = operation.Region
 	l["operator.kyma-project.io/kyma-name"] = KymaName(operation)
 	l["operator.kyma-project.io/managed-by"] = "lifecycle-manager"
 	object.SetLabels(l)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Adding the following three labels to each Kyma resource on SKR:
  - subaccount-id
  - shoot-name: name of the shoot cluster. The shoot name could also be extracted from the skr-domain (some lines below). However, this would require some string splitting and also accessing the resource annotations. I think adding a dedicated field to the labels is cleaner and doesn't introduce any overhead.
  - region

CC @ebensom, @a-thaler  

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
