### PR TITLE
Update golang builder image for Provisioner to version 1.20.6-alpine3.18

### DIFF
--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
+FROM golang:1.20.6-alpine3.18 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/kyma-project/external/golang:1.20.3-alpine3.17 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-alpine3.18 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.5-alpine3.18 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}


### PR DESCRIPTION
Golang builder image from Docker Repo `golang:1.20.6-alpine3.18`