### PR TITLE
bumps golang to 1.22.0 and alpine to 3.19.1 in provisioner

### DIFF
--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.3-alpine3.18 as builder
+FROM golang:1.21.7-alpine3.18 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 RUN go build -v -o main ./cmd/
 RUN mkdir /app && mv ./main /app/main
 
-FROM alpine:3.18.5
+FROM alpine:3.18.6
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.7-alpine3.18 as builder
+FROM golang:1.22.0-alpine3.19 as builder
 
 ENV BASE_APP_DIR /go/src/github.com/kyma-project/control-plane/components/provisioner
 WORKDIR ${BASE_APP_DIR}
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 RUN go build -v -o main ./cmd/
 RUN mkdir /app && mv ./main /app/main
 
-FROM alpine:3.18.6
+FROM alpine:3.19.1
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/components/provisioner/Dockerfile
+++ b/components/provisioner/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add -U --no-cache ca-certificates && update-ca-certificates
 RUN go build -v -o main ./cmd/
 RUN mkdir /app && mv ./main /app/main
 
-FROM alpine:3.19.1
+FROM europe-docker.pkg.dev/kyma-project/prod/external/alpine:3.19.1
 LABEL source = git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/control-plane/components/provisioner
 
-go 1.22.0
+go 1.21
 
 require (
 	github.com/99designs/gqlgen v0.11.3

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/control-plane/components/provisioner
 
-go 1.21
+go 1.22
 
 require (
 	github.com/99designs/gqlgen v0.11.3

--- a/components/provisioner/go.mod
+++ b/components/provisioner/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/control-plane/components/provisioner
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/99designs/gqlgen v0.11.3

--- a/tests/e2e/provisioning/Dockerfile
+++ b/tests/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.6-alpine3.18 as builder
+FROM golang:1.21.7-alpine3.18 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/e2e/provisioning
 
@@ -7,7 +7,7 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 GOOS=linux go test -ldflags="-s -w" -c ./test
 
-FROM alpine:3.17.3
+FROM alpine:3.18.6
 LABEL source=git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/tests/e2e/provisioning/Dockerfile
+++ b/tests/e2e/provisioning/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21.7-alpine3.18 as builder
+FROM golang:1.22.0-alpine3.19 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/e2e/provisioning
 
@@ -7,7 +7,7 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 GOOS=linux go test -ldflags="-s -w" -c ./test
 
-FROM alpine:3.18.6
+FROM alpine:3.19.1
 LABEL source=git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/tests/e2e/provisioning/Dockerfile
+++ b/tests/e2e/provisioning/Dockerfile
@@ -7,7 +7,7 @@ COPY . $SRC_DIR
 
 RUN CGO_ENABLED=0 GOOS=linux go test -ldflags="-s -w" -c ./test
 
-FROM alpine:3.19.1
+FROM europe-docker.pkg.dev/kyma-project/prod/external/alpine:3.19.1
 LABEL source=git@github.com:kyma-project/control-plane.git
 
 WORKDIR /app

--- a/tests/provisioner-tests/Dockerfile
+++ b/tests/provisioner-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/1.22.0-alpine3.19 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.22.0-alpine3.19 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/provisioner-tests
 

--- a/tests/provisioner-tests/Dockerfile
+++ b/tests/provisioner-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.20.3-alpine3.17 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.21.7-alpine3.18 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/provisioner-tests
 
@@ -13,7 +13,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go test -c ./test/provisioner
 
 
-FROM europe-docker.pkg.dev/kyma-project/prod/external/alpine:3.17.3
+FROM alpine:3.18.6
 LABEL source=git@github.com:kyma-project/kyma.git
 
 WORKDIR /app

--- a/tests/provisioner-tests/Dockerfile
+++ b/tests/provisioner-tests/Dockerfile
@@ -13,7 +13,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go test -c ./test/provisioner
 
 
-FROM alpine:3.19.1
+FROM europe-docker.pkg.dev/kyma-project/prod/external/alpine:3.19.1
 LABEL source=git@github.com:kyma-project/kyma.git
 
 WORKDIR /app

--- a/tests/provisioner-tests/Dockerfile
+++ b/tests/provisioner-tests/Dockerfile
@@ -1,4 +1,4 @@
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.21.7-alpine3.18 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/1.22.0-alpine3.19 as builder
 
 ENV SRC_DIR=/go/src/github.com/kyma-project/control-plane/tests/provisioner-tests
 
@@ -13,7 +13,7 @@ RUN go mod download
 RUN CGO_ENABLED=0 GOOS=linux go test -c ./test/provisioner
 
 
-FROM alpine:3.18.6
+FROM alpine:3.19.1
 LABEL source=git@github.com:kyma-project/kyma.git
 
 WORKDIR /app


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- bumps golang to 1.22.0 and alpine to 3.19.1 in provisioner - hoping it will resolve some busybox vulnerabilities. 
- image bump will follow
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
