### PR TITLE
Fix Deprovision_AVS_Evaluations step

### DIFF
--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -170,7 +170,7 @@ func (c *Client) RemoveReferenceFromParentEval(parentID, evaluationID int64) (er
 				err = kebError.AsTemporaryError(closeErr, "while closing body")
 			}
 		}()
-		var responseObject avsNonSuccessResp
+		var responseObject avsApiErrorResp
 		err := json.NewDecoder(response.Body).Decode(&responseObject)
 		if err != nil {
 			msg, e := io.ReadAll(response.Body)

--- a/components/kyma-environment-broker/internal/avs/client.go
+++ b/components/kyma-environment-broker/internal/avs/client.go
@@ -164,29 +164,26 @@ func (c *Client) RemoveReferenceFromParentEval(parentID, evaluationID int64) (er
 		return nil
 	}
 
-	if response != nil && response.StatusCode == http.StatusBadRequest && response.Body != nil {
+	if response != nil && response.StatusCode == http.StatusBadRequest {
 		defer func() {
 			if closeErr := c.closeResponseBody(response); closeErr != nil {
 				err = kebError.AsTemporaryError(closeErr, "while closing body")
 			}
 		}()
-		var responseObject avsApiErrorResp
-		err := json.NewDecoder(response.Body).Decode(&responseObject)
+		buff, err := io.ReadAll(response.Body)
 		if err != nil {
-			msg, e := io.ReadAll(response.Body)
-			if e != nil {
-				msg = []byte("unable to read the response body")
-			} else {
-				if strings.Contains(strings.ToLower(string(msg)), "does not contain subevaluation") {
-					return nil
-				}
-			}
-			return fmt.Errorf("while decoding avs non success response body for ID: %d, URL: %s, message: %s: %w",
-				evaluationID, absoluteURL, string(msg), err)
+			return fmt.Errorf("unable to read the response body: %w", err)
+		}
+		var responseObject avsApiErrorResp
+		err = json.NewDecoder(bytes.NewReader(buff)).Decode(&responseObject)
+		if err != nil {
+			return fmt.Errorf("while decoding AvS non success response body for ID: %d, URL: %s, error: %w",
+				evaluationID, absoluteURL, err)
 		}
 		if strings.Contains(strings.ToLower(responseObject.Message), "does not contain subevaluation") {
 			return nil
 		}
+		return fmt.Errorf("unable to delete subevaluation %d reference from the parent evaluation: %s", evaluationID, responseObject.Message)
 	}
 	return fmt.Errorf("unexpected response for evaluationId: %d while deleting reference from parent evaluation, error: %w", evaluationID, err)
 }
@@ -258,8 +255,7 @@ func (c *Client) execute(request *http.Request, allowNotFound bool, allowResetTo
 		return response, NewAvsError("avs server returned %d status code twice for %s", http.StatusUnauthorized, request.URL.String())
 	}
 
-	message, _ := io.ReadAll(response.Body)
-	return response, NewAvsError("unsupported status code: %d for %s. Message: %s", response.StatusCode, request.URL.String(), string(message))
+	return response, NewAvsError("unsupported status code: %d for %s.", response.StatusCode, request.URL.String())
 }
 
 func (c *Client) closeResponseBody(response *http.Response) error {
@@ -270,7 +266,7 @@ func (c *Client) closeResponseBody(response *http.Response) error {
 		return nil
 	}
 	// drain the body to let the transport reuse the connection
-	io.Copy(ioutil.Discard, response.Body)
+	io.Copy(io.Discard, response.Body)
 
 	return response.Body.Close()
 }

--- a/components/kyma-environment-broker/internal/avs/delegator.go
+++ b/components/kyma-environment-broker/internal/avs/delegator.go
@@ -18,9 +18,10 @@ type Delegator struct {
 	operationsStorage storage.Operations
 }
 
-type avsNonSuccessResp struct {
-	Status  int    `json:"status"`
-	Message string `json:"message"`
+type avsApiErrorResp struct {
+	StatusCode int    `json:"statusCode"`
+	Status     string `json:"status"`
+	Message    string `json:"message"`
 }
 
 func NewDelegator(client *Client, avsConfig Config, os storage.Operations) *Delegator {

--- a/components/kyma-environment-broker/internal/avs/mock_server.go
+++ b/components/kyma-environment-broker/internal/avs/mock_server.go
@@ -243,9 +243,10 @@ func (s *MockAvsServer) removeReferenceFromParentEval(w http.ResponseWriter, r *
 
 	_, exists := s.Evaluations.ParentIDrefs[parentID]
 	if !exists {
-		resp := avsNonSuccessResp{
-			Status:  http.StatusBadRequest,
-			Message: fmt.Sprintf("Evaluation %d does not contain subevaluation %d", parentID, evalID),
+		resp := avsApiErrorResp{
+			StatusCode: http.StatusBadRequest,
+			Status:     "BAD_REQUEST",
+			Message:    fmt.Sprintf("Evaluation %d does not contain subevaluation %d", parentID, evalID),
 		}
 		bytes, _ := json.Marshal(resp)
 		_, err := w.Write(bytes)

--- a/components/kyma-environment-broker/internal/avs/mock_server.go
+++ b/components/kyma-environment-broker/internal/avs/mock_server.go
@@ -248,10 +248,10 @@ func (s *MockAvsServer) removeReferenceFromParentEval(w http.ResponseWriter, r *
 			Status:     "BAD_REQUEST",
 			Message:    fmt.Sprintf("Evaluation %d does not contain subevaluation %d", parentID, evalID),
 		}
+		w.WriteHeader(http.StatusBadRequest)
 		bytes, _ := json.Marshal(resp)
 		_, err := w.Write(bytes)
 		assert.NoError(s.T, err)
-		w.WriteHeader(http.StatusBadRequest)
 	}
 
 	s.Evaluations.removeParentRef(parentID, evalID)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- update AvS API server response struct,
- fix a bug when reading the response body too many times prior to logging produces EOF message,
- fix mock server response for unit test.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Resolves #2665 