### PR TITLE
Adding talszabi to kubeconfig-service and kcp-cli code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -43,11 +43,11 @@
 /components/kyma-metrics-collector @kyma-project/eventing
 
 # OIDC-Kubeconfig-Service
-/components/kubeconfig-service @ebensom @lumi017 @AdrianPei @gczuczy @i332322 @zralt
-/resources/oidc-kubeconfig-service  @ebensom @lumi017 @AdrianPei @gczuczy @i332322 @zralt
+/components/kubeconfig-service @ebensom @lumi017 @AdrianPei @gczuczy @i332322 @zralt @talszabi
+/resources/oidc-kubeconfig-service  @ebensom @lumi017 @AdrianPei @gczuczy @i332322 @zralt @talszabi
 
 # KCP CLI
-/tools/cli @ebensom @lumi017 @kwiatekus @cortey @kyma-project/gopher @gczuczy @i332322 @zralt
+/tools/cli @ebensom @lumi017 @kwiatekus @cortey @kyma-project/gopher @gczuczy @i332322 @zralt @talszabi
 
 # reconciler
 /components/reconciler @kwiatekus @cortey @jeremyharisch @khlifi411 @Tomasz-Smelcerz-SAP @ruanxin 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

Add access to talszabi for the following components: 
- kubeconfig-service
- kcp-cli


**Related issue(s)**
-
