### PR TITLE
Add versions to kcp chart deps

### DIFF
--- a/resources/kcp/Chart.yaml
+++ b/resources/kcp/Chart.yaml
@@ -7,13 +7,19 @@ type: application
 dependencies:
 - name: postgresql
   condition: global.database.embedded.enabled
+  version: 5.3.11
 - name: provisioner
   condition: global.provisioning.enabled
+  version: 0.1.0
 - name: kyma-environment-broker
   condition: global.kyma_environment_broker.enabled
+  version: 0.1.0
 - name: kyma-metrics-collector
   condition: global.kyma_metrics_collector.enabled
+  version: 0.1.0
 - name: mothership-reconciler
   condition: global.mothership_reconciler.enabled
+  version: 0.1.0
 - name: component-reconcilers
   condition: global.component_reconcilers.enabled
+  version: 0.1.0


### PR DESCRIPTION
With the latest piper-lib and helm the build fails with:
```
Error: dependency "postgresql" has an invalid version/constraint format: improper constraint: 
```

This PR fixis this by adding the subcharts' version to the main chart's deps.
