### PR TITLE
Configure maxSurge equal to the number of znoes for enterprise plan runtimes

### DIFF
--- a/components/kyma-environment-broker/internal/process/provisioning/check_cluster_configuration_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/check_cluster_configuration_test.go
@@ -229,6 +229,8 @@ func fixInputCreator(t *testing.T) internal.ProvisionerInputCreator {
 			DefaultGardenerShootPurpose:   shootPurpose,
 			AutoUpdateKubernetesVersion:   autoUpdateKubernetesVersion,
 			AutoUpdateMachineImageVersion: autoUpdateMachineImageVersion,
+			MultiZoneCluster:              true,
+			ControlPlaneFailureTolerance:  "zone",
 		}, kymaVersion, fixTrialRegionMapping(), fixFreemiumProviders(), fixture.FixOIDCConfigDTO())
 	assert.NoError(t, err)
 

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -134,7 +134,7 @@ func fixProvisionerInput(disabled bool, euAccess bool) gqlschema.ProvisionRuntim
 				WorkerCidr:                          "10.250.0.0/19",
 				AutoScalerMin:                       3,
 				AutoScalerMax:                       20,
-				MaxSurge:                            1,
+				MaxSurge:                            3,
 				MaxUnavailable:                      0,
 				TargetSecret:                        "",
 				EnableKubernetesVersionAutoUpdate:   ptr.Bool(autoUpdateKubernetesVersion),

--- a/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
+++ b/components/kyma-environment-broker/internal/process/provisioning/create_runtime_without_kyma_test.go
@@ -137,6 +137,7 @@ func fixProvisionerInput(disabled bool, euAccess bool) gqlschema.ProvisionRuntim
 				MaxSurge:                            3,
 				MaxUnavailable:                      0,
 				TargetSecret:                        "",
+				ControlPlaneFailureTolerance:        ptr.String("zone"),
 				EnableKubernetesVersionAutoUpdate:   ptr.Bool(autoUpdateKubernetesVersion),
 				EnableMachineImageVersionAutoUpdate: ptr.Bool(autoUpdateMachineImageVersion),
 				ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{

--- a/components/kyma-environment-broker/internal/provider/aws_provider.go
+++ b/components/kyma-environment-broker/internal/provider/aws_provider.go
@@ -59,7 +59,7 @@ func (p *AWSInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/16",
 			AutoScalerMin:  3,
 			AutoScalerMax:  20,
-			MaxSurge:       1,
+			MaxSurge:       zonesCount,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AwsConfig: &gqlschema.AWSProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/azure_provider.go
+++ b/components/kyma-environment-broker/internal/provider/azure_provider.go
@@ -60,7 +60,7 @@ func (p *AzureInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/16",
 			AutoScalerMin:  3,
 			AutoScalerMax:  20,
-			MaxSurge:       1,
+			MaxSurge:       zonesCount,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				AzureConfig: &gqlschema.AzureProviderConfigInput{

--- a/components/kyma-environment-broker/internal/provider/gcp_provider.go
+++ b/components/kyma-environment-broker/internal/provider/gcp_provider.go
@@ -57,7 +57,7 @@ func (p *GcpInput) Defaults() *gqlschema.ClusterConfigInput {
 			WorkerCidr:     "10.250.0.0/19",
 			AutoScalerMin:  3,
 			AutoScalerMax:  20,
-			MaxSurge:       1,
+			MaxSurge:       zonesCount,
 			MaxUnavailable: 0,
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				GcpConfig: &gqlschema.GCPProviderConfigInput{


### PR DESCRIPTION
**Description**

Due to an [issue present in Gardener machine-controller-manager](https://github.com/gardener/machine-controller-manager/issues/798) (MCM), Kyma runtimes with a worker group using 3 AZs and maxSurge =1 are configured with the below machinedeployments

<html>
<body>
<!--StartFragment-->

MachineDeployment | Zone | maxSurge | maxUnavailable
-- | -- | -- | --
worker-z1 | europe-west1-a | 1 | 0
worker-z2 | europe-west1-b | 0 | 0
worker-z3 | europe-west1-b | 0 | 0

<!--EndFragment-->
</body>
</html>

During a rolling update of the worker groups this leads to nodes in z2 and z3 be drained before ANY new surge nodes being created, which is definitely not what we intended and could cause severe disruptions during maintenance.

This workaround applies one of the (easier) recommendations from the issue to increase the maxSurge to be greater or equal to the number of zones in the worker group.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
