### PR TITLE
Use production images for kubeconfig-service

### DIFF
--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -22,9 +22,9 @@ global:
 replicaCount: 1
 
 image:
-  repository: europe-docker.pkg.dev/kyma-project/dev/control-plane/kubeconfig-service
-  tag: "PR-2916"
-  pullPolicy: Always
+  repository: europe-docker.pkg.dev/kyma-project/prod/control-plane/kubeconfig-service
+  tag: "v20230825-ee8c3e31"
+  pullPolicy: IfNotPresent
 
 config:
   servicePort: 9090


### PR DESCRIPTION
The dev images are being phased out, and this continuously breaks kubeconfig-service. Right now the image specified in the chart doesn't exist anymore.

This PR switches the chart to use prod images instead of PR builds, which are retained.
