### PR TITLE
fix Blocking SSH access for all provisioned and upgraded Kyma runtimes

### DIFF
--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -3,7 +3,6 @@ package model
 import (
 	"encoding/json"
 	"fmt"
-
 	"github.com/hashicorp/go-version"
 
 	gardener_types "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -365,6 +364,9 @@ func (c GCPGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig, shoo
 		ControlPlaneConfig:   &apimachineryRuntime.RawExtension{Raw: jsonCPData},
 		InfrastructureConfig: &apimachineryRuntime.RawExtension{Raw: jsonData},
 		Workers:              workers,
+		WorkersSettings: &gardener_types.WorkersSettings{
+			SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+		},
 	}
 
 	return nil
@@ -519,6 +521,9 @@ func (c AzureGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig, sh
 		ControlPlaneConfig:   &apimachineryRuntime.RawExtension{Raw: jsonCPData},
 		InfrastructureConfig: &apimachineryRuntime.RawExtension{Raw: jsonData},
 		Workers:              workers,
+		WorkersSettings: &gardener_types.WorkersSettings{
+			SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+		},
 	}
 
 	return nil
@@ -662,6 +667,9 @@ func (c AWSGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig, shoo
 		ControlPlaneConfig:   &apimachineryRuntime.RawExtension{Raw: jsonCPData},
 		InfrastructureConfig: &apimachineryRuntime.RawExtension{Raw: jsonData},
 		Workers:              workers,
+		WorkersSettings: &gardener_types.WorkersSettings{
+			SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+		},
 	}
 
 	return nil
@@ -728,6 +736,9 @@ func (c OpenStackGardenerConfig) ExtendShootConfig(gardenerConfig GardenerConfig
 		ControlPlaneConfig:   &apimachineryRuntime.RawExtension{Raw: jsonCPData},
 		InfrastructureConfig: &apimachineryRuntime.RawExtension{Raw: jsonData},
 		Workers:              workers,
+		WorkersSettings: &gardener_types.WorkersSettings{
+			SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+		},
 	}
 
 	return nil
@@ -794,6 +805,12 @@ func updateShootConfig(upgradeConfig GardenerConfig, shoot *gardener_types.Shoot
 	if util.NotNilOrEmpty(upgradeConfig.MachineImageVersion) {
 		shoot.Spec.Provider.Workers[0].Machine.Image.Version = upgradeConfig.MachineImageVersion
 	}
+
+	// block SSHAccess for all upgraded clusters
+	shoot.Spec.Provider.WorkersSettings = &gardener_types.WorkersSettings{
+		SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+	}
+
 	if upgradeConfig.OIDCConfig != nil {
 		if shoot.Spec.Kubernetes.KubeAPIServer == nil {
 			shoot.Spec.Kubernetes.KubeAPIServer = &gardener_types.KubeAPIServerConfig{}

--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -206,6 +206,9 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						Workers: []gardener_types.Worker{
 							fixWorker([]string{"fix-zone-1", "fix-zone-2"}, nil),
 						},
+						WorkersSettings: &gardener_types.WorkersSettings{
+							SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+						},
 					},
 					Purpose:           &purpose,
 					ExposureClassName: util.PtrTo("internet"),
@@ -287,6 +290,9 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						},
 						Workers: []gardener_types.Worker{
 							fixWorker([]string{"fix-zone-1", "fix-zone-2"}, nil),
+						},
+						WorkersSettings: &gardener_types.WorkersSettings{
+							SSHAccess: &gardener_types.SSHAccess{Enabled: false},
 						},
 					},
 					Purpose:           &purpose,
@@ -370,6 +376,9 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						Workers: []gardener_types.Worker{
 							fixWorker(nil, nil),
 						},
+						WorkersSettings: &gardener_types.WorkersSettings{
+							SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+						},
 					},
 					Purpose:           &purpose,
 					ExposureClassName: util.PtrTo("internet"),
@@ -451,6 +460,9 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						},
 						Workers: []gardener_types.Worker{
 							fixWorker([]string{"1", "2"}, nil),
+						},
+						WorkersSettings: &gardener_types.WorkersSettings{
+							SSHAccess: &gardener_types.SSHAccess{Enabled: false},
 						},
 					},
 					Purpose:           &purpose,
@@ -535,6 +547,9 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 							fixWorker([]string{"zone"}, &apimachineryRuntime.RawExtension{
 								Raw: []byte(`{"kind":"WorkerConfig","apiVersion":"aws.provider.extensions.gardener.cloud/v1alpha1","instanceMetadataOptions":{"httpTokens":"required","httpPutResponseHopLimit":2}}`),
 							}),
+						},
+						WorkersSettings: &gardener_types.WorkersSettings{
+							SSHAccess: &gardener_types.SSHAccess{Enabled: false},
 						},
 					},
 					Purpose:           &purpose,

--- a/components/provisioner/internal/util/testkit/shoot.go
+++ b/components/provisioner/internal/util/testkit/shoot.go
@@ -96,6 +96,9 @@ func (ts *TestShoot) WithExposureClassName(exposureClassName string) *TestShoot 
 // See also testkit.TestWorker
 func (ts *TestShoot) WithWorkers(workers ...v1beta1.Worker) *TestShoot {
 	ts.shoot.Spec.Provider.Workers = append(ts.shoot.Spec.Provider.Workers, workers...)
+	ts.shoot.Spec.Provider.WorkersSettings = &gardener_types.WorkersSettings{
+		SSHAccess: &gardener_types.SSHAccess{Enabled: false},
+	}
 	return ts
 }
 


### PR DESCRIPTION
**What this PR does** :  Setting the parameter `shoot.Spec.Provider.WorkersSettings.SSHAccess` to false for all provisioned and updated Gardener Shoots resources to block SSH traffic.

**Related Issue**: someGHRepo/kyma/backlog/issues/5775

**Why this PR is created**: Requested by SRE to address SSH security vulnerability. Check the linked issue for more details.

Includes all required unit tests adjustments.