### PR TITLE
provisioner: add support for configuring AWS IMDSv2 access method

### DIFF
--- a/components/provisioner/cmd/init.go
+++ b/components/provisioner/cmd/init.go
@@ -45,11 +45,12 @@ func newProvisioningService(
 	shootUpgradeQueue queue.OperationQueue,
 	defaultEnableKubernetesVersionAutoUpdate,
 	defaultEnableMachineImageVersionAutoUpdate bool,
+	defaultEnableIMDSv2 bool,
 	runtimeRegistrationEnabled bool,
 	dynamicKubeconfigProvider DynamicKubeconfigProvider) provisioning.Service {
 
 	uuidGenerator := uuid.NewUUIDGenerator()
-	inputConverter := provisioning.NewInputConverter(uuidGenerator, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+	inputConverter := provisioning.NewInputConverter(uuidGenerator, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 	graphQLConverter := provisioning.NewGraphQLConverter()
 
 	return provisioning.NewProvisioningService(

--- a/components/provisioner/cmd/main.go
+++ b/components/provisioner/cmd/main.go
@@ -75,6 +75,7 @@ type config struct {
 		ClusterCleanupResourceSelector             string `envconfig:"default=https://service-manager."`
 		DefaultEnableKubernetesVersionAutoUpdate   bool   `envconfig:"default=false"`
 		DefaultEnableMachineImageVersionAutoUpdate bool   `envconfig:"default=false"`
+		DefaultEnableIMDSv2                        bool   `envconfig:"default=false"`
 	}
 
 	LatestDownloadedReleases int  `envconfig:"default=5"`
@@ -99,7 +100,7 @@ func (c *config) String() string {
 		"DeprovisioningNoInstallTimeoutClusterDeletion: %s, DeprovisioningNoInstallTimeoutWaitingForClusterDeletion: %s "+
 		"ShootUpgradeTimeout: %s, "+
 		"OperatorRoleBindingL2SubjectName: %s, OperatorRoleBindingL3SubjectName: %s, OperatorRoleBindingCreatingForAdmin: %t "+
-		"GardenerProject: %s, GardenerKubeconfigPath: %s, GardenerAuditLogsPolicyConfigMap: %s, AuditLogsTenantConfigPath: %s, "+
+		"GardenerProject: %s, GardenerKubeconfigPath: %s, GardenerAuditLogsPolicyConfigMap: %s, AuditLogsTenantConfigPath: %s, DefaultEnableIMDSv2: %v"+
 		"LatestDownloadedReleases: %d, DownloadPreReleases: %v, "+
 		"EnqueueInProgressOperations: %v"+
 		"LogLevel: %s",
@@ -114,7 +115,7 @@ func (c *config) String() string {
 		c.DeprovisioningTimeout.ClusterDeletion.String(), c.DeprovisioningTimeout.WaitingForClusterDeletion.String(),
 		c.ProvisioningTimeout.ShootUpgrade.String(),
 		c.OperatorRoleBinding.L2SubjectName, c.OperatorRoleBinding.L3SubjectName, c.OperatorRoleBinding.CreatingForAdmin,
-		c.Gardener.Project, c.Gardener.KubeconfigPath, c.Gardener.AuditLogsPolicyConfigMap, c.Gardener.AuditLogsTenantConfigPath,
+		c.Gardener.Project, c.Gardener.KubeconfigPath, c.Gardener.AuditLogsPolicyConfigMap, c.Gardener.AuditLogsTenantConfigPath, c.Gardener.DefaultEnableIMDSv2,
 		c.LatestDownloadedReleases, c.DownloadPreReleases,
 		c.EnqueueInProgressOperations,
 		c.LogLevel)
@@ -232,6 +233,7 @@ func main() {
 		shootUpgradeQueue,
 		cfg.Gardener.DefaultEnableKubernetesVersionAutoUpdate,
 		cfg.Gardener.DefaultEnableMachineImageVersionAutoUpdate,
+		cfg.Gardener.DefaultEnableIMDSv2,
 		cfg.RuntimeRegistrationEnabled,
 		kubeconfigProvider,
 	)

--- a/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
+++ b/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
@@ -77,6 +77,7 @@ const (
 
 	defaultEnableKubernetesVersionAutoUpdate   = false
 	defaultEnableMachineImageVersionAutoUpdate = false
+	defaultEnableIMDSv2                        = true
 
 	mockedKubeconfig = `apiVersion: v1
 clusters:
@@ -203,7 +204,7 @@ func TestProvisioning_ProvisionRuntimeWithDatabase(t *testing.T) {
 			uuidGenerator := uuid.NewUUIDGenerator()
 			provisioner := gardener.NewProvisioner(namespace, shootInterface, dbsFactory, auditLogPolicyCMName, maintenanceWindowConfigPath)
 
-			inputConverter := provisioning.NewInputConverter(uuidGenerator, "Project", defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+			inputConverter := provisioning.NewInputConverter(uuidGenerator, "Project", defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 			graphQLConverter := provisioning.NewGraphQLConverter()
 
 			runtimeRegistrationEnabled := true

--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -29,6 +29,7 @@ const (
 )
 
 var networkingType = "calico"
+var awsIMDSv2HTTPPutResponseHopLimit int64 = 2
 
 type OIDCConfig struct {
 	ClientID       string   `json:"clientID"`
@@ -598,11 +599,10 @@ func (c AWSGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoot 
 
 	if c.input.EnableIMDSv2 != nil && *c.input.EnableIMDSv2 {
 		var (
-			workerConfig            *aws.WorkerConfig
-			httpPutResponseHopLimit int64 = 2
+			workerConfig *aws.WorkerConfig
 		)
 		if shoot.Spec.Provider.Workers[0].ProviderConfig == nil {
-			workerConfig = NewAWSWorkerConfig(2)
+			workerConfig = NewAWSWorkerConfig(awsIMDSv2HTTPPutResponseHopLimit)
 		} else {
 			workerConfig = &aws.WorkerConfig{}
 			err := json.Unmarshal(shoot.Spec.Provider.Workers[0].ProviderConfig.Raw, &workerConfig)
@@ -615,8 +615,8 @@ func (c AWSGardenerConfig) EditShootConfig(gardenerConfig GardenerConfig, shoot 
 			if workerConfig.InstanceMetadataOptions.HTTPTokens == nil || *workerConfig.InstanceMetadataOptions.HTTPTokens != aws.HTTPTokensRequired {
 				workerConfig.InstanceMetadataOptions.HTTPTokens = &aws.HTTPTokensRequired
 			}
-			if workerConfig.InstanceMetadataOptions.HTTPPutResponseHopLimit == nil || *workerConfig.InstanceMetadataOptions.HTTPPutResponseHopLimit != httpPutResponseHopLimit {
-				workerConfig.InstanceMetadataOptions.HTTPPutResponseHopLimit = &httpPutResponseHopLimit
+			if workerConfig.InstanceMetadataOptions.HTTPPutResponseHopLimit == nil || *workerConfig.InstanceMetadataOptions.HTTPPutResponseHopLimit != awsIMDSv2HTTPPutResponseHopLimit {
+				workerConfig.InstanceMetadataOptions.HTTPPutResponseHopLimit = &awsIMDSv2HTTPPutResponseHopLimit
 			}
 		}
 		jsonWCData, err := json.Marshal(workerConfig)
@@ -649,7 +649,7 @@ func (c AWSGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig, shoo
 	}
 
 	if c.input.EnableIMDSv2 != nil && *c.input.EnableIMDSv2 {
-		awsWorkerConfig := NewAWSWorkerConfig(2)
+		awsWorkerConfig := NewAWSWorkerConfig(awsIMDSv2HTTPPutResponseHopLimit)
 		jsonWCData, err := json.Marshal(awsWorkerConfig)
 		if err != nil {
 			return apperrors.Internal("error encoding aws worker config: %s", err.Error())

--- a/components/provisioner/internal/model/infrastructure.go
+++ b/components/provisioner/internal/model/infrastructure.go
@@ -13,6 +13,7 @@ import (
 const (
 	infrastructureConfigKind = "InfrastructureConfig"
 	controlPlaneConfigKind   = "ControlPlaneConfig"
+	workerConfigKind         = "WorkerConfig"
 
 	gcpAPIVersion       = "gcp.provider.extensions.gardener.cloud/v1alpha1"
 	azureAPIVersion     = "azure.provider.extensions.gardener.cloud/v1alpha1"
@@ -164,5 +165,19 @@ func NewOpenStackControlPlane(loadBalancerProvider string) *openstack.ControlPla
 			APIVersion: openStackApiVersion,
 		},
 		LoadBalancerProvider: loadBalancerProvider,
+	}
+}
+
+func NewAWSWorkerConfig(httpPutResponseHopLimit int64) *aws.WorkerConfig {
+
+	return &aws.WorkerConfig{
+		TypeMeta: v1.TypeMeta{
+			APIVersion: awsAPIVersion,
+			Kind:       workerConfigKind,
+		},
+		InstanceMetadataOptions: &aws.InstanceMetadataOptions{
+			HTTPTokens:              &aws.HTTPTokensRequired,
+			HTTPPutResponseHopLimit: util.PtrTo(httpPutResponseHopLimit),
+		},
 	}
 }

--- a/components/provisioner/internal/model/infrastructure/aws/worker.go
+++ b/components/provisioner/internal/model/infrastructure/aws/worker.go
@@ -1,0 +1,34 @@
+package aws
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// WorkerConfig contains configuration settings for the worker nodes.
+type WorkerConfig struct {
+	metav1.TypeMeta `json:",inline"`
+
+	// InstanceMetadataOptions contains configuration for controlling access to the metadata API.
+	InstanceMetadataOptions *InstanceMetadataOptions `json:"instanceMetadataOptions,omitempty"`
+}
+
+// HTTPTokensValue is a constant for HTTPTokens values.
+type HTTPTokensValue string
+
+var (
+	// HTTPTokensRequired is a constant for requiring the use of tokens to access IMDS. Effectively disables access via
+	// the IMDSv1 endpoints.
+	HTTPTokensRequired HTTPTokensValue = "required"
+	// HTTPTokensOptional that makes the use of tokens for IMDS optional. Effectively allows access via both IMDSv1 and
+	// IMDSv2 endpoints.
+	HTTPTokensOptional HTTPTokensValue = "optional"
+)
+
+// InstanceMetadataOptions contains configuration for controlling access to the metadata API.
+type InstanceMetadataOptions struct {
+	// HTTPTokens enforces the use of metadata v2 API.
+	HTTPTokens *HTTPTokensValue `json:"httpTokens,omitempty"`
+	// HTTPPutResponseHopLimit is the response hop limit for instance metadata requests.
+	// Valid values are between 1 and 64.
+	HTTPPutResponseHopLimit *int64 `json:"httpPutResponseHopLimit,omitempty"`
+}

--- a/components/provisioner/internal/provisioning/input_converter.go
+++ b/components/provisioner/internal/provisioning/input_converter.go
@@ -28,7 +28,8 @@ func NewInputConverter(
 	uuidGenerator uuid.UUIDGenerator,
 	gardenerProject string,
 	defaultEnableKubernetesVersionAutoUpdate,
-	defaultEnableMachineImageVersionAutoUpdate bool) InputConverter {
+	defaultEnableMachineImageVersionAutoUpdate bool,
+	defaultEnableIMDSv2 bool) InputConverter {
 
 	return &converter{
 		uuidGenerator:                                    uuidGenerator,
@@ -37,6 +38,7 @@ func NewInputConverter(
 		defaultEnableMachineImageVersionAutoUpdate:       defaultEnableMachineImageVersionAutoUpdate,
 		defaultProvisioningShootNetworkingFilterDisabled: true,
 		defaultEuAccess:                                  false,
+		defaultEnableIMDSv2:                              defaultEnableIMDSv2,
 	}
 }
 
@@ -47,6 +49,7 @@ type converter struct {
 	defaultEnableMachineImageVersionAutoUpdate       bool
 	defaultProvisioningShootNetworkingFilterDisabled bool
 	defaultEuAccess                                  bool
+	defaultEnableIMDSv2                              bool
 }
 
 func (c converter) ProvisioningInputToCluster(runtimeID string, input gqlschema.ProvisionRuntimeInput, tenant, subAccountId string) (model.Cluster, apperrors.AppError) {
@@ -229,6 +232,9 @@ func (c converter) providerSpecificConfigFromInput(input *gqlschema.ProviderSpec
 		return model.NewAzureGardenerConfig(input.AzureConfig)
 	}
 	if input.AwsConfig != nil {
+		if input.AwsConfig.EnableIMDSv2 == nil {
+			input.AwsConfig.EnableIMDSv2 = util.PtrTo(c.defaultEnableIMDSv2)
+		}
 		return model.NewAWSGardenerConfig(input.AwsConfig)
 	}
 	if input.OpenStackConfig != nil {

--- a/components/provisioner/internal/provisioning/input_converter_test.go
+++ b/components/provisioner/internal/provisioning/input_converter_test.go
@@ -22,6 +22,7 @@ const (
 	gardenerProject                            = "gardener-project"
 	defaultEnableKubernetesVersionAutoUpdate   = false
 	defaultEnableMachineImageVersionAutoUpdate = false
+	defaultEnableIMDSv2                        = true
 )
 
 func Test_ProvisioningInputToCluster(t *testing.T) {
@@ -269,7 +270,9 @@ func Test_ProvisioningInputToCluster(t *testing.T) {
 		KymaConfig: fixKymaGraphQLConfigInput(&gqlEvaluationProfile),
 	}
 
-	expectedAWSProviderCfg, err := model.NewAWSGardenerConfig(awsGardenerProvider)
+	expectedAWSGardenerProviderInput := *awsGardenerProvider
+	expectedAWSGardenerProviderInput.EnableIMDSv2 = util.PtrTo(true)
+	expectedAWSProviderCfg, err := model.NewAWSGardenerConfig(&expectedAWSGardenerProviderInput)
 	require.NoError(t, err)
 
 	expectedGardenerAWSRuntimeConfig := model.Cluster{
@@ -448,7 +451,8 @@ func Test_ProvisioningInputToCluster(t *testing.T) {
 				uuidGeneratorMock,
 				gardenerProject,
 				defaultEnableKubernetesVersionAutoUpdate,
-				defaultEnableMachineImageVersionAutoUpdate)
+				defaultEnableMachineImageVersionAutoUpdate,
+				defaultEnableIMDSv2)
 
 			// when
 			runtimeConfig, err := inputConverter.ProvisioningInputToCluster("runtimeID", testCase.input, tenant, subAccountId)
@@ -550,7 +554,8 @@ func TestConverter_ParseInput(t *testing.T) {
 			uuidGeneratorMock,
 			gardenerProject,
 			defaultEnableKubernetesVersionAutoUpdate,
-			defaultEnableMachineImageVersionAutoUpdate)
+			defaultEnableMachineImageVersionAutoUpdate,
+			defaultEnableIMDSv2)
 
 		// when
 		output, err := inputConverter.KymaConfigFromInput("runtimeID", input)
@@ -573,7 +578,9 @@ func TestConverter_ProvisioningInputToCluster_Error(t *testing.T) {
 			nil,
 			gardenerProject,
 			defaultEnableKubernetesVersionAutoUpdate,
-			defaultEnableMachineImageVersionAutoUpdate)
+			defaultEnableMachineImageVersionAutoUpdate,
+			defaultEnableIMDSv2,
+		)
 
 		// when
 		_, err := inputConverter.ProvisioningInputToCluster("runtimeID", input, tenant, subAccountId)
@@ -596,7 +603,8 @@ func TestConverter_ProvisioningInputToCluster_Error(t *testing.T) {
 			nil,
 			gardenerProject,
 			defaultEnableKubernetesVersionAutoUpdate,
-			defaultEnableMachineImageVersionAutoUpdate)
+			defaultEnableMachineImageVersionAutoUpdate,
+			defaultEnableIMDSv2)
 
 		// when
 		_, err := inputConverter.ProvisioningInputToCluster("runtimeID", input, tenant, subAccountId)
@@ -622,7 +630,8 @@ func TestConverter_ProvisioningInputToCluster_Error(t *testing.T) {
 			uuidGeneratorMock,
 			gardenerProject,
 			defaultEnableKubernetesVersionAutoUpdate,
-			defaultEnableMachineImageVersionAutoUpdate)
+			defaultEnableMachineImageVersionAutoUpdate,
+			defaultEnableIMDSv2)
 
 		// when
 		_, err := inputConverter.ProvisioningInputToCluster("runtimeID", input, tenant, subAccountId)
@@ -865,6 +874,7 @@ func Test_UpgradeShootInputToGardenerConfig(t *testing.T) {
 				gardenerProject,
 				defaultEnableKubernetesVersionAutoUpdate,
 				defaultEnableMachineImageVersionAutoUpdate,
+				defaultEnableIMDSv2,
 			)
 
 			// when
@@ -886,6 +896,7 @@ func Test_UpgradeShootInputToGardenerConfig(t *testing.T) {
 				gardenerProject,
 				defaultEnableKubernetesVersionAutoUpdate,
 				defaultEnableMachineImageVersionAutoUpdate,
+				defaultEnableIMDSv2,
 			)
 
 			// when

--- a/components/provisioner/internal/provisioning/service_test.go
+++ b/components/provisioner/internal/provisioning/service_test.go
@@ -61,7 +61,7 @@ func kubeconfigProviderMock() *queue_mock.KubeconfigProvider {
 }
 
 func TestService_ProvisionRuntime(t *testing.T) {
-	inputConverter := NewInputConverter(uuid.NewUUIDGenerator(), gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+	inputConverter := NewInputConverter(uuid.NewUUIDGenerator(), gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 	graphQLConverter := NewGraphQLConverter()
 	uuidGenerator := uuid.NewUUIDGenerator()
 
@@ -302,7 +302,7 @@ func TestService_ProvisionRuntime(t *testing.T) {
 }
 
 func TestService_DeprovisionRuntime(t *testing.T) {
-	inputConverter := NewInputConverter(uuid.NewUUIDGenerator(), gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+	inputConverter := NewInputConverter(uuid.NewUUIDGenerator(), gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 	graphQLConverter := NewGraphQLConverter()
 	lastOperation := model.Operation{State: model.Succeeded}
 	mockedKubeconfig := kubeconfig
@@ -504,7 +504,7 @@ func TestService_DeprovisionRuntime(t *testing.T) {
 
 func TestService_RuntimeOperationStatus(t *testing.T) {
 	uuidGenerator := &uuidMocks.UUIDGenerator{}
-	inputConverter := NewInputConverter(uuidGenerator, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+	inputConverter := NewInputConverter(uuidGenerator, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 	graphQLConverter := NewGraphQLConverter()
 
 	operation := model.Operation{
@@ -560,7 +560,7 @@ func TestService_RuntimeOperationStatus(t *testing.T) {
 
 func TestService_RuntimeStatus(t *testing.T) {
 	uuidGenerator := &uuidMocks.UUIDGenerator{}
-	inputConverter := NewInputConverter(uuidGenerator, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+	inputConverter := NewInputConverter(uuidGenerator, gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 	graphQLConverter := NewGraphQLConverter()
 
 	operation := model.Operation{
@@ -641,7 +641,7 @@ func TestService_RuntimeStatus(t *testing.T) {
 }
 
 func TestService_UpgradeGardenerShoot(t *testing.T) {
-	inputConverter := NewInputConverter(uuid.NewUUIDGenerator(), gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate)
+	inputConverter := NewInputConverter(uuid.NewUUIDGenerator(), gardenerProject, defaultEnableKubernetesVersionAutoUpdate, defaultEnableMachineImageVersionAutoUpdate, defaultEnableIMDSv2)
 	graphQLConverter := NewGraphQLConverter()
 	uuidGenerator := uuid.NewUUIDGenerator()
 

--- a/components/provisioner/pkg/gqlschema/models_gen.go
+++ b/components/provisioner/pkg/gqlschema/models_gen.go
@@ -13,15 +13,17 @@ type ProviderSpecificConfig interface {
 }
 
 type AWSProviderConfig struct {
-	AwsZones []*AWSZone `json:"awsZones"`
-	VpcCidr  *string    `json:"vpcCidr,omitempty"`
+	AwsZones     []*AWSZone `json:"awsZones"`
+	VpcCidr      *string    `json:"vpcCidr,omitempty"`
+	EnableIMDSv2 *bool      `json:"enableIMDSv2,omitempty"`
 }
 
 func (AWSProviderConfig) IsProviderSpecificConfig() {}
 
 type AWSProviderConfigInput struct {
-	VpcCidr  string          `json:"vpcCidr"`
-	AwsZones []*AWSZoneInput `json:"awsZones"`
+	VpcCidr      string          `json:"vpcCidr"`
+	AwsZones     []*AWSZoneInput `json:"awsZones"`
+	EnableIMDSv2 *bool           `json:"enableIMDSv2,omitempty"`
 }
 
 type AWSZone struct {

--- a/components/provisioner/pkg/gqlschema/schema.graphql
+++ b/components/provisioner/pkg/gqlschema/schema.graphql
@@ -67,6 +67,7 @@ type AzureProviderConfig {
 type AWSProviderConfig {
     awsZones: [AWSZone]!
     vpcCidr: String
+    enableIMDSv2: Boolean
 }
 
 type OpenStackProviderConfig {
@@ -286,6 +287,7 @@ input AzureProviderConfigInput {
 input AWSProviderConfigInput {
     vpcCidr: String!        # Classless Inter-Domain Routing for the virtual public cloud
     awsZones: [AWSZoneInput]! # Zones, in which to create the cluster, configuration
+    enableIMDSv2: Boolean # Enable IMDSv2 access method only
 }
 
 input OpenStackProviderConfigInput {

--- a/components/provisioner/pkg/gqlschema/schema_gen.go
+++ b/components/provisioner/pkg/gqlschema/schema_gen.go
@@ -47,8 +47,9 @@ type DirectiveRoot struct {
 
 type ComplexityRoot struct {
 	AWSProviderConfig struct {
-		AwsZones func(childComplexity int) int
-		VpcCidr  func(childComplexity int) int
+		AwsZones     func(childComplexity int) int
+		EnableIMDSv2 func(childComplexity int) int
+		VpcCidr      func(childComplexity int) int
 	}
 
 	AWSZone struct {
@@ -253,6 +254,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.AWSProviderConfig.AwsZones(childComplexity), true
+
+	case "AWSProviderConfig.enableIMDSv2":
+		if e.complexity.AWSProviderConfig.EnableIMDSv2 == nil {
+			break
+		}
+
+		return e.complexity.AWSProviderConfig.EnableIMDSv2(childComplexity), true
 
 	case "AWSProviderConfig.vpcCidr":
 		if e.complexity.AWSProviderConfig.VpcCidr == nil {
@@ -1439,6 +1447,47 @@ func (ec *executionContext) fieldContext_AWSProviderConfig_vpcCidr(ctx context.C
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type String does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _AWSProviderConfig_enableIMDSv2(ctx context.Context, field graphql.CollectedField, obj *AWSProviderConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_AWSProviderConfig_enableIMDSv2(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.EnableIMDSv2, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_AWSProviderConfig_enableIMDSv2(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "AWSProviderConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
 		},
 	}
 	return fc, nil
@@ -7881,7 +7930,7 @@ func (ec *executionContext) unmarshalInputAWSProviderConfigInput(ctx context.Con
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"vpcCidr", "awsZones"}
+	fieldsInOrder := [...]string{"vpcCidr", "awsZones", "enableIMDSv2"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -7902,6 +7951,13 @@ func (ec *executionContext) unmarshalInputAWSProviderConfigInput(ctx context.Con
 				return it, err
 			}
 			it.AwsZones = data
+		case "enableIMDSv2":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("enableIMDSv2"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.EnableIMDSv2 = data
 		}
 	}
 
@@ -9065,6 +9121,8 @@ func (ec *executionContext) _AWSProviderConfig(ctx context.Context, sel ast.Sele
 			}
 		case "vpcCidr":
 			out.Values[i] = ec._AWSProviderConfig_vpcCidr(ctx, field, obj)
+		case "enableIMDSv2":
+			out.Values[i] = ec._AWSProviderConfig_enableIMDSv2(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add new Gardener configuration `DefaultEnableIMDSv2` as a feature flag to enabled IMDSv2 support during provisioning and shoot upgrade
- Add new fields in AWSProviderConfig and AWSProviderConfigInput GQL schema
- In input converter, support using the default AWS IMDVSv2 configuration if it was provided as input
- Enhance `AWSGardenerConfig.ExtendShootConfig()` to add the needed providerConfig to the single worker if `enableIMDSv2` is true
- Enhance `AWSGardenerConfig.EditShootConfig()` to check if the needed providerConfig is present in the shoot, and ensure it is configured with in the desired state, in case the `enableIMDSv2` is true


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.tools.sap/kyma/backlog/issues/5218
