### PR TITLE
adds a check for timeout tool for provisioner e2e test

### DIFF
--- a/components/provisioner/e2e_test/test.sh
+++ b/components/provisioner/e2e_test/test.sh
@@ -60,7 +60,6 @@ fi
 
 printf '\n########## SETTING UP PROVISIONER ##########\n\n'
 
-
 sleep 20
 
 docker network create $POSTGRES_NETWORK

--- a/components/provisioner/e2e_test/test.sh
+++ b/components/provisioner/e2e_test/test.sh
@@ -33,6 +33,12 @@ function has_to_succeed {
 function wait_for {
     echo "Waiting $1 to launch on $2"
 
+
+    if ! which timeout ; then
+        printf '\n Please install timeout; e.g. in MacOs you can use `brew install coreutils` \n\n'
+        exit 2
+    fi
+
     while ! timeout 1 bash -c "echo 2>>/dev/null > /dev/tcp/localhost/$2" ; do   
 	printf '.'
 	sleep 2
@@ -53,6 +59,7 @@ if which service; then
 fi
 
 printf '\n########## SETTING UP PROVISIONER ##########\n\n'
+
 
 sleep 20
 

--- a/components/provisioner/e2e_test/test.sh
+++ b/components/provisioner/e2e_test/test.sh
@@ -36,7 +36,7 @@ function wait_for {
 
     if ! which timeout ; then
         printf '\n Please install timeout; e.g. in MacOs you can use `brew install coreutils` \n\n'
-        exit 2
+        exit 1
     fi
 
     while ! timeout 1 bash -c "echo 2>>/dev/null > /dev/tcp/localhost/$2" ; do   


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- checks if `timeout` is installed and gives a MacOs hint if not
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
