### PR TITLE
Bump image tag to PR-2916

### DIFF
--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 
 image:
   repository: europe-docker.pkg.dev/kyma-project/dev/control-plane/kubeconfig-service
-  tag: "PR-2863"
+  tag: "PR-2916"
   pullPolicy: Always
 
 config:


### PR DESCRIPTION
Bumps image to `PR-2916`, because previous is not available anymore.
related: https://github.tools.sap/kyma/backlog/issues/4278