### PR TITLE
Bumping the image in kubeconfig-service chart to v20230927-3979470d

### DIFF
--- a/resources/oidc-kubeconfig-service/values.yaml
+++ b/resources/oidc-kubeconfig-service/values.yaml
@@ -23,7 +23,7 @@ replicaCount: 1
 
 image:
   repository: europe-docker.pkg.dev/kyma-project/prod/control-plane/kubeconfig-service
-  tag: "v20230825-ee8c3e31"
+  tag: "v20230927-3979470d"
   pullPolicy: IfNotPresent
 
 config:


### PR DESCRIPTION
**Description**

Bumping the kubeconfig-service image version to the latest which merges the recent go deps update opened by dependabot

Changes proposed in this pull request:
following PRs will be applied: 
- gomod(deps): bump github.com/smartystreets/goconvey from 1.8.0 to 1.8.1 in /components/kubeconfig-service #2890
- gomod(deps): bump golang.org/x/oauth2 from 0.8.0 to 0.12.0 in /components/kubeconfig-service #3050
- docker(deps): bump golang from 1.20.5-alpine3.18 to 1.21.1-alpine3.18 in /components/kubeconfig-service #3056

