### PR TITLE
Bump provisioner in kcp chart

### DIFF
--- a/resources/kcp/charts/provisioner/templates/deployment.yaml
+++ b/resources/kcp/charts/provisioner/templates/deployment.yaml
@@ -116,10 +116,6 @@ spec:
               value: {{ .Values.gardener.clusterCleanupTimeout | quote }}
             - name: APP_PROVISIONING_TIMEOUT_BINDINGS_CREATION
               value: {{ .Values.support.bindingsCreationTimeout | quote }}
-            - name: APP_OPERATOR_ROLE_BINDING_L2SUBJECT_NAME
-              value: {{ .Values.support.l2OperatorRoleBindingSubject | quote }}
-            - name: APP_OPERATOR_ROLE_BINDING_L3SUBJECT_NAME
-              value: {{ .Values.support.l3OperatorRoleBindingSubject | quote }}
             - name: APP_OPERATOR_ROLE_BINDING_CREATING_FOR_ADMIN
               value: {{ .Values.support.enabledCreatingRoleBindingForAdmin | quote }}
             - name: APP_GARDENER_PROJECT
@@ -138,7 +134,7 @@ spec:
               value: {{ .Values.gardener.defaultEnableKubernetesVersionAutoUpdate | quote }}
             - name: APP_GARDENER_DEFAULT_ENABLE_MACHINE_IMAGE_VERSION_AUTO_UPDATE
               value: {{ .Values.gardener.defaultEnableMachineImageVersionAutoUpdate | quote }}
-            - name: APP_GARDENER_DEFAULT_ENABLE_IMDSV2
+            - name: APP_GARDENER_DEFAULTENABLEIMDSV2
               value: {{ .Values.gardener.defaultEnableIMDSv2 | quote }}
             - name: APP_LATEST_DOWNLOADED_RELEASES
               value: "10"
@@ -235,4 +231,3 @@ spec:
           name: {{ .Values.gardener.maintenanceWindowConfigMapName }}
           optional: true
       {{end}}
-

--- a/resources/kcp/charts/provisioner/values.yaml
+++ b/resources/kcp/charts/provisioner/values.yaml
@@ -3,7 +3,7 @@ global:
     path: europe-docker.pkg.dev/kyma-project
   images:
     provisioner:
-      version: "v20240507-ff9c0545"
+      version: "v20240521-bc0d8345"
       dir: "prod"
 serviceMonitor:
   enabled: true
@@ -58,8 +58,6 @@ gardener:
   defaultEnableIMDSv2: false
 
 support:
-  l2OperatorRoleBindingSubject: "runtimeOperator"
-  l3OperatorRoleBindingSubject: "runtimeAdmin"
   enabledCreatingRoleBindingForAdmin: false
   bindingsCreationTimeout: 5m
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Bump provisioner to `v20240521-bc0d8345` tag to include https://github.com/kyma-project/control-plane/pull/3438
- Remove L2/L3 operator related chart configuration
- Fix passing the `gardener.defaultEnableIMDSv2` value to the provisioner as environment variable. 

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->

https://github.tools.sap/kyma/backlog/issues/5553