### PR TITLE
Update the structure of Azure Gardener extensions

### DIFF
--- a/components/provisioner/internal/gardener/provisioner.go
+++ b/components/provisioner/internal/gardener/provisioner.go
@@ -119,7 +119,7 @@ func (g *GardenerProvisioner) UpgradeCluster(clusterID string, upgradeConfig mod
 			return apperr.Append("error during marshaling Shoot data")
 		}
 
-		_, err = g.shootClient.Patch(context.Background(), shoot.Name, types.MergePatchType, shootData, v1.PatchOptions{FieldManager: "provisioner"})
+		_, err = g.shootClient.Patch(context.Background(), shoot.Name, types.ApplyPatchType, shootData, v1.PatchOptions{FieldManager: "provisioner", Force: util.BoolPtr(true)})
 		return err
 	})
 	if err != nil {

--- a/components/provisioner/internal/gardener/provisioner.go
+++ b/components/provisioner/internal/gardener/provisioner.go
@@ -119,7 +119,7 @@ func (g *GardenerProvisioner) UpgradeCluster(clusterID string, upgradeConfig mod
 			return apperr.Append("error during marshaling Shoot data")
 		}
 
-		_, err = g.shootClient.Patch(context.Background(), shoot.Name, types.ApplyPatchType, shootData, v1.PatchOptions{FieldManager: "provisioner", Force: util.BoolPtr(true)})
+		_, err = g.shootClient.Patch(context.Background(), shoot.Name, types.MergePatchType, shootData, v1.PatchOptions{FieldManager: "provisioner"})
 		return err
 	})
 	if err != nil {

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -485,7 +485,7 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 			for i := range infra.Networks.Zones {
 				zone := infra.Networks.Zones[i]
 				if *c.input.EnableNatGateway {
-					zone.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway}
+					zone.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway, IPAddresses: infra.Networks.Zones[i].NatGateway.IPAddresses}
 					zone.NatGateway.IdleConnectionTimeoutMinutes = util.UnwrapIntOrDefault(c.input.IdleConnectionTimeoutMinutes, defaultConnectionTimeOutMinutes)
 				} else {
 					zone.NatGateway = nil

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -475,13 +475,9 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 			return apperrors.Internal("error decoding infrastructure config: %s", err.Error())
 		}
 
