### PR TITLE
Remove obsolete L2/L3 operator bindings from provisioner

### DIFF
--- a/components/provisioner/cmd/main.go
+++ b/components/provisioner/cmd/main.go
@@ -87,7 +87,7 @@ func (c *config) String() string {
 		"ProvisioningTimeoutInstallation: %s, ProvisioningTimeoutUpgrade: %s, "+
 		"DeprovisioningNoInstallTimeoutClusterDeletion: %s, DeprovisioningNoInstallTimeoutWaitingForClusterDeletion: %s "+
 		"ShootUpgradeTimeout: %s, "+
-		"OperatorRoleBindingL2SubjectName: %s, OperatorRoleBindingL3SubjectName: %s, OperatorRoleBindingCreatingForAdmin: %t "+
+		"OperatorRoleBindingCreatingForAdmin: %t "+
 		"GardenerProject: %s, GardenerKubeconfigPath: %s, GardenerAuditLogsPolicyConfigMap: %s, AuditLogsTenantConfigPath: %s, DefaultEnableIMDSv2: %v"+
 		"EnqueueInProgressOperations: %v"+
 		"LogLevel: %s",
@@ -98,7 +98,7 @@ func (c *config) String() string {
 		c.ProvisioningTimeout.Installation.String(), c.ProvisioningTimeout.Upgrade.String(),
 		c.DeprovisioningTimeout.ClusterDeletion.String(), c.DeprovisioningTimeout.WaitingForClusterDeletion.String(),
 		c.ProvisioningTimeout.ShootUpgrade.String(),
-		c.OperatorRoleBinding.L2SubjectName, c.OperatorRoleBinding.L3SubjectName, c.OperatorRoleBinding.CreatingForAdmin,
+		c.OperatorRoleBinding.CreatingForAdmin,
 		c.Gardener.Project, c.Gardener.KubeconfigPath, c.Gardener.AuditLogsPolicyConfigMap, c.Gardener.AuditLogsTenantConfigPath, c.Gardener.DefaultEnableIMDSv2,
 		c.EnqueueInProgressOperations,
 		c.LogLevel)

--- a/components/provisioner/internal/api/resolver_integration_test.go
+++ b/components/provisioner/internal/api/resolver_integration_test.go
@@ -175,6 +175,7 @@ func azureGardenerClusterConfigInput(zones ...string) gqlschema.ClusterConfigInp
 			},
 			OidcConfig: oidcInput(),
 		},
+		Administrators: []string{"testadmin"},
 	}
 }
 
@@ -205,6 +206,7 @@ func azureGardenerClusterConfigInputNoSeed(zones ...string) gqlschema.ClusterCon
 			},
 			OidcConfig: oidcInput(),
 		},
+		Administrators: []string{"testadmin"},
 	}
 }
 
@@ -236,6 +238,7 @@ func openStackGardenerClusterConfigInput() gqlschema.ClusterConfigInput {
 			},
 			OidcConfig: oidcInput(),
 		},
+		Administrators: []string{"testadmin"},
 	}
 }
 

--- a/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
+++ b/components/provisioner/internal/api/resolver_integration_with_gardener_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	uuidMocks "github.com/kyma-project/control-plane/components/provisioner/internal/uuid/mocks"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	uuidMocks "github.com/kyma-project/control-plane/components/provisioner/internal/uuid/mocks"
 
 	"github.com/kyma-project/control-plane/components/provisioner/internal/api/fake/seeds"
 	"github.com/kyma-project/control-plane/components/provisioner/internal/api/fake/shoots"
