### PR TITLE
Change TW codeowners to team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -53,4 +53,4 @@
 /components/reconciler @kwiatekus @cortey @jeremyharisch @khlifi411 @Tomasz-Smelcerz-SAP @ruanxin 
 
 # All .md files
-*.md @mmitoraj @NHingerl @grego952 @IwonaLanger @nataliasitko
+*.md @kyma-project/technical-writers


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

Use github teams for TW in codeowners