### PR TITLE
Fix for provisioned shoot DNS

### DIFF
--- a/components/provisioner/internal/provisioning/graphql_converter_test.go
+++ b/components/provisioner/internal/provisioning/graphql_converter_test.go
@@ -201,7 +201,7 @@ func TestRuntimeStatusToGraphQLStatus(t *testing.T) {
 						Domain: "verylon.devtest.kyma.ondemand.com",
 						Providers: []*gqlschema.DNSProvider{
 							{
-								DomainsInclude: []string{"devtest.kyma.ondemand.com"},
+								DomainsInclude: []string{"verylon.devtest.kyma.ondemand.com"},
 								Primary:        true,
 								SecretName:     "aws_dns_domain_secrets_test_inconverter",
 								Type:           "route53_type_test",

--- a/components/provisioner/internal/provisioning/input_converter.go
+++ b/components/provisioner/internal/provisioning/input_converter.go
@@ -140,10 +140,11 @@ func dnsConfigFromInput(input *gqlschema.DNSConfigInput) *model.DNSConfig {
 	config := model.DNSConfig{}
 	if input != nil {
 		config.Domain = input.Domain
+
 		if len(input.Providers) != 0 {
 			for _, v := range input.Providers {
 				config.Providers = append(config.Providers, &model.DNSProvider{
-					DomainsInclude: v.DomainsInclude,
+					DomainsInclude: []string{input.Domain},
 					Primary:        v.Primary,
 					SecretName:     v.SecretName,
 					Type:           v.Type,

--- a/components/provisioner/internal/provisioning/input_converter.go
+++ b/components/provisioner/internal/provisioning/input_converter.go
@@ -144,6 +144,8 @@ func dnsConfigFromInput(input *gqlschema.DNSConfigInput) *model.DNSConfig {
 		if len(input.Providers) != 0 {
 			for _, v := range input.Providers {
 				config.Providers = append(config.Providers, &model.DNSProvider{
+					// after KEB fix it - restore original code
+					// DomainsInclude: v.DomainsInclude,
 					DomainsInclude: []string{input.Domain},
 					Primary:        v.Primary,
 					SecretName:     v.SecretName,

--- a/components/provisioner/internal/provisioning/input_converter_test.go
+++ b/components/provisioner/internal/provisioning/input_converter_test.go
@@ -513,7 +513,7 @@ func dnsConfig() *model.DNSConfig {
 		Domain: "verylon.devtest.kyma.ondemand.com",
 		Providers: []*model.DNSProvider{
 			{
-				DomainsInclude: []string{"devtest.kyma.ondemand.com"},
+				DomainsInclude: []string{"verylon.devtest.kyma.ondemand.com"},
 				Primary:        true,
 				SecretName:     "aws_dns_domain_secrets_test_inconverter",
 				Type:           "route53_type_test",


### PR DESCRIPTION
**Description**

The value `domains.include` in DNS config should contain only one value with the full shoot domain name.

This is just overriding the value passed by KEB. The final fix must be done on the KEB side since on KEB side the initial DNS providers configuration is created and Provisioner just stores this value. The proposed solution just ignores this value from KEB and use shootDomain as single `domains.include` entry.

After the fix - this PR can be reverted