### PR TITLE
Ignore Connectivity Proxy when CRD exists

### DIFF
--- a/resources/kcp/charts/mothership-reconciler/values.yaml
+++ b/resources/kcp/charts/mothership-reconciler/values.yaml
@@ -176,3 +176,7 @@ componentCRDs:
     group: operator.kyma-project.io
     version: v1alpha1
     kind: applicationconnector
+  connectivity-proxy:
+    group: connectivityproxy.sap.com
+    version: v1
+    kind: connectivityproxies


### PR DESCRIPTION
**Description**

Ignore the reconciliation of CP component when CP-CRD exists on SKR.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