-		fmt.Printf("%s", "\n$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n")
-		fmt.Printf("%s\n", string(shoot.Spec.Provider.InfrastructureConfig.Raw))
-		fmt.Printf("%s", "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n")
-
 		if len(c.input.AzureZones) == 0 {
 			if *c.input.EnableNatGateway {
-				infra.Networks.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway}
+				infra.Networks.NatGateway.Enabled = *c.input.EnableNatGateway
 				infra.Networks.NatGateway.IdleConnectionTimeoutMinutes = util.UnwrapIntOrDefault(c.input.IdleConnectionTimeoutMinutes, defaultConnectionTimeOutMinutes)
 			} else {
 				infra.Networks.NatGateway = nil
@@ -490,7 +486,7 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 			for i := range infra.Networks.Zones {
 				zone := infra.Networks.Zones[i]
 				if *c.input.EnableNatGateway {
-					zone.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway}
+					zone.NatGateway.Enabled = *c.input.EnableNatGateway
 					zone.NatGateway.IdleConnectionTimeoutMinutes = util.UnwrapIntOrDefault(c.input.IdleConnectionTimeoutMinutes, defaultConnectionTimeOutMinutes)
 				} else {
 					zone.NatGateway = nil
@@ -500,9 +496,6 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 		}
 		infra.Networks.VNet.CIDR = util.StringPtr(c.input.VnetCidr)
 		jsonData, err := json.Marshal(infra)
-		fmt.Printf("%s", "\n*********************************************************\n")
-		fmt.Printf("%s\n", string(jsonData))
-		fmt.Printf("%s", "*********************************************************\n")
 		if err != nil {
 			return apperrors.Internal("error encoding infrastructure config: %s", err.Error())
 		}

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -474,6 +474,11 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 		if err != nil {
 			return apperrors.Internal("error decoding infrastructure config: %s", err.Error())
 		}
+
+		fmt.Printf("%s", "\n$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n")
+		fmt.Printf("%s\n", string(shoot.Spec.Provider.InfrastructureConfig.Raw))
+		fmt.Printf("%s", "$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$\n")
+
 		if len(c.input.AzureZones) == 0 {
 			if *c.input.EnableNatGateway {
 				infra.Networks.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway}
@@ -485,7 +490,7 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 			for i := range infra.Networks.Zones {
 				zone := infra.Networks.Zones[i]
 				if *c.input.EnableNatGateway {
-					zone.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway, IPAddresses: infra.Networks.Zones[i].NatGateway.IPAddresses}
+					zone.NatGateway = &azure.NatGateway{Enabled: *c.input.EnableNatGateway}
 					zone.NatGateway.IdleConnectionTimeoutMinutes = util.UnwrapIntOrDefault(c.input.IdleConnectionTimeoutMinutes, defaultConnectionTimeOutMinutes)
 				} else {
 					zone.NatGateway = nil
@@ -495,6 +500,9 @@ func (c AzureGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoo
 		}
 		infra.Networks.VNet.CIDR = util.StringPtr(c.input.VnetCidr)
 		jsonData, err := json.Marshal(infra)
+		fmt.Printf("%s", "\n*********************************************************\n")
+		fmt.Printf("%s\n", string(jsonData))
+		fmt.Printf("%s", "*********************************************************\n")
 		if err != nil {
 			return apperrors.Internal("error encoding infrastructure config: %s", err.Error())
 		}

--- a/components/provisioner/internal/model/infrastructure/azure/infrastructure.go
+++ b/components/provisioner/internal/model/infrastructure/azure/infrastructure.go
@@ -42,8 +42,6 @@ type VNet struct {
 	ResourceGroup *string `json:"resourceGroup,omitempty"`
 	// CIDR is the VNet CIDR
 	CIDR *string `json:"cidr,omitempty"`
-	// DDosProtectionPlanID is the id of a ddos protection plan assigned to the vnet.
-	//DDosProtectionPlanID *string `json:"ddosProtectionPlanID,omitempty"`
 }
 
 // VNetStatus contains the VNet name.

--- a/components/provisioner/internal/model/infrastructure/azure/infrastructure.go
+++ b/components/provisioner/internal/model/infrastructure/azure/infrastructure.go
@@ -42,6 +42,8 @@ type VNet struct {
 	ResourceGroup *string `json:"resourceGroup,omitempty"`
 	// CIDR is the VNet CIDR
 	CIDR *string `json:"cidr,omitempty"`
+	// DDosProtectionPlanID is the id of a ddos protection plan assigned to the vnet.
+	//DDosProtectionPlanID *string `json:"ddosProtectionPlanID,omitempty"`
 }
 
 // VNetStatus contains the VNet name.
@@ -53,9 +55,24 @@ type VNetStatus struct {
 }
 
 type NatGateway struct {
-	Enabled                      bool `json:"enabled"`
-	IdleConnectionTimeoutMinutes int  `json:"idleConnectionTimeoutMinutes"`
-	Zone                         int  `json:"zone,omitempty"`
+	// Enabled is an indicator if NAT gateway should be deployed.
+	Enabled bool `json:"enabled"`
+	// IdleConnectionTimeoutMinutes specifies the idle connection timeout limit for NAT gateway in minutes.
+	IdleConnectionTimeoutMinutes int `json:"idleConnectionTimeoutMinutes"`
+	// Zone specifies the zone in which the NAT gateway should be deployed to.
+	Zone int `json:"zone,omitempty"`
+	// IPAddresses is a list of ip addresses which should be assigned to the NAT gateway.
+	IPAddresses []PublicIPReference `json:"ipAddresses,omitempty"`
+}
+
+// PublicIPReference contains information about a public ip.
+type PublicIPReference struct {
+	// Name is the name of the public ip.
+	Name string `json:"name"`
+	// ResourceGroup is the name of the resource group where the public ip is assigned to.
+	ResourceGroup string `json:"resourceGroup"`
+	// Zone is the zone in which the public ip is deployed to.
+	Zone int32 `json:"zone,omitempty"`
 }
 
 type Zone struct {

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,7 +3,7 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "PR-2902"
+      version: "PR-2920"
       dir: "dev"
 
 deployment:


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Adapt to Provisioner to prevent it from removing NAT `IPAdresses` fields from the Gardener Shoot object by changing the way of handling `EnableNatGateway` struct.


Changes proposed in this pull request:

- prevent Provisioner from removing NAT `IPAdresses`fields from the Gardener Shoot object

**Related issue(s)**
#2901 