### PR TITLE
KEB: don't provide GardenerShootName AvS tag

### DIFF
--- a/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/deployment.yaml
@@ -302,8 +302,6 @@ spec:
               value: "{{ .Values.avs.providerTagClassId }}"
             - name: APP_AVS_SHOOT_NAME_TAG_CLASS_ID
               value: "{{ .Values.avs.shootNameTagClassId }}"
-            - name: APP_AVS_GARDENER_SHOOT_NAME_TAG_CLASS_ID
-              value: "{{ .Values.avs.gardenerShootNameTagClassId }}"
             - name: APP_AVS_MAINTENANCE_MODE_DURING_UPGRADE_DISABLED
               value: "{{ .Values.avs.maintenanceModeDuringUpgrade.disabled }}"
             - name: APP_AVS_MAINTENANCE_MODE_DURING_UPGRADE_ALWAYS_DISABLED_GLOBAL_ACCOUNTS_FILE_PATH
@@ -456,7 +454,7 @@ spec:
       - name: cloudsql-sslrootcert
         secret:
           secretName: kcp-postgresql
-          items: 
+          items:
           - key: postgresql-sslRootCert
             path: server-ca.pem
           optional: true

--- a/resources/kcp/charts/kyma-environment-broker/templates/secrets.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/templates/secrets.yaml
@@ -11,8 +11,6 @@ data:
   externalTesterAccessId: {{ .Values.avs.externalTesterAccessId | b64enc | quote }}
   internalTesterService: {{ .Values.avs.internalTesterService | b64enc | quote }}
   externalTesterService: {{ .Values.avs.externalTesterService | b64enc | quote }}
-  internalTesterTags: {{ include "avs.utils.joinTags" .Values.avs.internalTesterTags | b64enc | quote }}
-  externalTesterTags: {{ include "avs.utils.joinTags" .Values.avs.externalTesterTags | b64enc | quote }}
   groupId: {{ .Values.avs.groupId | b64enc | quote }}
   parentId: {{ .Values.avs.parentId | b64enc | quote }}
   trialApiKey: {{ .Values.avs.trialApiKey | b64enc | quote }}

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -204,8 +204,6 @@ avs:
   providerTagClassId: "0"
   regionTagClassId: "0"
   shootNameTagClassId: "0"
-  gardenerShootNameTagClassId: "0"
-  regionTagClassId: "0"
   trialApiKey: ""
   trialInternalTesterAccessId: "0"
   trialGroupId: "0"

--- a/resources/kcp/charts/kyma-environment-broker/values.yaml
+++ b/resources/kcp/charts/kyma-environment-broker/values.yaml
@@ -5,7 +5,7 @@ global:
       path: europe-docker.pkg.dev/kyma-project/prod
     kyma_environment_broker:
       dir:
-      version: "v20231013-c329e328"
+      version: "v20231019-ed2b4bb9"
     kyma_environments_subaccount_cleanup_job:
       dir:
       version: "v20231013-c329e328"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump KEB image to include the https://github.com/kyma-project/kyma-environment-broker/pull/111 PR
- Removed unused `internalTesterTags` and `internalTesterTags` fields from `avs-creds` Secret
- W.r.t the aboe PR, remove `gardenerShootNameTagClassId` helm configuration


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
