### PR TITLE
Use instanceID for fetching kubeconfig in e2e tests

### DIFF
--- a/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
+++ b/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
@@ -47,15 +47,21 @@ type runtimeStatusResponse struct {
 	Result schema.RuntimeStatus `json:"result"`
 }
 
-func (c *Client) kubeconfigForRuntimeID(runtimeId string) ([]byte, error) {
-	kubeConfigSecret := &v1.Secret{}
-	err := c.kcpK8sClient.Get(context.Background(), c.objectKey(runtimeId), kubeConfigSecret)
+func (c *Client) kubeconfigForRuntimeID() ([]byte, error) {
+	secrets := &v1.SecretList{}
+	listOpts := secretListOptions(c.instanceID)
+
+	err := c.kcpK8sClient.List(context.Background(), secrets, listOpts...)
+
 	if err != nil {
-		return nil, fmt.Errorf("while getting secret from kcp for runtimeId=%s : %w", runtimeId, err)
+		return nil, fmt.Errorf("while getting secret from kcp for instanceID=%s : %w", c.instanceID, err)
 	}
-	config, ok := kubeConfigSecret.Data["config"]
+	if len(secrets.Items) != 1 {
+		return nil, fmt.Errorf("found %d secrets for instanceID %s but expected 1", len(secrets.Items), c.instanceID)
+	}
+	config, ok := secrets.Items[0].Data["config"]
 	if !ok {
-		return nil, fmt.Errorf("while getting 'config' from secret from %s", c.objectKey(runtimeId))
+		return nil, fmt.Errorf("while getting 'config' from secret from %s", c.instanceID)
 	}
 	if len(config) == 0 {
 		return nil, fmt.Errorf("empty kubeconfig")
@@ -64,12 +70,7 @@ func (c *Client) kubeconfigForRuntimeID(runtimeId string) ([]byte, error) {
 }
 
 func (c *Client) FetchRuntimeConfig() (*string, error) {
-	runtimeID, err := c.directorClient.GetRuntimeID(c.tenantID, c.instanceID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "while getting runtime id from director for instance ID %s", c.instanceID)
-	}
-
-	kubeconfig, err := c.kubeconfigForRuntimeID(runtimeID)
+	kubeconfig, err := c.kubeconfigForRuntimeID()
 	if err != nil {
 		return nil, errors.Wrapf(err, "while getting kubeconfig %s", c.instanceID)
 	}
@@ -118,5 +119,16 @@ func (c *Client) objectKey(runtimeId string) client.ObjectKey {
 	return client.ObjectKey{
 		Namespace: "kcp-system",
 		Name:      fmt.Sprintf("kubeconfig-%s", runtimeId),
+	}
+}
+
+func secretListOptions(instanceID string) []client.ListOption {
+	label := map[string]string{
+		"kyma-project.io/instance-id": instanceID,
+	}
+
+	return []client.ListOption{
+		client.InNamespace("kcp-system"),
+		client.MatchingLabels(label),
 	}
 }

--- a/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
+++ b/tests/e2e/provisioning/pkg/client/runtime/runtime_client.go
@@ -47,7 +47,7 @@ type runtimeStatusResponse struct {
 	Result schema.RuntimeStatus `json:"result"`
 }
 
-func (c *Client) kubeconfigForRuntimeID() ([]byte, error) {
+func (c *Client) kubeconfigForInstanceID() ([]byte, error) {
 	secrets := &v1.SecretList{}
 	listOpts := secretListOptions(c.instanceID)
 
@@ -70,7 +70,7 @@ func (c *Client) kubeconfigForRuntimeID() ([]byte, error) {
 }
 
 func (c *Client) FetchRuntimeConfig() (*string, error) {
-	kubeconfig, err := c.kubeconfigForRuntimeID()
+	kubeconfig, err := c.kubeconfigForInstanceID()
 	if err != nil {
 		return nil, errors.Wrapf(err, "while getting kubeconfig %s", c.instanceID)
 	}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Using the director to fetch the runtimeID and then using it to fetch the kubeconfig is no longer possible.

Changes proposed in this pull request:

- Use instanceID for fetching kubeconfig

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
