### PR TITLE
provisioner disable static kubeconfig

### DIFF
--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -139,4 +139,5 @@ replace (
 	golang.org/x/text => golang.org/x/text v0.14.0
 	golang.org/x/tools => golang.org/x/tools v0.16.0
 	k8s.io/client-go => k8s.io/client-go v0.26.1
+	sourcegraph.com/sourcegraph/appdash-data => github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )

--- a/components/provisioner/go.sum
+++ b/components/provisioner/go.sum
@@ -701,6 +701,7 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/soheilhy/cmux v0.1.5/go.mod h1:T7TcVDs9LWfQgPlPsdngu6I6QIoyIFZDDC6sNE1GqG0=
+github.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:tNZjgbYncKL5HxvDULAr/mWDmFz4B7H8yrXEDlnoIiw=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -1119,4 +1120,3 @@ sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
 sigs.k8s.io/yaml v1.3.0/go.mod h1:GeOyir5tyXNByN85N/dRIT9es5UQNerPYEKK56eTBm8=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20180110180208-2cc67fd64755/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=
-sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67/go.mod h1:L5q+DGLGOQFpo1snNEkLOJT2d1YTW66rWNzatr3He1k=

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -188,7 +188,7 @@ func (c GardenerConfig) ToShootTemplate(namespace string, accountId string, subA
 				KubeAPIServer: &gardener_types.KubeAPIServerConfig{
 					OIDCConfig: gardenerOidcConfig(oidcConfig),
 				},
-				EnableStaticTokenKubeconfig: util.BoolPtr(true),
+				EnableStaticTokenKubeconfig: util.BoolPtr(false),
 			},
 			Networking: &gardener_types.Networking{
 				Type:     &networkingType, // Default value - we may consider adding it to API (if Hydroform will support it)

--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -212,7 +212,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
 							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
-						EnableStaticTokenKubeconfig: util.BoolPtr(true),
+						EnableStaticTokenKubeconfig: util.BoolPtr(false),
 					},
 					Maintenance: &gardener_types.Maintenance{
 						AutoUpdate: &gardener_types.MaintenanceAutoUpdate{
@@ -294,7 +294,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
 							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
-						EnableStaticTokenKubeconfig: util.BoolPtr(true),
+						EnableStaticTokenKubeconfig: util.BoolPtr(false),
 					},
 					Maintenance: &gardener_types.Maintenance{
 						AutoUpdate: &gardener_types.MaintenanceAutoUpdate{
@@ -376,7 +376,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
 							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
-						EnableStaticTokenKubeconfig: util.BoolPtr(true),
+						EnableStaticTokenKubeconfig: util.BoolPtr(false),
 					},
 					Maintenance: &gardener_types.Maintenance{
 						AutoUpdate: &gardener_types.MaintenanceAutoUpdate{
@@ -458,7 +458,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
 							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
-						EnableStaticTokenKubeconfig: util.BoolPtr(true),
+						EnableStaticTokenKubeconfig: util.BoolPtr(false),
 					},
 					Maintenance: &gardener_types.Maintenance{
 						AutoUpdate: &gardener_types.MaintenanceAutoUpdate{
@@ -540,7 +540,7 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						KubeAPIServer: &gardener_types.KubeAPIServerConfig{
 							OIDCConfig: gardenerOidcConfig(oidcConfig()),
 						},
-						EnableStaticTokenKubeconfig: util.BoolPtr(true),
+						EnableStaticTokenKubeconfig: util.BoolPtr(false),
 					},
 					Maintenance: &gardener_types.Maintenance{
 						AutoUpdate: &gardener_types.MaintenanceAutoUpdate{


### PR DESCRIPTION
- disable static kubeconfig flag for provisioned Gardener shoots
- provides a workaround for broken appdash dependency

It is required for provisioning of shoots with Kubernetes version 1.27 or higher where static kubeconfig is not allowed by the Gardener.