### PR TITLE
Kubeconfig chart updates

### DIFF
--- a/resources/oidc-kubeconfig-service/Chart.yaml
+++ b/resources/oidc-kubeconfig-service/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: oidc-kubeconfig-service

--- a/resources/oidc-kubeconfig-service/templates/deployment.yaml
+++ b/resources/oidc-kubeconfig-service/templates/deployment.yaml
@@ -46,7 +46,11 @@ spec:
             - name: OIDC_KUBECONFIG_CLIENT_ID
               value: {{ .Values.config.oidc.kubeconfig.client | quote }}
             - name: OIDC_ISSUER_URL
-              value: {{ tpl .Values.config.oidc.issuer $ | quote }}
+              {{- if .Values.config.oidc.issuer }}
+              value: {{ .Values.config.oidc.issuer | quote }}
+              {{- else }}
+              value: "https://dex.{{ .Values.global.ingress.domainName }}"
+              {{- end }}
             - name: OIDC_CLIENT_ID
               value: {{ .Values.config.oidc.client }}
             {{- with .Values.config.oidc.caFile }}

--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -35,7 +35,7 @@ config:
       issuer: https://kymatest.accounts400.ondemand.com
       client: 1234-5678-qwer
     client: compass-ui
-    issuer: https://dex.{{ .Values.global.ingress.domainName }}
+    issuer: ~
     # caFile: /etc/dex-tls-cert/tls.crt
 
 


### PR DESCRIPTION
Updates to oidc-kubeconfig-service:

 - Bump the Chart.yaml's apiVersion to v2
 - Move the template out of values.yaml

Reason: newer piperlib's helmExecute is getting stuck on it
