### PR TITLE
Bump provisioner in kcp chart to v20240429-ea75326a

### DIFF
--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -152,6 +152,8 @@ spec:
               value: {{ .Values.gardener.defaultEnableKubernetesVersionAutoUpdate | quote }}
             - name: APP_GARDENER_DEFAULT_ENABLE_MACHINE_IMAGE_VERSION_AUTO_UPDATE
               value: {{ .Values.gardener.defaultEnableMachineImageVersionAutoUpdate | quote }}
+            - name: APP_GARDENER_DEFAULT_ENABLE_IMDSV2
+              value: {{ .Values.gardener.defaultEnableIMDSv2 | quote }}
             - name: APP_LATEST_DOWNLOADED_RELEASES
               value: "10"
             - name: APP_DOWNLOAD_PRE_RELEASES

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,7 +3,7 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "v20240423-2610070c"
+      version: "v20240429-ea75326a"
       dir: "prod"
 serviceMonitor:
   enabled: true
@@ -55,6 +55,7 @@ gardener:
   clusterUpgradeTimeout: 90m
   defaultEnableKubernetesVersionAutoUpdate: false
   defaultEnableMachineImageVersionAutoUpdate: false
+  defaultEnableIMDSv2: false
 
 support:
   l2OperatorRoleBindingSubject: "runtimeOperator"


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Bump provisioner in kcp chart to v20240429-ea75326a to include https://github.com/kyma-project/control-plane/pull/3429
- Define `defaultEnableIMDSv2` Helm value


**Related issue(s)**

https://github.tools.sap/kyma/backlog/issues/5218