@@ -403,8 +404,7 @@ func testDeprovisioningTimeouts() queue.DeprovisioningTimeouts {
 
 func testOperatorRoleBinding() provisioning2.OperatorRoleBinding {
 	return provisioning2.OperatorRoleBinding{
-		L2SubjectName: "runtimeOperator",
-		L3SubjectName: "runtimeAdmin",
+		CreatingForAdmin: true,
 	}
 }
 

--- a/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
+++ b/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
@@ -27,8 +27,7 @@ const (
 
 	ownerClusterRoleBindingRoleRefName = "cluster-admin"
 
-	groupKindSubject = "Group"
-	userKindSubject  = "User"
+	userKindSubject = "User"
 )
 
 //go:generate mockery --name=DynamicKubeconfigProvider

--- a/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
+++ b/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings.go
@@ -23,17 +23,9 @@ import (
 )
 
 const (
-	l2OperatorClusterRoleBindingName            = "l2-operator"
-	l3OperatorClusterRoleBindingName            = "l3-operator-admin"
 	administratorOperatorClusterRoleBindingName = "administrator"
 
-	l3OperatorClusterRoleBindingRoleRefName = "cluster-admin"
-	ownerClusterRoleBindingRoleRefName      = "cluster-admin"
-
-	l2OperatorClusterRoleName       = "l2-operator"
-	l2OperatorRulesClusterRoleName  = "l2-operator-rules"
-	l2OperatorBaseRolesLabelKey     = "rbac.authorization.k8s.io/aggregate-to-edit"
-	l2OperatorExtendedRolesLabelKey = "rbac.authorization.k8s.io/aggregate-to-l2-operator"
+	ownerClusterRoleBindingRoleRefName = "cluster-admin"
 
 	groupKindSubject = "Group"
 	userKindSubject  = "User"
@@ -45,9 +37,7 @@ type DynamicKubeconfigProvider interface {
 }
 
 type OperatorRoleBinding struct {
-	L2SubjectName    string `envconfig:"default=runtimeOperator"`
-	L3SubjectName    string `envconfig:"default=runtimeAdmin"`
-	CreatingForAdmin bool   `envconfig:"default=false"`
+	CreatingForAdmin bool `envconfig:"default=false"`
 }
 
 type CreateBindingsForOperatorsStep struct {
@@ -103,57 +93,7 @@ func (s *CreateBindingsForOperatorsStep) Run(cluster model.Cluster, _ model.Oper
 		return operations.StageResult{}, err
 	}
 
-	clusterRoles := make([]v12.ClusterRole, 0)
-	clusterRoles = append(clusterRoles,
-		buildClusterRole(
-			l2OperatorClusterRoleName,
-			map[string]string{
-				"app": "kyma",
-			},
-			[]metav1.LabelSelector{
-				{MatchLabels: map[string]string{l2OperatorBaseRolesLabelKey: "true"}},
-				{MatchLabels: map[string]string{l2OperatorExtendedRolesLabelKey: "true"}},
-			},
-			nil,
-		),
-	)
-	clusterRoles = append(clusterRoles,
-		buildClusterRole(
-			l2OperatorRulesClusterRoleName,
-			map[string]string{
-				"app":                           "kyma",
-				l2OperatorExtendedRolesLabelKey: "true",
-			},
-			nil,
-			[]v12.PolicyRule{
-				{APIGroups: []string{"*"}, Resources: []string{"*"}, Verbs: []string{"get", "list", "watch"}},
-			},
-		),
-	)
-
 	clusterRoleBindings := make([]v12.ClusterRoleBinding, 0)
-
-	clusterRoleBindings = append(clusterRoleBindings,
-		buildClusterRoleBinding(
-			l2OperatorClusterRoleBindingName,
-			s.operatorRoleBindingConfig.L2SubjectName,
-			l2OperatorClusterRoleBindingName,
-			groupKindSubject,
-			map[string]string{
-				"app":                                   "kyma",
-				"reconciler.kyma-project.io/managed-by": "reconciler",
-			}))
-
-	clusterRoleBindings = append(clusterRoleBindings,
-		buildClusterRoleBinding(
-			l3OperatorClusterRoleBindingName,
-			s.operatorRoleBindingConfig.L3SubjectName,
-			l3OperatorClusterRoleBindingRoleRefName,
-			groupKindSubject,
-			map[string]string{
-				"app":                                   "kyma",
-				"reconciler.kyma-project.io/managed-by": "reconciler",
-			}))
 
 	if s.operatorRoleBindingConfig.CreatingForAdmin {
 		for i, administrator := range cluster.Administrators {
@@ -168,10 +108,6 @@ func (s *CreateBindingsForOperatorsStep) Run(cluster model.Cluster, _ model.Oper
 						"reconciler.kyma-project.io/managed-by": "reconciler",
 					}))
 		}
-	}
-
-	if err := createClusterRoles(k8sClient.RbacV1().ClusterRoles(), clusterRoles); err != nil {
-		return operations.StageResult{}, err
 	}
 
 	if err := k8sClient.RbacV1().ClusterRoleBindings().DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{LabelSelector: "reconciler.kyma-project.io/managed-by=reconciler,app=kyma"}); err != nil {
@@ -202,39 +138,6 @@ func buildClusterRoleBinding(metaName, subjectName, roleRefName, subjectKind str
 			Name:     roleRefName,
 		},
 	}
-}
-
-func buildClusterRole(name string, labels map[string]string, aggregationSelectors []metav1.LabelSelector, rules []v12.PolicyRule) v12.ClusterRole {
-
-	cr := v12.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   name,
-			Labels: labels,
-		},
-	}
-	if len(aggregationSelectors) > 0 {
-		cr.AggregationRule = &v12.AggregationRule{
-			ClusterRoleSelectors: aggregationSelectors,
-		}
-	}
-
-	if len(rules) > 0 {
-		cr.Rules = rules
-	}
-
-	return cr
-}
-
-func createClusterRoles(crClient v1.ClusterRoleInterface, clusterRoles []v12.ClusterRole) error {
-	for _, cr := range clusterRoles {
-		if _, err := crClient.Create(context.Background(), &cr, metav1.CreateOptions{}); err != nil {
-			if !k8serrors.IsAlreadyExists(err) {
-				return util.K8SErrorToAppError(errors.Wrapf(err, "failed to create %s ClusterRole", cr.Name)).SetComponent(apperrors.ErrClusterK8SClient)
-			}
-		}
-	}
-
-	return nil
 }
 
 func createClusterRoleBindings(crbClient v1.ClusterRoleBindingInterface, clusterRoleBindings ...v12.ClusterRoleBinding) error {

--- a/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings_test.go
+++ b/components/provisioner/internal/operations/stages/provisioning/create_operators_bindings_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 const dynamicKubeconfig = "dynamic_kubeconfig"
-const testAdministrator = "testadmin"
+const testAdministrator1 = "testadmin1"
+const testAdministrator2 = "testadmin2"
 
 func TestCreateBindingsForOperatorsStep_Run(t *testing.T) {
 
@@ -34,7 +35,7 @@ func TestCreateBindingsForOperatorsStep_Run(t *testing.T) {
 		ClusterConfig: model.GardenerConfig{
 			Name: "shoot",
 		},
-		Administrators: []string{testAdministrator},
+		Administrators: []string{testAdministrator1, testAdministrator2},
 	}
 
 	operatorBindingConfig := OperatorRoleBinding{


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

The L2 and L3 operator bindings were for a legacy (OIDC based) approach to authorize SAP operator access to SKRs, but are not needed any more. 

After this PR is merged, I plan to raise another PR to remove related code from kcp chart.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.tools.sap/kyma/backlog/issues/5553