### PR TITLE
provisioner will now create istio-system namespace

### DIFF
--- a/components/provisioner/internal/runtime/configurator.go
+++ b/components/provisioner/internal/runtime/configurator.go
@@ -74,6 +74,11 @@ func (c *configurator) configureAgent(cluster model.Cluster, token graphql.OneTi
 		"TOKEN":         token.Token,
 	}
 
+	err = util.RetryOnError(3*time.Second, 2, "Error while creating istio-system namespace for Runtime Agent configuration: %s", func() (err apperrors.AppError) {
+		err = c.createNamespace(k8sClient.CoreV1().Namespaces(), "istio-system")
+		return
+	})
+
 	err = util.RetryOnError(3*time.Second, 2, "Error while creating namespace for Runtime Agent configuration: %s", func() (err apperrors.AppError) {
 		err = c.createNamespace(k8sClient.CoreV1().Namespaces(), namespace)
 		return


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- provisioner will now create `istio-system` namespace to allow the planned istio removal

**Related issue(s)**
- Please see the internal issue with number `4750`

/area control-plane