### PR TITLE
Corrected Image Path for Subscription Cleanup Job

### DIFF
--- a/resources/kcp/charts/kyma-metrics-collector/templates/_helpers.tpl
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/_helpers.tpl
@@ -75,7 +75,7 @@ imagePullSecrets:
 {{- if .Values.global -}}
   {{- if .Values.global.images -}}
     {{- if .Values.global.images.containerRegistry -}}
-      {{- $repository = printf "%s/%skyma-metrics-collector" .Values.global.images.containerRegistry.path (default "" .Values.global.images.kyma_metrics_collector.dir) -}}
+      {{- $repository = printf "%s/%s/kyma-metrics-collector" .Values.global.images.containerRegistry.path (default "" .Values.global.images.kyma_metrics_collector.dir) -}}
       {{- $tag = .Values.global.images.kyma_metrics_collector.version | toString -}}
     {{- end -}}
   {{- end -}}

--- a/resources/kcp/charts/kyma-metrics-collector/templates/_helpers.tpl
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/_helpers.tpl
@@ -75,7 +75,7 @@ imagePullSecrets:
 {{- if .Values.global -}}
   {{- if .Values.global.images -}}
     {{- if .Values.global.images.containerRegistry -}}
-      {{- $repository = printf "%s/%s/kyma-metrics-collector" .Values.global.images.containerRegistry.path (default "" .Values.global.images.kyma_metrics_collector.dir) -}}
+      {{- $repository = printf "%s/%skyma-metrics-collector" .Values.global.images.containerRegistry.path (default "" .Values.global.images.kyma_metrics_collector.dir) -}}
       {{- $tag = .Values.global.images.kyma_metrics_collector.version | toString -}}
     {{- end -}}
   {{- end -}}

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -3,22 +3,22 @@ global:
   images:
     cloudsql_proxy_image: "europe-docker.pkg.dev/kyma-project/prod/tpi/cloudsql-docker/gce-proxy:v1.33.8-afb993b8"
     containerRegistry:
-      path: europe-docker.pkg.dev/kyma-project/prod/control-plane
+      path: europe-docker.pkg.dev/kyma-project/prod
     schema_migrator:
-      dir:
+      dir: control-plane
       version: "v20230120-865831c1"
     subscription_cleanup_job:
-      dir:
+      dir: 
       version: "v20240109-3d6a573e"
     kyma_metrics_collector:
-      dir:
+      dir: control-plane
       version: v20231220-5c7452bb
     tests:
       provisioner:
-        dir:
+        dir: control-plane
         version: "v20230426-ad965fac"
       e2e_provisioning:
-        dir:
+        dir: control-plane
         version: "v20230614-bcb66b55"
     busybox: eu.gcr.io/kyma-project/external/busybox:1.34.1
   isLocalEnv: false

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -8,7 +8,7 @@ global:
       dir: control-plane/
       version: "v20230120-865831c1"
     subscription_cleanup_job:
-      dir: 
+      dir:
       version: "v20240109-3d6a573e"
     kyma_metrics_collector:
       dir: control-plane/

--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -5,20 +5,20 @@ global:
     containerRegistry:
       path: europe-docker.pkg.dev/kyma-project/prod
     schema_migrator:
-      dir: control-plane
+      dir: control-plane/
       version: "v20230120-865831c1"
     subscription_cleanup_job:
       dir: 
       version: "v20240109-3d6a573e"
     kyma_metrics_collector:
-      dir: control-plane
+      dir: control-plane/
       version: v20231220-5c7452bb
     tests:
       provisioner:
-        dir: control-plane
+        dir: control-plane/
         version: "v20230426-ad965fac"
       e2e_provisioning:
-        dir: control-plane
+        dir: control-plane/
         version: "v20230614-bcb66b55"
     busybox: eu.gcr.io/kyma-project/external/busybox:1.34.1
   isLocalEnv: false


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Subscription Cleanup Job (SCJ) has been moved outside of `control-plane` directory. This PR updates paths to allow usage of no dir value for SCJ but leaving other places unchanged.

Changes proposed in this pull request:

- set dir to `control-plane` for all components,
- removed `control-plane` from `containerRegistry` property,
- left dir empty for SCJ.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
