### PR TITLE
bump go version to 1.20.5 in /components/kubeconfig-service

### DIFF
--- a/components/kubeconfig-service/Dockerfile
+++ b/components/kubeconfig-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.4-alpine3.16 as builder
+FROM golang:1.20.5-alpine3.16 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/kubeconfig-service
 ENV CGO_ENABLED 0

--- a/components/kubeconfig-service/Dockerfile
+++ b/components/kubeconfig-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5-alpine3.16 as builder
+FROM golang:1.20.5-alpine3.18 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/kubeconfig-service
 ENV CGO_ENABLED 0

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 
 image:
   repository: europe-docker.pkg.dev/kyma-project/dev/control-plane/kubeconfig-service
-  tag: "PR-2829"
+  tag: "PR-2863"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

This version bump should fix the following Security vulnerabilities in /components/kubeconfig-service: 

BDSA-2023-0791
BDSA-2023-1067
BDSA-2023-1074
BDSA-2023-1078
BDSA-2023-1165
BDSA-2023-1414
BDSA-2023-1417
BDSA-2023-1422
BDSA-2023-1424
CVE-2022-41722
CVE-2022-41723
CVE-2022-41724
CVE-2022-41725
CVE-2023-24532
CVE-2023-24534
CVE-2023-24536
CVE-2023-24537
CVE-2023-24538

**Related issue(s)**
[Protecode MPS security scans dashboard shows few unassigned items. #3964](https://github.tools.sap/kyma/backlog/issues/3964)

























