### PR TITLE
Bump KMC image

### DIFF
--- a/resources/kcp/values.yaml
+++ b/resources/kcp/values.yaml
@@ -12,7 +12,7 @@ global:
       version: "v20240129-70857389"
     kyma_metrics_collector:
       dir: control-plane/
-      version: v20240215-6ecb4717
+      version: v20240215-b53a794b
     tests:
       provisioner:
         dir: control-plane/


### PR DESCRIPTION
**Description**
Bump KMC latest image for removing gardener dependency

Prow [build job](https://status.build.kyma-project.io/view/gs/kyma-prow-logs/logs/post-kyma-metrics-collector-build/1758121976037117952)

**Related issue(s)**
#3353 