### PR TITLE
Make env-vars configurable

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/deployment.yaml
@@ -101,6 +101,10 @@ spec:
         {{- if ($.Values.global.mothership_reconciler.features) }}
         {{- ($.Values.global.mothership_reconciler.features) | nindent 8 }}
         {{- end }}
+        {{- range .Values.skippedComponents}}
+        - name: "SKIP_COMPONENT_{{ regexReplaceAll "-" . "_"  | upper }}"
+          value: "true"
+        {{- end}}
         name: mothership-reconciler
         ports:
         - name: http

--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -1,4 +1,15 @@
 global:
+  database:
+    embedded:
+      enabled: true
+    managedGCP:
+      sslRootCert: ""
+  mothership_reconciler:
+    auditlog:
+      persistence:
+        enabled: false
+      enabled: false
+    expose: false
   images:
     cloudsql_proxy_image: "europe-docker.pkg.dev/kyma-project/prod/tpi/cloudsql-docker/gce-proxy:v1.33.8-afb993b8"
     mothership_reconciler: "europe-docker.pkg.dev/kyma-project/prod/incubator/reconciler/mothership:v20230720-32bfb537"
@@ -167,3 +178,6 @@ componentCRDs:
     group: operator.kyma-project.io
     version: v1alpha2
     kind: istios
+
+# these components will NEVER be reconciled
+skippedComponents: []

--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -1,15 +1,4 @@
 global:
-  database:
-    embedded:
-      enabled: true
-    managedGCP:
-      sslRootCert: ""
-  mothership_reconciler:
-    auditlog:
-      persistence:
-        enabled: false
-      enabled: false
-    expose: false
   images:
     cloudsql_proxy_image: "europe-docker.pkg.dev/kyma-project/prod/tpi/cloudsql-docker/gce-proxy:v1.33.8-afb993b8"
     mothership_reconciler: "europe-docker.pkg.dev/kyma-project/prod/incubator/reconciler/mothership:v20230720-32bfb537"


### PR DESCRIPTION
Allows the mothership to skip some components if needed

Relates to https://github.com/kyma-incubator/reconciler/pull/1377