### PR TITLE
Provisioner - enable oidc extension by default for newly provisioned clusters

### DIFF
--- a/components/provisioner/internal/model/gardener_config.go
+++ b/components/provisioner/internal/model/gardener_config.go
@@ -211,6 +211,7 @@ func (c GardenerConfig) ToShootTemplate(namespace string, accountId string, subA
 				{Type: "shoot-dns-service", ProviderConfig: &apimachineryRuntime.RawExtension{Raw: jsonDNSConfig}},
 				{Type: "shoot-cert-service", ProviderConfig: &apimachineryRuntime.RawExtension{Raw: jsonCertConfig}},
 				{Type: ShootNetworkingFilterExtensionType, Disabled: util.OkOrDefault(c.ShootNetworkingFilterDisabled, util.PtrTo(ShootNetworkingFilterDisabledDefault))},
+				{Type: "shoot-oidc-service", Disabled: util.PtrTo(false)},
 			},
 			ControlPlane: controlPlane,
 		},

--- a/components/provisioner/internal/model/gardener_config_test.go
+++ b/components/provisioner/internal/model/gardener_config_test.go
@@ -243,6 +243,10 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 							Type:     ShootNetworkingFilterExtensionType,
 							Disabled: util.PtrTo(true),
 						},
+						{
+							Type:     "shoot-oidc-service",
+							Disabled: util.PtrTo(false),
+						},
 					},
 					ControlPlane: &gardener_types.ControlPlane{
 						HighAvailability: &gardener_types.HighAvailability{
@@ -327,6 +331,10 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						{
 							Type:     ShootNetworkingFilterExtensionType,
 							Disabled: util.PtrTo(true),
+						},
+						{
+							Type:     "shoot-oidc-service",
+							Disabled: util.PtrTo(false),
 						},
 					},
 					ControlPlane: &gardener_types.ControlPlane{
@@ -413,6 +421,10 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 							Type:     ShootNetworkingFilterExtensionType,
 							Disabled: util.PtrTo(true),
 						},
+						{
+							Type:     "shoot-oidc-service",
+							Disabled: util.PtrTo(false),
+						},
 					},
 					ControlPlane: &gardener_types.ControlPlane{
 						HighAvailability: &gardener_types.HighAvailability{
@@ -497,6 +509,10 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						{
 							Type:     ShootNetworkingFilterExtensionType,
 							Disabled: util.PtrTo(true),
+						},
+						{
+							Type:     "shoot-oidc-service",
+							Disabled: util.PtrTo(false),
 						},
 					},
 					ControlPlane: &gardener_types.ControlPlane{
@@ -584,6 +600,10 @@ func TestGardenerConfig_ToShootTemplate(t *testing.T) {
 						{
 							Type:     ShootNetworkingFilterExtensionType,
 							Disabled: util.PtrTo(true),
+						},
+						{
+							Type:     "shoot-oidc-service",
+							Disabled: util.PtrTo(false),
 						},
 					},
 					ControlPlane: &gardener_types.ControlPlane{


### PR DESCRIPTION
Enabling OIDC extension for Provisioned shoots by adding following item to list of shoot extensions

```
extensions:
   - type: shoot-oidc-service  #this line enables OIDC extension
     disabled: false
```

This change will affect only new clusters as specified in https://github.com/kyma-project/control-plane/issues/3466


Extension section from test shoot provisioned on AWS

  ```
extensions:
    - type: shoot-dns-service
      providerConfig:
        apiVersion: some-version
        dnsProviderReplication:
          enabled: true
        kind: DNSConfig
        providers:
          - domains:
              include:
                - some-domain
            secretName: some-name
            type: some-type
        syncProvidersFromShootSpecDNS: true
    - type: shoot-cert-service
      providerConfig:
        apiVersion: some-api-version
        shootIssuers:
          enabled: true
        kind: CertConfig
    - type: shoot-networking-filter
      disabled: true
    - type: shoot-oidc-service
      disabled: false
    - type: shoot-auditlog-service
      providerConfig:
        kind: AuditlogConfig
        apiVersion: some-api-version
        type: standard
        tenantID: some-tenant
        serviceURL: some-url
        secretReferenceName: some-name
```