### PR TITLE
Adds option VMServiceScrape generation

### DIFF
--- a/resources/kcp/charts/component-reconcilers/templates/service-monitor.yaml
+++ b/resources/kcp/charts/component-reconcilers/templates/service-monitor.yaml
@@ -1,5 +1,6 @@
 {{- range $component := .Values.global.components }}
 {{ if $.Values.serviceMonitor.enabled }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -18,6 +19,27 @@ spec:
   selector:
     matchLabels:
       component: {{ $component }}
+{{- end }}
+{{- if and ($.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") $.Values.vmscrapes.enabled }}
 ---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  name: {{ $component }}-reconciler
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    component: {{ $component }}
+spec:
+  endpoints:
+  - attach_metadata: {}
+    port: http
+    interval: {{ $.Values.vmscrapes.interval }}
+    scrapeTimeout: {{ $.Values.vmscrapes.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ $.Release.Namespace }}
+  selector:
+    matchLabels:
+      component: {{ $component }}
 {{- end }}
 {{- end }}

--- a/resources/kcp/charts/component-reconcilers/values.yaml
+++ b/resources/kcp/charts/component-reconcilers/values.yaml
@@ -29,5 +29,11 @@ service:
 # disable here to bypass deploy AuthorizationPolicy and ServiceMonitor in Pipeline Cluster
 serviceMonitor:
   enabled: false
-  scrapeTimeout: 30s
-  interval: 60s
+  scrapeTimeout: &scrapeTimeout 30s
+  interval: &scrapeInterval 60s
+
+vmscrapes:
+  enabled: false
+  scrapeTimeout: *scrapeTimeout
+  interval: *scrapeInterval
+

--- a/resources/kcp/charts/kyma-environment-broker/templates/service-monitor.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/service-monitor.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
 {{ include "kyma-env-broker.labels" . | indent 4 }}
   name: {{ include "kyma-env-broker.fullname" . }}
-  namespace: kcp-system
+  namespace: {{ .Release.Namespace }}
 spec:
   endpoints:
   - port: http
@@ -12,7 +13,29 @@ spec:
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
   namespaceSelector:
     matchNames:
-    - kcp-system
+    - {{ .Release.Namespace }}
   selector:
     matchLabels:
 {{ include "kyma-env-broker.labels" . | indent 8 }}
+{{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  labels:
+{{ include "kyma-env-broker.labels" . | indent 4 }}
+  name: {{ include "kyma-env-broker.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - attach_metadata: {}
+    port: http
+    interval: {{ .Values.vmscrapes.interval }}
+    scrapeTimeout: {{ .Values.vmscrapes.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{ include "kyma-env-broker.labels" . | indent 8 }}
+{{- end }}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -286,8 +286,13 @@ deprovisionRetrigger:
   #   - APP_DRY_RUN: "{{ .Values.deprovisionRetrigger.dryRun }}"
 
 serviceMonitor:
-  scrapeTimeout: 10s
-  interval: 30s
+  scrapeTimeout: &scrapeTimeout 10s
+  interval: &scrapeInterval 30s
+
+vmscrapes:
+  enabled: false
+  scrapeTimeout: *scrapeTimeout
+  interval: *scrapeInterval
 
 dashboardConfig:
   landscapeURL: "https://dashboard.dev.kyma.cloud.sap"

--- a/resources/kcp/charts/kyma-metrics-collector/templates/service-monitor.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/service-monitor.yaml
@@ -1,3 +1,5 @@
+{{- if .Values.global.kyma_metrics_collector.enabled -}}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -14,3 +16,28 @@ spec:
   selector:
     matchLabels:
 {{ include "kyma-metrics-collector.labels" . | indent 8 }}
+{{- end }}
+
+{{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled .Values.global.kyma_metrics_collector.enabled }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  labels:
+{{ include "kyma-metrics-collector.labels" . | indent 4 }}
+  name: {{ include "kyma-metrics-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+    - attach_metadata: {}
+      port: http
+      interval: {{ .Values.vmscrapes.interval }}
+      scrapeTimeout: {{ .Values.vmscrapes.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+{{ include "kyma-metrics-collector.labels" . | indent 6 }}
+{{- end }}

--- a/resources/kcp/charts/kyma-metrics-collector/templates/service.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/service.yaml
@@ -6,6 +6,7 @@ metadata:
     app: {{ .Chart.Name }}
 {{ include "kyma-metrics-collector.labels" . | indent 4 }}
   name: {{ template "kyma-metrics-collector.fullname" . }}
+  namespace: {{ .Release.Namespace }}
 spec:
   ports:
   - name: {{ .Values.service.name }}

--- a/resources/kcp/charts/kyma-metrics-collector/values.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/values.yaml
@@ -7,6 +7,11 @@ global:
 nameOverride: ""
 fullnameOverride: ""
 
+vmscrapes:
+  enabled: false
+  scrapeTimeout: 10s
+  interval: 30s
+
 image:
   # these override the values from global chart
   repository: ""

--- a/resources/kcp/charts/mothership-reconciler/templates/service-monitor.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/service-monitor.yaml
@@ -1,4 +1,5 @@
 {{ if .Values.serviceMonitor.enabled }}
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -14,6 +15,39 @@ spec:
   - port: fluentbit
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+    path: /api/v1/metrics/prometheus
+    metricRelabelings:
+      - action: keep
+        regex: ^(fluentbit_.*|go_.*|process_.*)$
+        sourceLabels:
+          - __name__
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{ include "mothership-reconciler.labels" . | indent 6 }}
+{{- end }}
+
+{{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  labels:
+{{ include "mothership-reconciler.labels" . | indent 4 }}
+  name: {{ include "mothership-reconciler.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - attach_metadata: {}
+    port: http
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.vmscrapes.scrapeTimeout }}
+  - attach_metadata: {}
+    port: fluentbit
+    interval: {{ .Values.vmscrapes.interval }}
+    scrapeTimeout: {{ .Values.vmscrapes.scrapeTimeout }}
     path: /api/v1/metrics/prometheus
     metricRelabelings:
       - action: keep

--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -141,8 +141,13 @@ fluentbit:
 # disable here to bypass deploy AuthorizationPolicy and ServiceMonitor in Pipeline Cluster
 serviceMonitor:
   enabled: false
-  scrapeTimeout: 30s
-  interval: 60s
+  scrapeTimeout: &scrapeTimeout 30s
+  interval: &scrapeInterval 60s
+
+vmscrapes:
+  enabled: false
+  scrapeTimeout: *scrapeTimeout
+  interval: *scrapeInterval
 
 # needs to be enabled in https://github.tools.sap/kyma/management-plane-config/blob/master/resources/control-plane/config/base/kcp.yaml
 # by default purgeOlderThan (old cleaner script) is activated

--- a/resources/kcp/charts/provisioner/templates/service-monitor.yaml
+++ b/resources/kcp/charts/provisioner/templates/service-monitor.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -16,3 +17,28 @@ spec:
     matchLabels:
       app: {{ .Chart.Name }}
       release: {{ .Release.Name }}
+
+{{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled }}
+---
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMServiceScrape
+metadata:
+  labels:
+    app: {{ .Chart.Name }}
+    release: {{ .Release.Name }}
+  name: {{ template "fullname" . }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  endpoints:
+  - attach_metadata: {}
+    port: http-metrics
+    interval: {{ .Values.vmscrapes.interval }}
+    scrapeTimeout: {{ .Values.vmscrapes.scrapeTimeout }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -6,6 +6,11 @@ global:
       version: "PR-2979"
       dir: "dev"
 
+vmscrapes:
+  enabled: false
+  scrapeTimeout: 10s
+  interval: 30s
+
 deployment:
   replicaCount: 1
   image:


### PR DESCRIPTION
**Description**

This PR adds optional generation of `VMServiceScrape` manifests for direct monitoring with victoriametrics. Everything is conditional on two points:

 1. `VMServiceScrape` manifests are only generated if the APIVersion is available through helm's `.Capabilities.APIVersions`
 2. is explicitly enabled using `vmscrapes.enabled` in the values

