### PR TITLE
Make all kcp servicemonitors conditional

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/service-monitor.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/service-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -17,6 +18,7 @@ spec:
   selector:
     matchLabels:
 {{ include "kyma-env-broker.labels" . | indent 8 }}
+{{- end }}
 {{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -292,6 +292,7 @@ deprovisionRetrigger:
   #   - APP_DRY_RUN: "{{ .Values.deprovisionRetrigger.dryRun }}"
 
 serviceMonitor:
+  enabled: true
   scrapeTimeout: &scrapeTimeout 10s
   interval: &scrapeInterval 30s
 

--- a/resources/kcp/charts/kyma-metrics-collector/templates/service-monitor.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/service-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.kyma_metrics_collector.enabled -}}
+{{- if .Values.serviceMonitor.enabled -}}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -18,7 +18,7 @@ spec:
 {{ include "kyma-metrics-collector.labels" . | indent 8 }}
 {{- end }}
 
-{{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled .Values.global.kyma_metrics_collector.enabled }}
+{{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1
 kind: VMServiceScrape

--- a/resources/kcp/charts/kyma-metrics-collector/values.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/values.yaml
@@ -7,10 +7,15 @@ global:
 nameOverride: ""
 fullnameOverride: ""
 
+serviceMonitor:
+  enabled: true
+  scrapeTimeout: &scrapeTimeout 10s
+  interval: &scrapeInterval 30s
+
 vmscrapes:
   enabled: false
-  scrapeTimeout: 10s
-  interval: 30s
+  scrapeTimeout: *scrapeTimeout
+  interval: *scrapeInterval
 
 image:
   # these override the values from global chart

--- a/resources/kcp/charts/mothership-reconciler/templates/service-monitor.yaml
+++ b/resources/kcp/charts/mothership-reconciler/templates/service-monitor.yaml
@@ -49,7 +49,7 @@ spec:
     interval: {{ .Values.vmscrapes.interval }}
     scrapeTimeout: {{ .Values.vmscrapes.scrapeTimeout }}
     path: /api/v1/metrics/prometheus
-    metricRelabelings:
+    metricRelabelConfigs:
       - action: keep
         regex: ^(fluentbit_.*|go_.*|process_.*)$
         sourceLabels:

--- a/resources/kcp/charts/provisioner/templates/service-monitor.yaml
+++ b/resources/kcp/charts/provisioner/templates/service-monitor.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.serviceMonitor.enabled }}
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
@@ -17,7 +18,7 @@ spec:
     matchLabels:
       app: {{ .Chart.Name }}
       release: {{ .Release.Name }}
-
+{{- end }}
 {{- if and (.Capabilities.APIVersions.Has "operator.victoriametrics.com/v1beta1/VMServiceScrape") .Values.vmscrapes.enabled }}
 ---
 apiVersion: operator.victoriametrics.com/v1beta1

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -5,10 +5,14 @@ global:
     provisioner:
       version: "v20230930-6fff193f"
       dir: "prod"
+serviceMonitor:
+  enabled: true
+  scrapeTimeout: &scrapeTimeout 10s
+  interval: &scrapeInterval 30s
 vmscrapes:
   enabled: false
-  scrapeTimeout: 10s
-  interval: 30s
+  scrapeTimeout: *scrapeTimeout
+  interval: *scrapeInterval
 deployment:
   replicaCount: 1
   image:


### PR DESCRIPTION
**Description**

Ensure all ServiceMonitor CRs can be conditionally rendered based on Helm variable. 
This is needed to be able to disable all kcp ServiceMonitoris once the migration from prometheus-operator (Kyma monitoring component) is completed. 