### PR TITLE
Fix leftover batch/v1beta1 CronJob

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/subaccount-cleanup-job.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/subaccount-cleanup-job.yaml
@@ -155,7 +155,7 @@ spec:
                 optional: true
           {{- end}}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "kcp-subaccount-cleaner-v2.0"


### PR DESCRIPTION
There was a leftover `batch/v1beta1` `CronJob` in the KEB subchar, this PR is fixing that with an update to `batch/v1`
