### PR TITLE
sets EnableStaticTokenKubeconfig to false during 1.27.0+ upgrades

### DIFF
--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -794,7 +794,7 @@ func updateShootConfig(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot
 }
 
 func adjustStaticKubeconfigFlag(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot) {
-	if util.NotNilOrEmpty(&upgradeConfig.KubernetesVersion) {
+	if upgradeConfig.KubernetesVersion != "" {
 		var upgradedKubernetesVersion, _ = version.NewVersion(upgradeConfig.KubernetesVersion)
 		var firstVersionNotSupportingStaticConfigs, _ = version.NewVersion("1.27.0")
 		if upgradedKubernetesVersion.GreaterThanOrEqual(firstVersionNotSupportingStaticConfigs) {

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/go-version"
 
 	gardener_types "github.com/gardener/gardener/pkg/apis/core/v1beta1"

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/go-version"
 
 	gardener_types "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/model/infrastructure/aws"
@@ -710,6 +711,12 @@ func updateShootConfig(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot
 
 	if upgradeConfig.KubernetesVersion != "" {
 		shoot.Spec.Kubernetes.Version = upgradeConfig.KubernetesVersion
+
+		var upgradedKubernetesVersion, _ = version.NewVersion(upgradeConfig.KubernetesVersion)
+		var firstVersionNotSupportingStaticConfigs, _ = version.NewVersion("1.27.0")
+		if upgradedKubernetesVersion.GreaterThanOrEqual(firstVersionNotSupportingStaticConfigs) {
+			shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(false)
+		}
 	}
 
 	if util.NotNilOrEmpty(upgradeConfig.Purpose) {

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -713,11 +713,7 @@ func updateShootConfig(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot
 	if upgradeConfig.KubernetesVersion != "" {
 		shoot.Spec.Kubernetes.Version = upgradeConfig.KubernetesVersion
 
-		var upgradedKubernetesVersion, _ = version.NewVersion(upgradeConfig.KubernetesVersion)
-		var firstVersionNotSupportingStaticConfigs, _ = version.NewVersion("1.27.0")
-		if upgradedKubernetesVersion.GreaterThanOrEqual(firstVersionNotSupportingStaticConfigs) {
-			shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(false)
-		}
+		adjustStaticKubeconfigFlag(upgradeConfig, shoot)
 	}
 
 	if util.NotNilOrEmpty(upgradeConfig.Purpose) {
@@ -795,6 +791,16 @@ func updateShootConfig(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot
 	shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = append(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins, podSecurityPolicyPlugin)
 
 	return nil
+}
+
+func adjustStaticKubeconfigFlag(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot) {
+	if util.NotNilOrEmpty(&upgradeConfig.KubernetesVersion) {
+		var upgradedKubernetesVersion, _ = version.NewVersion(upgradeConfig.KubernetesVersion)
+		var firstVersionNotSupportingStaticConfigs, _ = version.NewVersion("1.27.0")
+		if upgradedKubernetesVersion.GreaterThanOrEqual(firstVersionNotSupportingStaticConfigs) {
+			shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(false)
+		}
+	}
 }
 
 func getMachineConfig(config GardenerConfig) gardener_types.Machine {

--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -592,6 +592,43 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 	}
 }
 
+func TestAdjustStaticKubeconfigFlagK8s126(t *testing.T) {
+	//given old (1.26) shoot and request to upgrade not relevant to k8s version
+	config := GardenerConfig{}
+	shoot := testkit.NewTestShoot("shoot").WithKubernetesVersion("1.26.8")
+	shoot.ToShoot().Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(true)
+
+	//when
+	adjustStaticKubeconfigFlag(config, shoot.ToShoot())
+
+	//then
+	assert.Equal(t, util.BoolPtr(true), shoot.ToShoot().Spec.Kubernetes.EnableStaticTokenKubeconfig)
+}
+
+func TestAdjustStaticKubeconfigFlagForK8s127(t *testing.T) {
+	//given old shoot config being 1.26 and upgrade requesting updating to 1.27 version
+	config := GardenerConfig{
+		KubernetesVersion: "1.27.8",
+	}
+
+	shoot := testkit.NewTestShoot("shoot").WithKubernetesVersion("1.26.8")
+	shoot.ToShoot().Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(true)
+
+	//when
+	adjustStaticKubeconfigFlag(config, shoot.ToShoot())
+
+	//then
+	assert.Equal(t, util.BoolPtr(false), shoot.ToShoot().Spec.Kubernetes.EnableStaticTokenKubeconfig)
+}
+
+//func adjustStaticKubeconfigFlag(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot) {
+//	var upgradedKubernetesVersion, _ = version.NewVersion(upgradeConfig.KubernetesVersion)
+//	var firstVersionNotSupportingStaticConfigs, _ = version.NewVersion("1.27.0")
+//	if upgradedKubernetesVersion.GreaterThanOrEqual(firstVersionNotSupportingStaticConfigs) {
+//		shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(false)
+//	}
+//}
+
 func TestEditShootConfig(t *testing.T) {
 	zones := []string{"fix-zone-1", "fix-zone-2"}
 

--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -621,14 +621,6 @@ func TestAdjustStaticKubeconfigFlagForK8s127(t *testing.T) {
 	assert.Equal(t, util.BoolPtr(false), shoot.ToShoot().Spec.Kubernetes.EnableStaticTokenKubeconfig)
 }
 
-//func adjustStaticKubeconfigFlag(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot) {
-//	var upgradedKubernetesVersion, _ = version.NewVersion(upgradeConfig.KubernetesVersion)
-//	var firstVersionNotSupportingStaticConfigs, _ = version.NewVersion("1.27.0")
-//	if upgradedKubernetesVersion.GreaterThanOrEqual(firstVersionNotSupportingStaticConfigs) {
-//		shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = util.BoolPtr(false)
-//	}
-//}
-
 func TestEditShootConfig(t *testing.T) {
 	zones := []string{"fix-zone-1", "fix-zone-2"}
 


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- [WiP] sets EnableStaticTokenKubeconfig to false during 1.27.0+ upgradeShoots operations
- ...
- ...

**Related issue(s)**
- https://github.com/kyma-project/control-plane/issues/3240