### PR TITLE
adds git ignore for migration files generated by provisioner e2e tests

### DIFF
--- a/components/provisioner/.gitignore
+++ b/components/provisioner/.gitignore
@@ -4,3 +4,4 @@ vendor
 /licenses
 /.hydroform
 /dev
+/e2e_test/migrations/


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- adds git ignore for migration files generated by provisioner e2e tests
-
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/test-infra/issues/7662