### PR TITLE
Correction for #344 - seedAndSameRegion in GardenerConfigInput

### DIFF
--- a/components/provisioner/pkg/gqlschema/models_gen.go
+++ b/components/provisioner/pkg/gqlschema/models_gen.go
@@ -168,6 +168,7 @@ type GardenerConfig struct {
 	ShootNetworkingFilterDisabled       *bool                  `json:"shootNetworkingFilterDisabled,omitempty"`
 	ControlPlaneFailureTolerance        *string                `json:"controlPlaneFailureTolerance,omitempty"`
 	EuAccess                            *bool                  `json:"euAccess,omitempty"`
+	ShootAndSeedSameRegion              *bool                  `json:"shootAndSeedSameRegion,omitempty"`
 }
 
 type GardenerConfigInput struct {

--- a/components/provisioner/pkg/gqlschema/models_gen.go
+++ b/components/provisioner/pkg/gqlschema/models_gen.go
@@ -168,7 +168,6 @@ type GardenerConfig struct {
 	ShootNetworkingFilterDisabled       *bool                  `json:"shootNetworkingFilterDisabled,omitempty"`
 	ControlPlaneFailureTolerance        *string                `json:"controlPlaneFailureTolerance,omitempty"`
 	EuAccess                            *bool                  `json:"euAccess,omitempty"`
-	ShootAndSeedSameRegion              *bool                  `json:"shootAndSeedSameRegion,omitempty"`
 }
 
 type GardenerConfigInput struct {
@@ -201,6 +200,7 @@ type GardenerConfigInput struct {
 	ShootNetworkingFilterDisabled       *bool                  `json:"shootNetworkingFilterDisabled,omitempty"`
 	ControlPlaneFailureTolerance        *string                `json:"controlPlaneFailureTolerance,omitempty"`
 	EuAccess                            *bool                  `json:"euAccess,omitempty"`
+	ShootAndSeedSameRegion              *bool                  `json:"shootAndSeedSameRegion,omitempty"`
 }
 
 type GardenerUpgradeInput struct {

--- a/components/provisioner/pkg/gqlschema/schema.graphql
+++ b/components/provisioner/pkg/gqlschema/schema.graphql
@@ -36,6 +36,7 @@ type GardenerConfig {
     shootNetworkingFilterDisabled: Boolean
     controlPlaneFailureTolerance: String
     euAccess: Boolean
+    shootAndSeedSameRegion: Boolean
 }
 
 union ProviderSpecificConfig = GCPProviderConfig | AzureProviderConfig | AWSProviderConfig | OpenStackProviderConfig

--- a/components/provisioner/pkg/gqlschema/schema.graphql
+++ b/components/provisioner/pkg/gqlschema/schema.graphql
@@ -36,7 +36,6 @@ type GardenerConfig {
     shootNetworkingFilterDisabled: Boolean
     controlPlaneFailureTolerance: String
     euAccess: Boolean
-    shootAndSeedSameRegion: Boolean
 }
 
 union ProviderSpecificConfig = GCPProviderConfig | AzureProviderConfig | AWSProviderConfig | OpenStackProviderConfig
@@ -243,6 +242,7 @@ input GardenerConfigInput {
     shootNetworkingFilterDisabled: Boolean          # Indicator for the Shoot Networking Filter extension being disabled. If 'nil' provided, 'true' will be used as a default value
     controlPlaneFailureTolerance: String            # Shoot control plane HA failure tolerance level to configure. Valid values: 'nil' (left empty, no HA), "node", "zone"
     euAccess: Boolean                               # EU Access indicated whether to annotate the Shoot with the 'support.gardener.cloud/eu-access-for-cluster-nodes' annotation
+    shootAndSeedSameRegion: Boolean                 # If set to true, Provisioner will add seedSelector with region matching the one that shoot is created in
 }
 
 input OIDCConfigInput {

--- a/components/provisioner/pkg/gqlschema/schema_gen.go
+++ b/components/provisioner/pkg/gqlschema/schema_gen.go
@@ -131,7 +131,6 @@ type ComplexityRoot struct {
 		Region                              func(childComplexity int) int
 		Seed                                func(childComplexity int) int
 		ServicesCidr                        func(childComplexity int) int
-		ShootAndSeedSameRegion              func(childComplexity int) int
 		ShootNetworkingFilterDisabled       func(childComplexity int) int
 		TargetSecret                        func(childComplexity int) int
 		VolumeSizeGb                        func(childComplexity int) int
@@ -626,13 +625,6 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GardenerConfig.ServicesCidr(childComplexity), true
-
-	case "GardenerConfig.shootAndSeedSameRegion":
-		if e.complexity.GardenerConfig.ShootAndSeedSameRegion == nil {
-			break
-		}
-
-		return e.complexity.GardenerConfig.ShootAndSeedSameRegion(childComplexity), true
 
 	case "GardenerConfig.shootNetworkingFilterDisabled":
 		if e.complexity.GardenerConfig.ShootNetworkingFilterDisabled == nil {
@@ -3836,47 +3828,6 @@ func (ec *executionContext) fieldContext_GardenerConfig_euAccess(ctx context.Con
 	return fc, nil
 }
 
-func (ec *executionContext) _GardenerConfig_shootAndSeedSameRegion(ctx context.Context, field graphql.CollectedField, obj *GardenerConfig) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_GardenerConfig_shootAndSeedSameRegion(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.ShootAndSeedSameRegion, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		return graphql.Null
-	}
-	res := resTmp.(*bool)
-	fc.Result = res
-	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_GardenerConfig_shootAndSeedSameRegion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "GardenerConfig",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type Boolean does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
 func (ec *executionContext) _HibernationStatus_hibernated(ctx context.Context, field graphql.CollectedField, obj *HibernationStatus) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HibernationStatus_hibernated(ctx, field)
 	if err != nil {
@@ -5811,8 +5762,6 @@ func (ec *executionContext) fieldContext_RuntimeConfig_clusterConfig(ctx context
 				return ec.fieldContext_GardenerConfig_controlPlaneFailureTolerance(ctx, field)
 			case "euAccess":
 				return ec.fieldContext_GardenerConfig_euAccess(ctx, field)
-			case "shootAndSeedSameRegion":
-				return ec.fieldContext_GardenerConfig_shootAndSeedSameRegion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GardenerConfig", field.Name)
 		},
@@ -8398,7 +8347,7 @@ func (ec *executionContext) unmarshalInputGardenerConfigInput(ctx context.Contex
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"name", "kubernetesVersion", "provider", "targetSecret", "region", "machineType", "machineImage", "machineImageVersion", "diskType", "volumeSizeGB", "workerCidr", "podsCidr", "servicesCidr", "autoScalerMin", "autoScalerMax", "maxSurge", "maxUnavailable", "purpose", "licenceType", "enableKubernetesVersionAutoUpdate", "enableMachineImageVersionAutoUpdate", "providerSpecificConfig", "dnsConfig", "seed", "oidcConfig", "exposureClassName", "shootNetworkingFilterDisabled", "controlPlaneFailureTolerance", "euAccess"}
+	fieldsInOrder := [...]string{"name", "kubernetesVersion", "provider", "targetSecret", "region", "machineType", "machineImage", "machineImageVersion", "diskType", "volumeSizeGB", "workerCidr", "podsCidr", "servicesCidr", "autoScalerMin", "autoScalerMax", "maxSurge", "maxUnavailable", "purpose", "licenceType", "enableKubernetesVersionAutoUpdate", "enableMachineImageVersionAutoUpdate", "providerSpecificConfig", "dnsConfig", "seed", "oidcConfig", "exposureClassName", "shootNetworkingFilterDisabled", "controlPlaneFailureTolerance", "euAccess", "shootAndSeedSameRegion"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
@@ -8608,6 +8557,13 @@ func (ec *executionContext) unmarshalInputGardenerConfigInput(ctx context.Contex
 				return it, err
 			}
 			it.EuAccess = data
+		case "shootAndSeedSameRegion":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("shootAndSeedSameRegion"))
+			data, err := ec.unmarshalOBoolean2ᚖbool(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.ShootAndSeedSameRegion = data
 		}
 	}
 
@@ -9660,8 +9616,6 @@ func (ec *executionContext) _GardenerConfig(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._GardenerConfig_controlPlaneFailureTolerance(ctx, field, obj)
 		case "euAccess":
 			out.Values[i] = ec._GardenerConfig_euAccess(ctx, field, obj)
-		case "shootAndSeedSameRegion":
-			out.Values[i] = ec._GardenerConfig_shootAndSeedSameRegion(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/components/provisioner/pkg/gqlschema/schema_gen.go
+++ b/components/provisioner/pkg/gqlschema/schema_gen.go
@@ -131,6 +131,7 @@ type ComplexityRoot struct {
 		Region                              func(childComplexity int) int
 		Seed                                func(childComplexity int) int
 		ServicesCidr                        func(childComplexity int) int
+		ShootAndSeedSameRegion              func(childComplexity int) int
 		ShootNetworkingFilterDisabled       func(childComplexity int) int
 		TargetSecret                        func(childComplexity int) int
 		VolumeSizeGb                        func(childComplexity int) int
@@ -625,6 +626,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.GardenerConfig.ServicesCidr(childComplexity), true
+
+	case "GardenerConfig.shootAndSeedSameRegion":
+		if e.complexity.GardenerConfig.ShootAndSeedSameRegion == nil {
+			break
+		}
+
+		return e.complexity.GardenerConfig.ShootAndSeedSameRegion(childComplexity), true
 
 	case "GardenerConfig.shootNetworkingFilterDisabled":
 		if e.complexity.GardenerConfig.ShootNetworkingFilterDisabled == nil {
@@ -3828,6 +3836,47 @@ func (ec *executionContext) fieldContext_GardenerConfig_euAccess(ctx context.Con
 	return fc, nil
 }
 
+func (ec *executionContext) _GardenerConfig_shootAndSeedSameRegion(ctx context.Context, field graphql.CollectedField, obj *GardenerConfig) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_GardenerConfig_shootAndSeedSameRegion(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ShootAndSeedSameRegion, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*bool)
+	fc.Result = res
+	return ec.marshalOBoolean2ᚖbool(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_GardenerConfig_shootAndSeedSameRegion(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "GardenerConfig",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HibernationStatus_hibernated(ctx context.Context, field graphql.CollectedField, obj *HibernationStatus) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HibernationStatus_hibernated(ctx, field)
 	if err != nil {
@@ -5762,6 +5811,8 @@ func (ec *executionContext) fieldContext_RuntimeConfig_clusterConfig(ctx context
 				return ec.fieldContext_GardenerConfig_controlPlaneFailureTolerance(ctx, field)
 			case "euAccess":
 				return ec.fieldContext_GardenerConfig_euAccess(ctx, field)
+			case "shootAndSeedSameRegion":
+				return ec.fieldContext_GardenerConfig_shootAndSeedSameRegion(ctx, field)
 			}
 			return nil, fmt.Errorf("no field named %q was found under type GardenerConfig", field.Name)
 		},
@@ -9609,6 +9660,8 @@ func (ec *executionContext) _GardenerConfig(ctx context.Context, sel ast.Selecti
 			out.Values[i] = ec._GardenerConfig_controlPlaneFailureTolerance(ctx, field, obj)
 		case "euAccess":
 			out.Values[i] = ec._GardenerConfig_euAccess(ctx, field, obj)
+		case "shootAndSeedSameRegion":
+			out.Values[i] = ec._GardenerConfig_shootAndSeedSameRegion(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/CONTRIBUTING.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Put `seedAndShootSameRegion` field to GardenerConfigInput instead of GardenerConfig.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
