### PR TITLE
The Provisioner adds OpenStack parameters

### DIFF
--- a/components/provisioner/internal/api/resolver_integration_test.go
+++ b/components/provisioner/internal/api/resolver_integration_test.go
@@ -211,7 +211,7 @@ func openStackGardenerClusterConfigInput() gqlschema.ClusterConfigInput {
 			ProviderSpecificConfig: &gqlschema.ProviderSpecificInput{
 				OpenStackConfig: &gqlschema.OpenStackProviderConfigInput{
 					Zones:                []string{"eu-de-1a"},
-					FloatingPoolName:     "FloatingIP-external-cp",
+					FloatingPoolName:     util.StringPtr("FloatingIP-external-cp"),
 					CloudProfileName:     "converged-cloud-cp",
 					LoadBalancerProvider: "f5",
 				},

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -650,7 +650,7 @@ func (c OpenStackGardenerConfig) NodeCIDR(gardenerConfig GardenerConfig) string 
 func (c OpenStackGardenerConfig) AsProviderSpecificConfig() gqlschema.ProviderSpecificConfig {
 	return gqlschema.OpenStackProviderConfig{
 		Zones:                c.input.Zones,
-		FloatingPoolName:     c.input.FloatingPoolName,
+		FloatingPoolName:     util.UnwrapStr(c.input.FloatingPoolName),
 		CloudProfileName:     c.input.CloudProfileName,
 		LoadBalancerProvider: c.input.LoadBalancerProvider,
 	}
@@ -675,11 +675,11 @@ func (c OpenStackGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig
 		shoot.Spec.ExposureClassName = util.StringPtr(OpenStackExposureClassName)
 	}
 
-	if c.input.FloatingPoolName == "" {
+	if c.input.FloatingPoolName == nil {
 		openStackInfra = NewOpenStackInfrastructure(OpenStackFloatingPoolName, gardenerConfig.WorkerCidr)
 	}
 
-	openStackInfra = NewOpenStackInfrastructure(c.input.FloatingPoolName, gardenerConfig.WorkerCidr)
+	openStackInfra = NewOpenStackInfrastructure(util.UnwrapStr(c.input.FloatingPoolName), gardenerConfig.WorkerCidr)
 	jsonData, err := json.Marshal(openStackInfra)
 	if err != nil {
 		return apperrors.Internal("error encoding infrastructure config: %s", err.Error())

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -3,6 +3,7 @@ package model
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/kyma-project/control-plane/components/provisioner/internal/model/infrastructure/openstack"
 
 	"github.com/hashicorp/go-version"

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -677,9 +677,10 @@ func (c OpenStackGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig
 
 	if c.input.FloatingPoolName == nil {
 		openStackInfra = NewOpenStackInfrastructure(OpenStackFloatingPoolName, gardenerConfig.WorkerCidr)
+	} else {
+		openStackInfra = NewOpenStackInfrastructure(util.UnwrapStr(c.input.FloatingPoolName), gardenerConfig.WorkerCidr)
 	}
 
-	openStackInfra = NewOpenStackInfrastructure(util.UnwrapStr(c.input.FloatingPoolName), gardenerConfig.WorkerCidr)
 	jsonData, err := json.Marshal(openStackInfra)
 	if err != nil {
 		return apperrors.Internal("error encoding infrastructure config: %s", err.Error())

--- a/components/provisioner/internal/provisioning/input_converter_test.go
+++ b/components/provisioner/internal/provisioning/input_converter_test.go
@@ -316,7 +316,7 @@ func Test_ProvisioningInputToCluster(t *testing.T) {
 
 	openstackGardenerProvider := &gqlschema.OpenStackProviderConfigInput{
 		Zones:                []string{"eu-de-1a"},
-		FloatingPoolName:     "FloatingIP-external-cp",
+		FloatingPoolName:     util.StringPtr("FloatingIP-external-cp"),
 		CloudProfileName:     "converged-cloud-cp",
 		LoadBalancerProvider: "f5",
 	}

--- a/components/provisioner/pkg/gqlschema/models_gen.go
+++ b/components/provisioner/pkg/gqlschema/models_gen.go
@@ -275,7 +275,7 @@ func (OpenStackProviderConfig) IsProviderSpecificConfig() {}
 
 type OpenStackProviderConfigInput struct {
 	Zones                []string `json:"zones"`
-	FloatingPoolName     string   `json:"floatingPoolName"`
+	FloatingPoolName     *string  `json:"floatingPoolName"`
 	CloudProfileName     string   `json:"cloudProfileName"`
 	LoadBalancerProvider string   `json:"loadBalancerProvider"`
 }

--- a/components/provisioner/pkg/gqlschema/schema.graphql
+++ b/components/provisioner/pkg/gqlschema/schema.graphql
@@ -290,7 +290,7 @@ input AWSProviderConfigInput {
 
 input OpenStackProviderConfigInput {
     zones:           [String!]!   # Zones in which to create the cluster
-    floatingPoolName: String!     # FloatingPoolName name in which LoadBalancer FIPs should be created.
+    floatingPoolName: String     # FloatingPoolName name in which LoadBalancer FIPs should be created. Set to FloatingIP-external-kyma-01 by default
     cloudProfileName: String!     # Name of the target Cloud Profile
     loadBalancerProvider: String! # Name of load balancer provider, e.g. f5
 }

--- a/components/provisioner/pkg/gqlschema/schema_gen.go
+++ b/components/provisioner/pkg/gqlschema/schema_gen.go
@@ -1347,7 +1347,7 @@ input AWSProviderConfigInput {
 
 input OpenStackProviderConfigInput {
     zones:           [String!]!   # Zones in which to create the cluster
-    floatingPoolName: String!     # FloatingPoolName name in which LoadBalancer FIPs should be created.
+    floatingPoolName: String     # FloatingPoolName name in which LoadBalancer FIPs should be created. Set to FloatingIP-external-kyma-01 by default
     cloudProfileName: String!     # Name of the target Cloud Profile
     loadBalancerProvider: String! # Name of load balancer provider, e.g. f5
 }
@@ -6756,7 +6756,7 @@ func (ec *executionContext) unmarshalInputOpenStackProviderConfigInput(ctx conte
 			}
 		case "floatingPoolName":
 			var err error
-			it.FloatingPoolName, err = ec.unmarshalNString2string(ctx, v)
+			it.FloatingPoolName, err = ec.unmarshalOString2ᚖstring(ctx, v)
 			if err != nil {
 				return it, err
 			}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

From now Provisioner is responsible for adding (if KEB does not provide) these parameters during provision of the OpenStack cluster:
- `FloatingPoolName`
- `ExposureClassName`
- GraphQL `provisionRuntime` mutation now does not require `floatingPoolName` to be provided

