### PR TITLE
Clean-up gardener secret configs references

### DIFF
--- a/components/kyma-metrics-collector/options/options.go
+++ b/components/kyma-metrics-collector/options/options.go
@@ -14,8 +14,6 @@ type Options struct {
 	KEBPollWaitDuration time.Duration
 	KEBReqTimeout       time.Duration
 	KEBRuntimeURL       *url.URL
-	GardenerSecretPath  string
-	GardenerNamespace   string
 	ScrapeInterval      time.Duration
 	WorkerPoolSize      int
 	DebugPort           int
@@ -25,8 +23,6 @@ type Options struct {
 
 func ParseArgs() *Options {
 	var logLevel zapcore.Level
-	gardenerSecretPath := flag.String("gardener-secret-path", "/gardener/kubeconfig", "The path to the secret which contains kubeconfig of the Gardener MPS cluster")
-	gardenerNamespace := flag.String("gardener-namespace", "garden-kyma-dev", "The namespace in gardener cluster where information about Kyma clusters are")
 	scrapeInterval := flag.Duration("scrape-interval", 3*time.Minute, "The wait duration of the interval between 2 executions of metrics generation")
 	workerPoolSize := flag.Int("worker-pool-size", 5, "The number of workers in the pool")
 	logLevelStr := flag.String("log-level", "info", "The log-level of the application. E.g. fatal, error, info, debug etc")
@@ -40,19 +36,16 @@ func ParseArgs() *Options {
 	}
 
 	return &Options{
-		GardenerSecretPath: *gardenerSecretPath,
-		GardenerNamespace:  *gardenerNamespace,
-		ScrapeInterval:     *scrapeInterval,
-		WorkerPoolSize:     *workerPoolSize,
-		DebugPort:          *debugPort,
-		LogLevel:           logLevel,
-		ListenAddr:         *listenAddr,
+		ScrapeInterval: *scrapeInterval,
+		WorkerPoolSize: *workerPoolSize,
+		DebugPort:      *debugPort,
+		LogLevel:       logLevel,
+		ListenAddr:     *listenAddr,
 	}
 }
 
 func (o *Options) String() string {
-	return fmt.Sprintf("--gardener-secret-path=%s --gardener-namespace=%s --scrape-interval=%v "+
+	return fmt.Sprintf("--scrape-interval=%v "+
 		"--worker-pool-size=%d --log-level=%s --listen-addr=%d, --debug-port=%d",
-		o.GardenerSecretPath, o.GardenerNamespace, o.ScrapeInterval,
-		o.WorkerPoolSize, o.LogLevel, o.ListenAddr, o.DebugPort)
+		o.ScrapeInterval, o.WorkerPoolSize, o.LogLevel, o.ListenAddr, o.DebugPort)
 }

--- a/resources/kcp/charts/kyma-metrics-collector/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/deployment.yaml
@@ -90,18 +90,12 @@ spec:
           securityContext: {{ toYaml . | trim | nindent 12 }}
           {{- end }}
           volumeMounts:
-            - mountPath: /gardener
-              name: gardener-kubeconfig
-              readOnly: true
             - mountPath: /edp-credentials
               name: edp
               readOnly: true
             - name: tmp
               mountPath: /tmp
       volumes:
-      - name: gardener-kubeconfig
-        secret:
-          secretName: {{ .Values.gardener.secretName }}
       - name: edp
         secret:
           secretName: {{ template "kyma-metrics-collector.fullname" . }}

--- a/resources/kcp/charts/kyma-metrics-collector/templates/deployment.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/deployment.yaml
@@ -36,7 +36,6 @@ spec:
             - "--worker-pool-size={{ .Values.config.workerPoolSize }}"
             - "--log-level={{ .Values.config.logLevel }}"
             - "--listen-addr={{ .Values.config.port }}"
-            - "--gardener-namespace={{ .Values.gardener.namespace }}"
             {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | trim | indent 12 }}
             {{- end }}

--- a/resources/kcp/charts/kyma-metrics-collector/values.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/values.yaml
@@ -58,10 +58,6 @@ serviceAccount:
   ## Name of an already existing service account. Setting this value disables the automatic service account creation.
   # name:
 
-gardener:
-  secretName: "gardener-credentials"
-  namespace: "garden-kyma-dev"
-
 edp:
   namespace: "TBD"
   datastream:


### PR DESCRIPTION
**Description**
Clean-up Gardener secret references as it is not needed anymore. None of the metrics are retrieved from the gardener anymore.

**Related issue(s)**
#3312 