### PR TITLE
Update kcp config to use provisioner image from prod

### DIFF
--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,8 +3,8 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "PR-2979"
-      dir: "dev"
+      version: "v20230830-022128f8"
+      dir: "prod"
 
 vmscrapes:
   enabled: false


### PR DESCRIPTION
This change sets image tag to prod `v20230830-022128f8` which is respective to `PR-2979` on dev