### PR TITLE
Use batch/v1 for CronJobs

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/keb-db-job.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/keb-db-job.yaml
@@ -1,7 +1,7 @@
 {{- range $index, $property := .Values.cronJobs }}
 {{- $job := get $.Values $property }}
 
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ $job.name }}

--- a/resources/kcp/charts/kyma-environment-broker/templates/subaccount-cleanup-job.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/subaccount-cleanup-job.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.subaccountCleanup.enabled }}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "kcp-subaccount-cleaner-v1.0"


### PR DESCRIPTION
Couple of manifests in the kcp helm charts were using v1beta1 CronJobs which are no longer available on newer kubernetes installations. Bumped those to use v1.
