### PR TITLE
Add option for additional gateways

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/virtualservice.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/virtualservice.yaml
@@ -1,10 +1,15 @@
-apiVersion: networking.istio.io/v1alpha3
+{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1" }}
+---
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{ template "fullname" . }}
 spec:
   gateways:
-  - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+    - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+    {{- if .Values.global.istio.additionalGateways }}
+    {{ toYaml .Values.global.istio.additionalGateways | nindent 4 }}
+    {{- end }}
   hosts:
   - {{ .Values.host }}.{{ .Values.global.ingress.domainName }}
   http:
@@ -163,3 +168,4 @@ spec:
           port:
             number: 80
   {{ end }}
+{{- end }}

--- a/resources/kcp/charts/mothership-reconciler/templates/virtualservice.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/virtualservice.yaml
@@ -1,11 +1,15 @@
-{{ if .Values.global.mothership_reconciler.expose }}
-apiVersion: networking.istio.io/v1alpha3
+{{- if and .Values.global.mothership_reconciler.expose (.Capabilities.APIVersions.Has "networking.istio.io/v1beta1") }}
+---
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{ template "fullname" . }}
 spec:
   gateways:
-  - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+    - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+    {{- if .Values.global.istio.additionalGateways }}
+    {{ toYaml .Values.global.istio.additionalGateways | nindent 4 }}
+    {{- end }}
   hosts:
   - {{ .Values.host }}.{{ .Values.global.ingress.domainName }}
   http:

--- a/resources/kcp/charts/provisioner/templates/virtual-service.yaml
+++ b/resources/kcp/charts/provisioner/templates/virtual-service.yaml
@@ -1,4 +1,6 @@
-apiVersion: networking.istio.io/v1alpha3
+{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1" }}
+---
+apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
 metadata:
   name: {{ template "fullname" . }}
@@ -14,6 +16,9 @@ spec:
     - provisioner.{{ .Values.global.ingress.domainName }}
   gateways:
     - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+    {{- if .Values.global.istio.additionalGateways }}
+    {{ toYaml .Values.global.istio.additionalGateways | nindent 4 }}
+    {{- end }}
   http:
       - match:
         - uri:
@@ -23,3 +28,4 @@ spec:
               port:
                 number: {{ .Values.global.provisioner.graphql.port }}
               host: {{ template "fullname" . }}
+{{- end }}

--- a/resources/oidc-kubeconfig-service/templates/virutalservice.yaml
+++ b/resources/oidc-kubeconfig-service/templates/virutalservice.yaml
@@ -1,6 +1,6 @@
-{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1alpha3" }}
+{{- if .Capabilities.APIVersions.Has "networking.istio.io/v1beta1" }}
 ---
-apiVersion: networking.istio.io/v1alpha3
+apiVersion: networking.istio.io/v1abeta1
 kind: VirtualService
 metadata:
   name: {{ template "oidc-kubeconfig-service.fullname" . }}
@@ -11,6 +11,9 @@ spec:
     - {{ .Values.service.hostname }}.{{ .Values.global.ingress.domainName }}
   gateways:
     - {{ .Values.global.istio.gateway.namespace }}/{{ .Values.global.istio.gateway.name }}
+    {{- if .Values.global.istio.additionalGateways }}
+    {{ toYaml .Values.global.istio.additionalGateways | nindent 4 }}
+    {{- end }}
   http:
     - match:
         - uri:


### PR DESCRIPTION
We need to have multiple gateways defined in the VirtualServices, this patch adds this functionality:

```
$ helm template --kube-version 1.27.0 --api-versions $(cat $apiver) -f ~/tmp/global-istio-gw.yaml oidc-kubeconfig-service/ | yq 'select(.kind == "VirtualService").spec.gateways'
- kyma-system/kyma-gateway
- mostrum/ridcully
$ helm template --kube-version 1.27.0 --api-versions $(cat $apiver) -f ~/tmp/global-istio-gw.yaml -f ~/tmp/kcp-defvalues.yaml -f ~/tmp/kcp-values.yaml kcp/ | yq 'select(.kind == "VirtualService").spec.gateways'
- kyma-system/kyma-gateway
- mostrum/ridcully
---
- kyma-system/kyma-gateway
- mostrum/ridcully
---
- kyma-system/kyma-gateway
- mostrum/ridcully
```

Also, VirtualGateway apiVersions are updated to v1beta1, as that's the current one with isito.
