### PR TITLE
feat: added machine types in KMC

### DIFF
--- a/components/kyma-metrics-collector/pkg/testing/fixtures/static_providers.json
+++ b/components/kyma-metrics-collector/pkg/testing/fixtures/static_providers.json
@@ -227,6 +227,12 @@
       "memory": 256,
       "storage": 0,
       "max_nics": 8
+    },
+    "standard_d2s_v5": {
+      "cpu_cores": 2,
+      "memory": 8,
+      "storage": 0,
+      "max_nics": 2
     }
   },
   "aws": {
@@ -345,6 +351,10 @@
     "m6i.12xlarge": {
       "cpu_cores": 48,
       "memory": 192
+    },
+    "m6i.large": {
+      "cpu_cores": 2,
+      "memory": 8
     }
   },
   "gcp": {
@@ -413,6 +423,10 @@
     "g_c8_m32": {
       "cpu_cores": 8,
       "memory": 32
+    },
+    "g_c2_m8": {
+      "cpu_cores": 2,
+      "memory": 8
     }
   }
 }

--- a/resources/kcp/charts/kyma-metrics-collector/templates/public-cloud-info-config-map.yaml
+++ b/resources/kcp/charts/kyma-metrics-collector/templates/public-cloud-info-config-map.yaml
@@ -235,6 +235,12 @@ data:
             "memory": 256,
             "storage": 0,
             "max_nics": 8
+        },
+        "standard_d2s_v5": {
+            "cpu_cores": 2,
+            "memory": 8,
+            "storage": 0,
+            "max_nics": 2
         }
       },
       "aws": {
@@ -353,6 +359,10 @@ data:
         "m6i.12xlarge": {
             "cpu_cores": 48,
             "memory": 192
+        },
+        "m6i.large": {
+            "cpu_cores": 2,
+            "memory": 8
         }
       },
       "gcp": {
@@ -421,6 +431,10 @@ data:
        "g_c8_m32": {
          "cpu_cores": 8,
          "memory": 32
+       },
+       "g_c2_m8": {
+         "cpu_cores": 2,
+         "memory": 8
        }
      }
     }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- added machine types in KMC
- AWS
  - m6i.large - https://aws.amazon.com/de/ec2/instance-types/m6i/
  - ~m5.large~ - already exists in KMC.
- Azure
  - Standard_D2s_v5 - https://learn.microsoft.com/en-us/azure/virtual-machines/dv5-dsv5-series#dsv5-series
- GCP
  - ~n2-standard-2~ - already exists in KMC.
- SAP Converged Cloud
  - g_c2_m8

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/control-plane/issues/3364